### PR TITLE
docs: add REST API standards and best practices guide

### DIFF
--- a/Documentation/Response/ErrorObject.php
+++ b/Documentation/Response/ErrorObject.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Documentation\Response;
+
+use apivalk\apivalk\Documentation\Property\AbstractObjectProperty;
+use apivalk\apivalk\Documentation\Property\AbstractPropertyCollection;
+
+class ErrorObject extends AbstractObjectProperty
+{
+    /** @var string */
+    private $errorKey;
+    /** @var string */
+    private $message;
+
+    final public function __construct()
+    {
+        parent::__construct('error', 'Error');
+    }
+
+    public function populate(string $errorKey, string $message): void
+    {
+        $this->errorKey = $errorKey;
+        $this->message = $message;
+    }
+
+    public function getErrorKey(): string
+    {
+        return $this->errorKey;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getPropertyCollection(): AbstractPropertyCollection
+    {
+        return new ErrorObjectPropertyCollection(AbstractPropertyCollection::MODE_VIEW);
+    }
+
+    /** @return array{key: string, message: string} */
+    public function toArray(): array
+    {
+        return [
+            'key' => $this->errorKey,
+            'message' => $this->message,
+        ];
+    }
+}

--- a/Documentation/Response/ErrorObjectPropertyCollection.php
+++ b/Documentation/Response/ErrorObjectPropertyCollection.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Documentation\Response;
+
+use apivalk\apivalk\Documentation\Property\AbstractPropertyCollection;
+use apivalk\apivalk\Documentation\Property\StringProperty;
+
+class ErrorObjectPropertyCollection extends AbstractPropertyCollection
+{
+    public function __construct(string $mode)
+    {
+        $this->addProperty(new StringProperty('errorKey', 'A key identifying the error'));
+        $this->addProperty(new StringProperty('message', 'The error message'));
+    }
+}

--- a/Tests/PhpUnit/Documentation/Response/ErrorObjectPropertyCollectionTest.php
+++ b/Tests/PhpUnit/Documentation/Response/ErrorObjectPropertyCollectionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documentation\Response;
+
+use apivalk\apivalk\Documentation\Property\AbstractPropertyCollection;
+use apivalk\apivalk\Documentation\Response\ErrorObjectPropertyCollection;
+use PHPUnit\Framework\TestCase;
+
+class ErrorObjectPropertyCollectionTest extends TestCase
+{
+    public function testCollection(): void
+    {
+        $collection = new ErrorObjectPropertyCollection(AbstractPropertyCollection::MODE_VIEW);
+        $properties = iterator_to_array($collection);
+
+        $this->assertCount(2, $properties);
+        $this->assertEquals('errorKey', $properties[0]->getPropertyName());
+        $this->assertTrue($properties[0]->isRequired());
+        $this->assertEquals('message', $properties[1]->getPropertyName());
+        $this->assertTrue($properties[1]->isRequired());
+    }
+}

--- a/Tests/PhpUnit/Documentation/Response/ErrorObjectTest.php
+++ b/Tests/PhpUnit/Documentation/Response/ErrorObjectTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documentation\Response;
+
+use apivalk\apivalk\Documentation\Property\AbstractPropertyCollection;
+use apivalk\apivalk\Documentation\Response\ErrorObject;
+use apivalk\apivalk\Documentation\Response\ErrorObjectPropertyCollection;
+use PHPUnit\Framework\TestCase;
+
+final class ErrorObjectTest extends TestCase
+{
+    public function testPopulateAndGetters(): void
+    {
+        $obj = new ErrorObject();
+        $obj->populate('validation_failed', 'Name is required.');
+
+        $this->assertSame('validation_failed', $obj->getErrorKey());
+        $this->assertSame('Name is required.', $obj->getMessage());
+    }
+
+    public function testToArray(): void
+    {
+        $obj = new ErrorObject();
+        $obj->populate('unauthorized', 'Missing token.');
+
+        $this->assertSame(
+            [
+                'key' => 'unauthorized',
+                'message' => 'Missing token.',
+            ],
+            $obj->toArray()
+        );
+    }
+
+    public function testGetPropertyCollectionReturnsExpectedCollection(): void
+    {
+        $obj = new ErrorObject();
+        $collection = $obj->getPropertyCollection();
+
+        $this->assertInstanceOf(AbstractPropertyCollection::class, $collection);
+        $this->assertInstanceOf(ErrorObjectPropertyCollection::class, $collection);
+
+        if (method_exists($collection, 'getMode')) {
+            $this->assertSame(AbstractPropertyCollection::MODE_VIEW, $collection->getMode());
+        }
+    }
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -114,6 +114,17 @@
             "pages": [
               "customization/customization"
             ]
+          },
+          {
+            "group": "API Standards",
+            "pages": [
+              "open-api-best-practices/01-overview",
+              "open-api-best-practices/02-rest-design-and-naming",
+              "open-api-best-practices/03-versioning-and-structure",
+              "open-api-best-practices/04-pagination-filtering-sorting",
+              "open-api-best-practices/05-responses-errors-status-codes",
+              "open-api-best-practices/06-localization-i18n"
+            ]
           }
         ]
       }

--- a/docs/open-api-best-practices/01-overview.mdx
+++ b/docs/open-api-best-practices/01-overview.mdx
@@ -1,0 +1,23 @@
+---
+title: REST API Standards Overview
+description: Core principles and scope of REST API standards in Apivalk.
+---
+
+# REST API Standards Overview
+
+These standards define how REST APIs are designed, documented, and operated within the **Apivalk** ecosystem.
+
+They exist to ensure:
+
+- Consistency across APIs
+- Predictable contracts for consumers
+- First-class OpenAPI and SDK support
+- Long-term maintainability and version safety
+
+> ⚠️ All APIs built with Apivalk **should** comply with these standards.
+
+Benefits:
+
+- Unified documentation (internal and external)
+- API-first workflows
+- Swagger, Postman, Insomnia, Stoplight compatibility

--- a/docs/open-api-best-practices/02-rest-design-and-naming.mdx
+++ b/docs/open-api-best-practices/02-rest-design-and-naming.mdx
@@ -1,0 +1,117 @@
+---
+title: RESTful design and naming
+description: REST principles, HTTP methods, and naming conventions for routes, identifiers, and fields.
+---
+
+# RESTful design and naming
+
+## RESTful design principles
+
+Follow industry-standard REST conventions.
+
+### HTTP methods
+
+| Method | Description |
+|---|---|
+| GET | Retrieve resources |
+| POST | Create a new resource |
+| PUT | Fully update an existing resource |
+| PATCH | Partially update an existing resource |
+| DELETE | Delete a resource |
+| OPTIONS | Show available methods (optional if docs cover it) |
+| HEAD | Same as GET but returns only headers, no response body |
+
+## Naming conventions
+
+### URI naming
+
+Rules:
+
+- Use plural nouns, lowercase, hyphenated names
+- No verbs in URLs
+- Nest resources only if there is a logical hierarchy or relationship
+- Keep nesting shallow (2 levels max)
+
+Examples:
+
+```http
+GET    /users
+POST   /users
+GET    /users/{user_uuid}
+PATCH  /users/{user_uuid}
+DELETE /users/{user_uuid}
+GET    /users/{user_uuid}/authenticators
+
+GET    /user-groups
+GET    /user/{user_uuid}/adress-verification-requests
+```
+
+### Resource identifiers: IDs vs UUIDs
+
+Path parameters that identify a single resource should (if possible) use UUIDs.
+
+Rules:
+
+- UUIDs should be used for externally exposed REST APIs
+- Numeric, auto-increment IDs (/users/1) must not be exposed; they have a risk for enumeration
+- Only when there is no other way around it you can use auto-increment IDs
+- Internal IDs may exist but should never be part of the public API contract
+
+Rationale:
+
+- Prevents ID enumeration and scraping
+- Improves security by design
+- Decouples API contracts from database implementation details
+- Enables safer data migrations and sharding
+
+Examples:
+
+Correct:
+
+```http
+GET /users/550e8400-e29b-41d4-a716-446655440000
+PATCH /devices/{device_uuid}
+DELETE /orders/{order_uuid}
+```
+
+Avoid:
+
+```http
+GET /users/1
+PATCH /devices/42
+```
+
+### Path parameter naming
+
+Path parameters should be explicitly named:
+
+- {user_uuid}
+- {order_uuid}
+- {device_uuid}
+
+Avoid generic {id} or {uuid} naming to clarify to what resource the ID belongs to.
+
+### Field naming (JSON bodies)
+
+Use snake_case:
+
+```json
+{
+  "user_name": "john_doe",
+  "email_address": "john@example.com"
+}
+```
+
+### Parameter naming in URI, path, body
+
+Use snake_case consistently:
+
+```http
+GET /users?page_size=50&client_id=123
+```
+
+```json
+{
+  "first_name": "Max"
+}
+```

--- a/docs/open-api-best-practices/03-versioning-and-structure.mdx
+++ b/docs/open-api-best-practices/03-versioning-and-structure.mdx
@@ -1,0 +1,38 @@
+---
+title: Versioning and resource structure
+description: URL-based versioning and folder and resource organization guidelines.
+---
+
+# Versioning and resource structure
+
+## API versioning strategy
+
+Use URL-based versioning.
+
+Examples:
+
+- https://api.example.com/v1/...
+- https://app.example.com/v1/...
+
+Why:
+
+- Explicit versioning in every request
+- Easier debugging, monitoring, and routing
+- Cleaner folder structure
+- Old versions can coexist safely
+
+## Resource structure and folder organization
+
+Use RESTful, hierarchical naming to reflect relationships.
+
+Example:
+
+```http
+GET /users/{user_uuid}/addresses
+```
+
+Guidelines:
+
+- Plural nouns only (/users, /addresses)
+- Keep nesting shallow (2 levels max)
+- Actions are defined by HTTP verbs, not URLs

--- a/docs/open-api-best-practices/04-pagination-filtering-sorting.mdx
+++ b/docs/open-api-best-practices/04-pagination-filtering-sorting.mdx
@@ -1,0 +1,105 @@
+---
+title: Pagination, filtering, and sorting
+description: How to paginate, sort, and filter collections consistently.
+---
+
+# Pagination, filtering, and sorting
+
+## Pagination, filtering and sorting
+
+### Pagination
+
+#### Offset or page pagination
+
+Use limit and offset or page:
+
+```http
+GET /users?limit=50&offset=100
+GET /users?page=2
+```
+
+Example response snippet:
+
+```json
+{
+  "pagination": {
+    "page": 1,
+    "total_pages": 1,
+    "page_size": 10
+  }
+}
+```
+
+#### Cursor pagination
+
+```http
+GET /users?cursor=base64EncodedCursor
+GET /users?cursor=base64EncodedCursor&limit=100
+```
+
+Example response snippet:
+
+```json
+{
+  "pagination": {
+    "cursor": {
+      "next": "string",
+      "prev": "string"
+    }
+  }
+}
+```
+
+### Sorting
+
+Use '+' (ASC) or '-' (DESC) as a prefix for each field. If not specified, default is ASC.
+
+```http
+GET /users?order_by=+id,-price
+```
+
+### Filtering
+
+Filtering allows clients to narrow down results by specifying conditions on fields.
+
+Two supported approaches:
+
+- Basic filters: simple key-value pairs, useful for direct or indirect matching in smaller or performance-sensitive APIs
+- Advanced filters: a filter parameter allowing multiple field expressions
+
+#### Basic filtering
+
+Use flat key-value parameters.
+
+Example: retrieve all plugs with phase AC:
+
+```http
+GET /plugs?phase=AC
+```
+
+Basic filters may also use parameter names that are not directly bound to object fields.
+
+Example:
+
+```http
+GET /orders?min_price=200
+```
+
+#### Advanced filtering
+
+Use the `filter` parameter (inspired by JSON:API).
+
+```http
+GET /users?filter[email]=@example.com&filter[id]=5
+```
+
+Notes:
+
+- Advanced filters must always be bound to actual fields on the resource
+- Operators (`=, LIKE, <, >, etc.`) are decided by the API implementation and must be documented
+
+#### Combining basic and advanced filters
+
+```http
+GET /orders?filter[status]=active&min_gross=200
+```

--- a/docs/open-api-best-practices/05-responses-errors-status-codes.mdx
+++ b/docs/open-api-best-practices/05-responses-errors-status-codes.mdx
@@ -1,0 +1,161 @@
+---
+title: Response format and status codes
+description: Standard response envelopes, error objects, validation errors, and HTTP status codes.
+---
+
+# Response format and status codes
+
+## Response format and status codes
+
+### Base success response (200, 201, 202)
+
+```json
+{
+  "data": {
+    "user_id": 123,
+    "user_name": "john_doe"
+  },
+  "message": "User retrieved successfully."
+}
+```
+
+### Base collection response (200)
+
+```json
+{
+  "data": [
+    { "user_id": 123, "user_name": "john_doe" },
+    { "user_id": 456, "user_name": "jane_doe" }
+  ],
+  "pagination": {
+    "page": 1,
+    "page_size": 10,
+    "total_pages": 5
+  },
+  "message": "Users retrieved successfully."
+}
+```
+
+Empty response must be an empty array:
+
+```json
+{
+  "data": [],
+  "pagination": {
+    "page": 1,
+    "page_size": 10,
+    "total_pages": null
+  },
+  "message": "Users retrieved successfully."
+}
+```
+
+### Base error response (400-500)
+
+```json
+{
+  "error": {
+    "key": "USER_NOT_FOUND",
+    "message": "The specified user does not exist."
+  }
+}
+```
+
+Rules:
+
+- error.key is mandatory and machine-readable
+- error.message is human-readable and should be localized
+
+### Base deleted response (204)
+
+HTTP 204 responses have no body.
+
+### Base validation error response (422)
+
+```json
+{
+  "errors": [
+    {
+      "parameter": "user_name",
+      "message": "User name is not long enough.",
+      "key": "USER_NAME_NOT_LONG_ENOUGH"
+    }
+  ]
+}
+```
+
+Rules:
+
+- parameter should use snake_case and match the request field name where possible
+- message should be localized
+- key should be stable and machine-readable
+
+### Base OPTIONS response
+
+OPTIONS responses should rely on headers, not a body.
+
+Example headers:
+
+```http
+HTTP/1.1 200 OK
+Allow: GET,HEAD,POST,OPTIONS
+Content-Length: 0
+```
+
+### HTTP status codes
+
+| Code | Meaning | Use when |
+|---|---|---|
+| 200 | OK | Standard GET, PUT, PATCH, DELETE |
+| 201 | Created | New resource created (POST) |
+| 202 | Accepted | Async operation started |
+| 204 | No Content | Successful with no body |
+| 400 | Bad Request | Validation error or bad input |
+| 401 | Unauthorized | Auth missing or invalid |
+| 403 | Forbidden | No permission |
+| 404 | Not Found | Resource does not exist |
+| 409 | Conflict | Duplicate or inconsistent data |
+| 422 | Unprocessable Entity | Semantic validation failure |
+| 429 | Too Many Requests | Rate limit exceeded |
+| 500 | Internal Server Error | Unexpected backend failure |
+
+## Rate limiting
+
+All REST APIs should expose standardized rate-limit information via HTTP response headers.
+
+Headers:
+
+| Header | Description |
+|---|---|
+| X-RateLimit-Limit | Maximum number of requests allowed within the time window |
+| X-RateLimit-Remaining | Requests remaining in the current window |
+| X-RateLimit-Reset | UNIX timestamp (seconds) when the window resets |
+| Retry-After | Seconds to wait before retrying (429 only) |
+
+Example:
+
+```http
+HTTP/1.1 200 OK
+X-RateLimit-Limit: 1000
+X-RateLimit-Remaining: 742
+X-RateLimit-Reset: 1705228800
+```
+
+Rate limit exceeded example:
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 60
+X-RateLimit-Limit: 1000
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 1705228800
+```
+
+```json
+{
+  "error": {
+    "key": "RATE_LIMIT_EXCEEDED",
+    "message": "Too many requests. Please retry after the rate limit window resets."
+  }
+}
+```

--- a/docs/open-api-best-practices/06-localization-i18n.mdx
+++ b/docs/open-api-best-practices/06-localization-i18n.mdx
@@ -1,0 +1,59 @@
+---
+title: Localization and internationalization
+description: Standards for localized response messages and language negotiation.
+---
+
+# Localization and internationalization
+
+## Localization and internationalization (i18n)
+
+All REST APIs should support localized, human-readable messages (success, error, validation). Localization applies only to message strings, never to API contracts or machine-readable fields.
+If you do not want to be as dynamic, at least make sure to include English readable messages.
+
+### Request language negotiation
+
+APIs must determine the response language using the standard HTTP request header Accept-Language.
+
+The value must follow BCP 47 language tags (RFC 5646).
+
+Examples:
+
+```http
+Accept-Language: de-DE
+Accept-Language: de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7
+Accept-Language: en
+```
+
+### Language resolution rules (mandatory)
+
+Resolve the response language in this order:
+
+1. Accept-Language header
+2. Fallback to default language en
+
+If the requested language is not supported, the API must fall back to English and continue processing.
+
+### Response language declaration
+
+Return the resolved language via Content-Language.
+
+```http
+Content-Language: de-DE
+```
+
+### What must be localized
+
+Localize:
+
+- message fields in success responses
+- message fields in error responses
+- Validation error messages
+- Human-readable descriptions
+
+Must not be localized:
+
+- Field names
+- JSON keys
+- Error keys or error codes
+- Enum values
+- IDs, UUIDs, technical identifiers

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -297,6 +297,11 @@ parameters:
 			path: Documentation/Response/ValidationErrorObjectPropertyCollection.php
 
 		-
+			message: "#^Constructor of class apivalk\\\\apivalk\\\\Documentation\\\\Response\\\\ErrorObjectPropertyCollection has an unused parameter \\$mode\\.$#"
+			count: 1
+			path: Documentation/Response/ErrorObjectPropertyCollection.php
+
+		-
 			message: "#^Class apivalk\\\\apivalk\\\\Http\\\\Request\\\\File\\\\FileBag implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: Http/Request/File/FileBag.php


### PR DESCRIPTION
- Introduce detailed guidelines on RESTful design, naming conventions, versioning, and resource structure.
- Add recommendations for pagination, filtering, sorting, and standard response formats.
- Include sections on localization, error handling, rate limiting, and tooling for docs and SDK generation.
- Update docs.json to register new API standards documentation pages.

Issue: #28