### PR TITLE
feat: improve not found error massage

### DIFF
--- a/Http/Response/NotFoundApivalkResponse.php
+++ b/Http/Response/NotFoundApivalkResponse.php
@@ -9,6 +9,9 @@ use apivalk\apivalk\Documentation\Property\StringProperty;
 
 class NotFoundApivalkResponse extends AbstractApivalkResponse
 {
+    /** @var string */
+    private $errorMessage = 'Not found';
+
     public static function getDocumentation(): ApivalkResponseDocumentation
     {
         $responseDocumentation = new ApivalkResponseDocumentation();
@@ -24,10 +27,17 @@ class NotFoundApivalkResponse extends AbstractApivalkResponse
         return self::HTTP_404_NOT_FOUND;
     }
 
+    public function setErrorMessage(string $errorMessage): self
+    {
+        $this->errorMessage = $errorMessage;
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return [
-            'error' => 'Not found'
+            'error' => $this->errorMessage
         ];
     }
 }


### PR DESCRIPTION
adds a setErrorMassage to the NotFoundApivalkResponse class to be able to set custom massages for the error