### PR TITLE
feat: extend Route with HTTP methods, summary, and fluent API

### DIFF
--- a/Documentation/OpenAPI/Generator/OperationGenerator.php
+++ b/Documentation/OpenAPI/Generator/OperationGenerator.php
@@ -67,7 +67,7 @@ class OperationGenerator
         return new OperationObject(
             $route->getMethod(),
             $route->getTags(),
-            $route->getDescription(),
+            $route->getSummary(),
             $route->getDescription(),
             \sprintf('%s_%s', $route->getUrl(), $route->getMethod()->getName()),
             $parameters,

--- a/Router/Route.php
+++ b/Router/Route.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Router;
 
 use apivalk\apivalk\Documentation\OpenAPI\Object\TagObject;
+use apivalk\apivalk\Http\Method\DeleteMethod;
+use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Method\MethodInterface;
+use apivalk\apivalk\Http\Method\PatchMethod;
+use apivalk\apivalk\Http\Method\PostMethod;
+use apivalk\apivalk\Http\Method\PutMethod;
 use apivalk\apivalk\Router\RateLimit\RateLimitInterface;
 use apivalk\apivalk\Security\RouteAuthorization;
 
@@ -17,6 +22,8 @@ class Route
     private $method;
     /** @var string|null */
     private $description;
+    /** @var string|null */
+    private $summary;
     /** @var RouteAuthorization */
     private $routeAuthorization;
     /** @var TagObject[] */
@@ -28,6 +35,7 @@ class Route
      * @param string                  $url
      * @param MethodInterface         $method
      * @param string|null             $description
+     * @param string|null             $summary
      * @param TagObject[]             $tags
      * @param RouteAuthorization|null $routeAuthorization
      * @param RateLimitInterface|null $rateLimit
@@ -36,6 +44,7 @@ class Route
         string $url,
         MethodInterface $method,
         ?string $description = null,
+        ?string $summary = null,
         ?array $tags = null,
         ?RouteAuthorization $routeAuthorization = null,
         ?RateLimitInterface $rateLimit = null
@@ -43,9 +52,80 @@ class Route
         $this->url = $url;
         $this->method = $method;
         $this->description = $description;
+        $this->summary = $summary;
         $this->tags = $tags ?? [];
         $this->routeAuthorization = $routeAuthorization;
         $this->rateLimit = $rateLimit;
+    }
+
+    public static function get(string $url): self
+    {
+        return new self($url, new GetMethod());
+    }
+
+    public static function post(string $url): self
+    {
+        return new self($url, new PostMethod());
+    }
+
+    public static function delete(string $url): self
+    {
+        return new self($url, new DeleteMethod());
+    }
+
+    public static function patch(string $url): self
+    {
+        return new self($url, new PatchMethod());
+    }
+
+    public static function put(string $url): self
+    {
+        return new self($url, new PutMethod());
+    }
+
+    /**
+     * @param TagObject[] $tags
+     *
+     * @return self
+     */
+    public function tags(array $tags): self
+    {
+        $this->tags = $tags;
+
+        return $this;
+    }
+
+    public function routeAuthorization(RouteAuthorization $routeAuthorization): self
+    {
+        $this->routeAuthorization = $routeAuthorization;
+
+        return $this;
+    }
+
+    public function rateLimit(RateLimitInterface $rateLimit): self
+    {
+        $this->rateLimit = $rateLimit;
+
+        return $this;
+    }
+
+    public function description(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function summary(string $summary): self
+    {
+        $this->summary = $summary;
+
+        return $this;
+    }
+
+    public function getSummary(): ?string
+    {
+        return $this->summary;
     }
 
     public function getUrl(): string

--- a/Router/RouteJsonSerializer.php
+++ b/Router/RouteJsonSerializer.php
@@ -16,6 +16,7 @@ class RouteJsonSerializer
      *     url: string,
      *     method: string,
      *     description: string|null,
+     *     summary: string|null,
      *     tags: array<int, array{
      *         name: string,
      *         description: string|null
@@ -63,6 +64,7 @@ class RouteJsonSerializer
             'url' => $route->getUrl(),
             'method' => $route->getMethod()->getName(),
             'description' => $route->getDescription(),
+            'summary' => $route->getSummary(),
             'tags' => $tags,
             'routeAuthorization' => $routeAuthorizationData ?? null,
             'rateLimit' => $rateLimitData ?? null,
@@ -112,6 +114,7 @@ class RouteJsonSerializer
             $jsonArray['url'],
             MethodFactory::create($jsonArray['method']),
             $jsonArray['description'] ?? null,
+            $jsonArray['summary'] ?? null,
             $tags,
             $routeAuthorization,
             $rateLimit

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/OperationGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/OperationGeneratorTest.php
@@ -45,7 +45,8 @@ class OperationGeneratorTest extends TestCase
         
         $operation = $generator->generate($route, $requestDoc, [TestResponse::class]);
         
-        $this->assertEquals('Route desc', $operation->getSummary());
+        $this->assertEquals('Route desc', $operation->getDescription());
+        $this->assertNull($operation->getSummary());
         $this->assertCount(6, $operation->getResponses()); // 1 custom + 5 default
     }
 }

--- a/Tests/PhpUnit/Router/RouteJsonSerializerTest.php
+++ b/Tests/PhpUnit/Router/RouteJsonSerializerTest.php
@@ -18,6 +18,7 @@ class RouteJsonSerializerTest extends TestCase
             '/users',
             new GetMethod(),
             'User list',
+            null,
             [],
             null,
             new IpRateLimit('ip_limit', 10, 60)
@@ -36,6 +37,38 @@ class RouteJsonSerializerTest extends TestCase
         $this->assertEquals($route->getUrl(), $deserialized->getUrl());
         $this->assertEquals($route->getMethod()->getName(), $deserialized->getMethod()->getName());
         $this->assertEquals($route->getDescription(), $deserialized->getDescription());
+        $this->assertNull($deserialized->getSummary());
+        $this->assertInstanceOf(IpRateLimit::class, $deserialized->getRateLimit());
+        $this->assertEquals('ip_limit', $deserialized->getRateLimit()->getName());
+    }
+
+    public function testSerializeDeserializeWithSummary(): void
+    {
+        $route = new Route(
+            '/users',
+            new GetMethod(),
+            'User list',
+            'Test',
+            [],
+            null,
+            new IpRateLimit('ip_limit', 10, 60)
+        );
+
+        $serialized = RouteJsonSerializer::serialize($route);
+        $this->assertEquals('/users', $serialized['url']);
+        $this->assertEquals('GET', $serialized['method']);
+        $this->assertEquals('User list', $serialized['description']);
+        $this->assertEquals('Test', $serialized['summary']);
+        $this->assertEquals('apivalk\apivalk\Router\RateLimit\IpRateLimit', $serialized['rateLimit']['class']);
+        $this->assertEquals('ip_limit', $serialized['rateLimit']['name']);
+
+        $json = json_encode($serialized);
+        $deserialized = RouteJsonSerializer::deserialize($json);
+
+        $this->assertEquals($route->getUrl(), $deserialized->getUrl());
+        $this->assertEquals($route->getMethod()->getName(), $deserialized->getMethod()->getName());
+        $this->assertEquals($route->getDescription(), $deserialized->getDescription());
+        $this->assertEquals($route->getSummary(), $deserialized->getSummary());
         $this->assertInstanceOf(IpRateLimit::class, $deserialized->getRateLimit());
         $this->assertEquals('ip_limit', $deserialized->getRateLimit()->getName());
     }

--- a/Tests/PhpUnit/Router/RouteTest.php
+++ b/Tests/PhpUnit/Router/RouteTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Router;
 
+use apivalk\apivalk\Http\Method\PostMethod;
+use apivalk\apivalk\Router\RateLimit\IpRateLimit;
 use apivalk\apivalk\Router\RouteJsonSerializer;
 use PHPUnit\Framework\TestCase;
 use apivalk\apivalk\Router\Route;
@@ -19,7 +21,7 @@ class RouteTest extends TestCase
         $tag = new TagObject('user');
         $security = new RouteAuthorization('Bearer');
 
-        $route = new Route('/users', $method, 'Description', [$tag], $security);
+        $route = new Route('/users', $method, 'Description', null, [$tag], $security);
 
         $this->assertEquals('/users', $route->getUrl());
         $this->assertSame($method, $route->getMethod());
@@ -28,13 +30,40 @@ class RouteTest extends TestCase
         $this->assertSame($security, $route->getRouteAuthorization());
     }
 
+    public function testFluentBuilderApi(): void
+    {
+        $getRoute = new Route('/users', new GetMethod(), 'Description', 's');
+        $this->assertEquals($getRoute, Route::get('/users')->summary('s')->description('Description'));
+
+        $getRoute = new Route('/users', new GetMethod());
+        $this->assertEquals($getRoute, Route::get('/users'));
+
+        $postRoute = new Route(
+            '/cr/{d}',
+            new PostMethod(),
+            'Nice',
+            null,
+            [new TagObject('abc')],
+            new RouteAuthorization('api', ['test'], ['test:read']),
+            new IpRateLimit('test', 20, 5)
+        );
+        $this->assertEquals(
+            $postRoute,
+            Route::post('/cr/{d}')
+                ->description('Nice')
+                ->tags([new TagObject('abc')])
+                ->rateLimit(new IpRateLimit('test', 20, 5))
+                ->routeAuthorization(new RouteAuthorization('api', ['test'], ['test:read']))
+        );
+    }
+
     public function testJsonSerialization(): void
     {
         $method = new GetMethod();
         $tag = new TagObject('user', 'User tag');
         $security = new RouteAuthorization('Bearer', ['read']);
 
-        $route = new Route('/users', $method, 'Desc', [$tag], $security);
+        $route = new Route('/users', $method, 'Desc', null, [$tag], $security);
 
         $json = json_encode(RouteJsonSerializer::serialize($route));
         $this->assertIsString($json);

--- a/docs/documentation/openapi-generator.mdx
+++ b/docs/documentation/openapi-generator.mdx
@@ -151,9 +151,7 @@ $components->setSecuritySchemes([
 ]);
 
 // In your route:
-$route = new Route('/orders', new PostMethod(), 'Create order', [],
-    new RouteAuthorization('BearerAuth', ['write:orders'])
-);
+$route = Route::post('/orders')->description('Create order')->authorization('BearerAuth', ['write:orders'])
 ```
 
 Passing your custom components to the generator:

--- a/docs/middleware/security.mdx
+++ b/docs/middleware/security.mdx
@@ -27,16 +27,17 @@ A route that requires a logged-in user with specific scopes and permissions.
 use apivalk\apivalk\Router\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 
-$route = new Route('/admin/dashboard', new GetMethod(), 'Admin Dashboard', [],
-    new RouteAuthorization('BearerAuth', ['admin'], ['admin:dashboard:read'])
-);
+$route = Route::get('/admin/dashboard')
+                ->description('Admin Dashboard')
+                ->authorization(new RouteAuthorization('BearerAuth', ['admin'], ['admin:dashboard:read']))
+
 ```
 
 ### Public Route (No Authorization)
 A route that is accessible by anyone.
 
 ```php
-$route = new Route('/about', new GetMethod(), 'About page', [], null);
+$route = Route::get('/about')->description('About page');
 ```
 
 ### Optional Security (Public with Authorization)

--- a/docs/routing/route.mdx
+++ b/docs/routing/route.mdx
@@ -19,7 +19,7 @@ A `Route` instance contains the following information:
 Routes support dynamic path parameters using the `{parameterName}` syntax. For example:
 
 ```php
-new Route('/users/{id}/profile', new GetMethod());
+Route::get('/users/{id}/profile');
 ```
 
 These parameters are automatically identified and converted into capture groups in the internal regex generation logic.
@@ -36,12 +36,9 @@ To make a route private, you add a `RouteAuthorization` to the route's construct
 use apivalk\apivalk\Router\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 
-new Route('/orders',
-    new PostMethod(),
-    'Create order',
-    [],
-    new RouteAuthorization('apiKey', ['accounting:orders'], ['accounting:orders:create'])
-);
+Route::post('/orders')
+       ->description('Create order')
+       ->routeAuthorization(new RouteAuthorization('apiKey', ['accounting:orders'], ['accounting:orders:create']));
 ```
 
 ### Public and Optional Security
@@ -65,12 +62,9 @@ In an Apivalk application, you typically don't instantiate `Route` objects manua
 ```php
 public static function getRoute(): Route
 {
-    return new Route(
-        '/v1/hello-world',
-        new GetMethod(),
-        'A simple hello world endpoint',
-        [new TagObject('Greeting', 'Endpoints for saying hello')]
-    );
+    return Route::get('/v1/hello-world')
+                  ->description('A simple hello world endpoint')
+                  ->tag(new TagObject('Greeting', 'Endpoints for saying hello'));
 }
 ```
 
@@ -83,14 +77,9 @@ use apivalk\apivalk\Router\RateLimit\IpRateLimit;
 
 public static function getRoute(): Route
 {
-    return new Route(
-        '/v1/sensitive-data',
-        new GetMethod(),
-        'Access sensitive data',
-        [], // Tags
-        null, // Security
-        new IpRateLimit('sensitive_access', 5, 60) // 5 requests per minute
-    );
+    return new Route::get('/v1/sensitive-data')
+                      ->description('Access sensitive data')
+                      ->rateLimit(new IpRateLimit('sensitive_access', 5, 60));
 }
 ```
 

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -27,9 +27,7 @@ The security layer consists of four main pillars:
 use apivalk\apivalk\Router\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 
-$route = new Route('/admin/settings', new GetMethod(), 'Admin Settings', [],
-    new RouteAuthorization('BearerAuth', ['admin:settings'], ['admin:settings:read'])
-);
+$route = Route::get('/admin/settings')->description('Admin Settings')->authorization(new RouteAuthorization('BearerAuth', ['admin:settings'], ['admin:settings:read']))
 ```
 
 In this example, the route requires a security scheme named `BearerAuth` with the `admin:settings` scope and `admin:settings:read` permission.
@@ -91,12 +89,10 @@ use apivalk\apivalk\Router\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 
 // PRIVATE: Requires 'write:orders' scope
-$privateRoute = new Route('/orders', new PostMethod(), 'Create order', [],
-    new RouteAuthorization('BearerAuth', ['order'], ['order:create'])
-);
+$privateRoute = Route::post('/orders')->description('Create order')->authorization(new RouteAuthorization('BearerAuth', ['order'], ['order:create']))
 
 // PUBLIC: No security requirements
-$publicRoute = new Route('/about', new GetMethod(), 'About us');
+$publicRoute = Route::get('/about')->description('About us');
 ```
 
 For more details on custom logic, check the [Custom Authentication](/middleware/authentication#custom-authentication-logic) section.


### PR DESCRIPTION
- Add static builders for HTTP methods (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`).
- Introduce `summary` alongside `description` for enhanced metadata.
- Implement fluent API for configuring `tags`, `description`, `summary`, and more.
- Update tests for new methods and fluent API implementation.

Issue: #47