### PR TITLE
fix: property validator init

### DIFF
--- a/Documentation/ApivalkRequestDocumentation.php
+++ b/Documentation/ApivalkRequestDocumentation.php
@@ -18,17 +18,17 @@ class ApivalkRequestDocumentation
 
     public function addBodyProperty(AbstractProperty $property): void
     {
-        $this->bodyProperties[$property->getPropertyName()] = $property;
+        $this->bodyProperties[$property->getPropertyName()] = $property->init();
     }
 
     public function addQueryProperty(AbstractProperty $property): void
     {
-        $this->queryProperties[$property->getPropertyName()] = $property;
+        $this->queryProperties[$property->getPropertyName()] = $property->init();
     }
 
     public function addPathProperty(AbstractProperty $property): void
     {
-        $this->pathProperties[$property->getPropertyName()] = $property;
+        $this->pathProperties[$property->getPropertyName()] = $property->init();
     }
 
     public function getBodyProperties(): array

--- a/Documentation/ApivalkResponseDocumentation.php
+++ b/Documentation/ApivalkResponseDocumentation.php
@@ -15,9 +15,9 @@ class ApivalkResponseDocumentation
     /** @var bool */
     private $hasResponsePagination = false;
 
-    public function addProperty(AbstractProperty $parameter): void
+    public function addProperty(AbstractProperty $property): void
     {
-        $this->properties[] = $parameter;
+        $this->properties[] = $property->init();
     }
 
     public function setHasResponsePagination(bool $hasResponsePagination): void

--- a/Documentation/Property/AbstractProperty.php
+++ b/Documentation/Property/AbstractProperty.php
@@ -38,8 +38,6 @@ abstract class AbstractProperty
     ) {
         $this->propertyName = $propertyName;
         $this->propertyDescription = $propertyDescription;
-
-        $this->addValidator(ValidatorFactory::create($this));
     }
 
     final public function getPropertyName(): string
@@ -83,8 +81,17 @@ abstract class AbstractProperty
         return $this;
     }
 
+    /** @return array<int, AbstractValidator> */
     final public function getValidators(): array
     {
         return $this->validators;
+    }
+
+    /** Init's the property. Should be done everytime before properties are used. */
+    final public function init(): self
+    {
+        $this->addValidator(ValidatorFactory::create($this));
+
+        return $this;
     }
 }

--- a/Middleware/RequestValidationMiddleware.php
+++ b/Middleware/RequestValidationMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Middleware;
 
+use apivalk\apivalk\Documentation\Property\AbstractProperty;
 use apivalk\apivalk\Documentation\Property\Validator\ValidatorResult;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
@@ -52,6 +53,7 @@ class RequestValidationMiddleware implements MiddlewareInterface
         array $properties,
         ParameterBag $parameterBag
     ): void {
+        /** @var AbstractProperty $property */
         foreach ($properties as $property) {
             $parameter = $parameterBag->get($property->getPropertyName());
 

--- a/Tests/PhpUnit/Documentation/Property/AbstractPropertyTest.php
+++ b/Tests/PhpUnit/Documentation/Property/AbstractPropertyTest.php
@@ -12,21 +12,36 @@ class AbstractPropertyTest extends TestCase
     public function testAbstractProperty()
     {
         $property = new class('testProp', 'Description') extends AbstractProperty {
-            public function getType(): string { return 'test'; }
-            public function getPhpType(): string { return 'string'; }
-            public function getDocumentationArray(): array { return []; }
+            public function getType(): string
+            {
+                return 'test';
+            }
+
+            public function getPhpType(): string
+            {
+                return 'string';
+            }
+
+            public function getDocumentationArray(): array
+            {
+                return [];
+            }
         };
 
         $this->assertEquals('testProp', $property->getPropertyName());
         $this->assertEquals('Description', $property->getPropertyDescription());
         $this->assertTrue($property->isRequired());
-        
+
         $property->setIsRequired(false);
         $this->assertFalse($property->isRequired());
 
         $this->assertNull($property->getExample());
         $property->setExample('example-value');
         $this->assertEquals('example-value', $property->getExample());
+
+        $this->assertCount(0, $property->getValidators()); // not initialized yet, no validators
+
+        $property->init();
 
         $this->assertCount(1, $property->getValidators()); // Default validator from factory
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -291,11 +291,6 @@ parameters:
 			path: Documentation/Property/AbstractProperty.php
 
 		-
-			message: "#^Method apivalk\\\\apivalk\\\\Documentation\\\\Property\\\\AbstractProperty\\:\\:getValidators\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: Documentation/Property/AbstractProperty.php
-
-		-
 			message: "#^Class apivalk\\\\apivalk\\\\Documentation\\\\Property\\\\AbstractPropertyCollection implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: Documentation/Property/AbstractPropertyCollection.php


### PR DESCRIPTION
- base/default validators were added before even for factory necessary data was set. now there is an init method and everytime when we use properties we will init them. in the init method  the base validator is added.