### PR TITLE
feat(logger): Add logger support

### DIFF
--- a/Apivalk.php
+++ b/Apivalk.php
@@ -9,6 +9,7 @@ use apivalk\apivalk\Middleware\MiddlewareStack;
 use apivalk\apivalk\Http\Renderer\RendererInterface;
 use apivalk\apivalk\Router\AbstractRouter;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 class Apivalk
 {
@@ -20,6 +21,8 @@ class Apivalk
     private $router;
     /** @var ContainerInterface|null */
     private $container;
+    /** @var LoggerInterface */
+    private $logger;
 
     public function __construct(ApivalkConfiguration $apivalkConfiguration)
     {
@@ -27,6 +30,7 @@ class Apivalk
         $this->renderer = $apivalkConfiguration->getRenderer();
         $this->router = $apivalkConfiguration->getRouter();
         $this->container = $apivalkConfiguration->getContainer();
+        $this->logger = $apivalkConfiguration->getLogger();
 
         if ($apivalkConfiguration->getExceptionHandler() !== null) {
             set_exception_handler($apivalkConfiguration->getExceptionHandler());
@@ -56,5 +60,10 @@ class Apivalk
     public function getContainer(): ?ContainerInterface
     {
         return $this->container;
+    }
+
+    public function getLogger(): LoggerInterface
+    {
+        return $this->logger;
     }
 }

--- a/ApivalkConfiguration.php
+++ b/ApivalkConfiguration.php
@@ -9,6 +9,8 @@ use apivalk\apivalk\Http\Renderer\JsonRenderer;
 use apivalk\apivalk\Http\Renderer\RendererInterface;
 use apivalk\apivalk\Router\AbstractRouter;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 //TODO: add optional "grantedscopeinterface" object
 //TODO: add middleware which checks if current route scope/scopes are granted in the interface
@@ -24,18 +26,22 @@ class ApivalkConfiguration
     private $exceptionHandler;
     /** @var ContainerInterface|null */
     private $container;
+    /** @var LoggerInterface */
+    private $logger;
 
     public function __construct(
         AbstractRouter $router,
         ?RendererInterface $renderer = null,
         ?callable $exceptionHandler = null,
-        ?ContainerInterface $container = null
+        ?ContainerInterface $container = null,
+        ?LoggerInterface $logger = null
     ) {
         $this->router = $router;
         $this->middlewareStack = new MiddlewareStack();
         $this->renderer = $renderer ?? new JsonRenderer();
         $this->exceptionHandler = $exceptionHandler;
         $this->container = $container;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function getMiddlewareStack(): MiddlewareStack
@@ -61,5 +67,10 @@ class ApivalkConfiguration
     public function getContainer(): ?ContainerInterface
     {
         return $this->container;
+    }
+
+    public function getLogger(): LoggerInterface
+    {
+        return $this->logger;
     }
 }

--- a/Tests/PhpUnit/ApivalkConfigurationTest.php
+++ b/Tests/PhpUnit/ApivalkConfigurationTest.php
@@ -11,6 +11,8 @@ use apivalk\apivalk\Http\Renderer\JsonRenderer;
 use apivalk\apivalk\Router\AbstractRouter;
 use apivalk\apivalk\Middleware\MiddlewareStack;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class ApivalkConfigurationTest extends TestCase
 {
@@ -24,6 +26,7 @@ class ApivalkConfigurationTest extends TestCase
         $this->assertInstanceOf(MiddlewareStack::class, $config->getMiddlewareStack());
         $this->assertNull($config->getExceptionHandler());
         $this->assertNull($config->getContainer());
+        $this->assertInstanceOf(NullLogger::class, $config->getLogger());
     }
 
     public function testCustomConfiguration(): void
@@ -31,13 +34,15 @@ class ApivalkConfigurationTest extends TestCase
         $router = $this->createMock(AbstractRouter::class);
         $renderer = $this->createMock(RendererInterface::class);
         $container = $this->createMock(ContainerInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
         $handler = function () {};
 
-        $config = new ApivalkConfiguration($router, $renderer, $handler, $container);
+        $config = new ApivalkConfiguration($router, $renderer, $handler, $container, $logger);
 
         $this->assertSame($router, $config->getRouter());
         $this->assertSame($renderer, $config->getRenderer());
         $this->assertSame($handler, $config->getExceptionHandler());
         $this->assertSame($container, $config->getContainer());
+        $this->assertSame($logger, $config->getLogger());
     }
 }

--- a/Tests/PhpUnit/ApivalkTest.php
+++ b/Tests/PhpUnit/ApivalkTest.php
@@ -12,6 +12,7 @@ use apivalk\apivalk\Router\AbstractRouter;
 use apivalk\apivalk\Middleware\MiddlewareStack;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 class ApivalkTest extends TestCase
 {
@@ -20,13 +21,15 @@ class ApivalkTest extends TestCase
         $router = $this->createMock(AbstractRouter::class);
         $renderer = $this->createMock(RendererInterface::class);
         $container = $this->createMock(ContainerInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
         
-        $config = new ApivalkConfiguration($router, $renderer, null, $container);
+        $config = new ApivalkConfiguration($router, $renderer, null, $container, $logger);
         $apivalk = new Apivalk($config);
 
         $this->assertSame($router, $apivalk->getRouter());
         $this->assertSame($renderer, $apivalk->getRenderer());
         $this->assertSame($container, $apivalk->getContainer());
+        $this->assertSame($logger, $apivalk->getLogger());
         $this->assertInstanceOf(MiddlewareStack::class, $apivalk->getMiddlewareStack());
     }
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     "php": ">=7.2",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "psr/container": "^1.1.1 || ^2.0.1"
+    "psr/container": "^1.1.1 || ^2.0.1",
+    "psr/log": "^1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5"


### PR DESCRIPTION
This commit enables the usage of logging inside the apivalk package. For this purpose, an implementation of `LoggerInterface` can be injected via `ApivalConfiguration` into `Apivalk`. This change allows logs from the apivalk package to be integrated directly into your own logging system.