### PR TITLE
Allow path properties to define custom route regex patterns

### DIFF
--- a/Http/Request/Parameter/ParameterBagFactory.php
+++ b/Http/Request/Parameter/ParameterBagFactory.php
@@ -7,6 +7,7 @@ namespace apivalk\apivalk\Http\Request\Parameter;
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Documentation\Property\AbstractProperty;
 use apivalk\apivalk\Documentation\Property\ArrayProperty;
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Router\Route;
 
 final class ParameterBagFactory
@@ -62,13 +63,23 @@ final class ParameterBagFactory
 
         $url = $route->getUrl();
         $escapedUrl = preg_replace_callback(
-            '/(\{[a-zA-Z0-9]+\})|([^{]+)/',
-            static function ($matches) {
+            '/(\{([a-zA-Z0-9]+)\})|([^{]+)/',
+            static function ($matches) use ($properties) {
                 if (!empty($matches[1])) {
+                    $paramName = $matches[2];
+
+                    // Use custom pattern from documentation if available
+                    if (isset($properties[$paramName])
+                        && $properties[$paramName] instanceof StringProperty
+                        && $properties[$paramName]->getPattern() !== null
+                    ) {
+                        return \sprintf('(%s)', $properties[$paramName]->getPattern());
+                    }
+
                     return '([a-zA-Z0-9-_]+)';
                 }
 
-                return preg_quote($matches[2], '#');
+                return preg_quote($matches[3], '#');
             },
             $url
         );

--- a/Router/RouteCacheFactory.php
+++ b/Router/RouteCacheFactory.php
@@ -41,9 +41,9 @@ class RouteCacheFactory
             }
 
             $route = $className::getRoute();
+            $documentation = ($className::getRequestClass())::getDocumentation();
 
             $routeCacheKey = $this->getRouteCacheKey($route);
-
             $cache->set(
                 new CacheItem(
                     $routeCacheKey,
@@ -53,7 +53,7 @@ class RouteCacheFactory
             );
 
             $cacheIndex[] = [
-                'regex' => RouteRegexFactory::build($route),
+                'regex' => RouteRegexFactory::build($route, $documentation),
                 'method' => $route->getMethod()->getName(),
                 'key' => $routeCacheKey,
                 'controllerClass' => $className,

--- a/Router/RouteRegexFactory.php
+++ b/Router/RouteRegexFactory.php
@@ -4,12 +4,36 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Router;
 
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Documentation\Property\StringProperty;
+
 class RouteRegexFactory
 {
-    public static function build(Route $route): string
+    public static function build(Route $route, ?ApivalkRequestDocumentation $documentation = null): string
     {
         $escaped = str_replace(['/', '.'], ['\/', '\.'], $route->getUrl());
-        $regexPattern = preg_replace('#\{[a-zA-Z0-9_]+\}#', '([a-zA-Z0-9_-]+)', $escaped);
+
+        $regexPattern = preg_replace_callback(
+            '#\{([a-zA-Z0-9_]+)\}#',
+            // Use custom pattern from request documentation if the path property
+            // defines one via setPattern(), otherwise fall back to the default.
+            static function (array $matches) use ($documentation): string {
+                $paramName = $matches[1];
+
+                if ($documentation !== null) {
+                    $pathProperties = $documentation->getPathProperties();
+                    if (isset($pathProperties[$paramName])
+                        && $pathProperties[$paramName] instanceof StringProperty
+                        && $pathProperties[$paramName]->getPattern() !== null
+                    ) {
+                        return \sprintf('(%s)', $pathProperties[$paramName]->getPattern());
+                    }
+                }
+
+                return '([a-zA-Z0-9_-]+)';
+            },
+            $escaped
+        );
 
         return \sprintf('#^%s$#', $regexPattern);
     }

--- a/Tests/PhpUnit/Router/RouteRegexFactoryTest.php
+++ b/Tests/PhpUnit/Router/RouteRegexFactoryTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Router;
 
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Router\Route;
 use apivalk\apivalk\Router\RouteRegexFactory;
@@ -23,5 +25,40 @@ class RouteRegexFactoryTest extends TestCase
 
         $route = new Route('/users/{id}/profile/{type}', $method);
         $this->assertEquals('#^\/users\/([a-zA-Z0-9_-]+)\/profile\/([a-zA-Z0-9_-]+)$#', RouteRegexFactory::build($route));
+    }
+
+    public function testBuildWithDocumentationPattern(): void
+    {
+        $method = new GetMethod();
+        $route = new Route('/assets/{identifier}/health', $method);
+
+        $documentation = new ApivalkRequestDocumentation();
+        $documentation->addPathProperty(
+            (new StringProperty('identifier', 'ID or EVSE ID'))->setPattern('[^/]+')
+        );
+
+        $regex = RouteRegexFactory::build($route, $documentation);
+
+        $this->assertEquals('#^\/assets\/([^/]+)\/health$#', $regex);
+        $this->assertRegExp($regex, '/assets/123/health');
+        $this->assertRegExp($regex, '/assets/DE%2ATST%2AETHG_0002%2A00101/health');
+        $this->assertRegExp($regex, '/assets/DE*TST*ETHG_0002*00101/health');
+        $this->assertNotRegExp($regex, '/assets/foo/bar/health');
+    }
+
+    public function testBuildWithoutDocumentationUsesDefault(): void
+    {
+        $method = new GetMethod();
+        $route = new Route('/users/{id}', $method);
+
+        // Without documentation → default regex
+        $regex = RouteRegexFactory::build($route);
+        $this->assertEquals('#^\/users\/([a-zA-Z0-9_-]+)$#', $regex);
+
+        // With documentation but without pattern → also default
+        $documentation = new ApivalkRequestDocumentation();
+        $documentation->addPathProperty(new StringProperty('id', 'User ID'));
+        $regex = RouteRegexFactory::build($route, $documentation);
+        $this->assertEquals('#^\/users\/([a-zA-Z0-9_-]+)$#', $regex);
     }
 }


### PR DESCRIPTION
RouteRegexFactory used a hardcoded capture group ([a-zA-Z0-9_-]+) for
all path parameters. This breaks routing for endpoints that accept
URL-encoded identifiers (e.g. DE%2ATST%2AETHG_0002%2A00101) because
% is not in the character class.

Instead of broadening the default for everyone, this change lets
individual endpoints opt in: if a path property defines a pattern via
setPattern(), RouteRegexFactory and ParameterBagFactory now use that
pattern as the capture group. Without a pattern, the existing default
applies — fully backward compatible.

Changes:
- RouteRegexFactory::build() accepts optional ApivalkRequestDocumentation
- RouteCacheFactory passes documentation through to RouteRegexFactory
- ParameterBagFactory::createPathBag() applies the same logic
- Tests for both with-pattern and without-pattern cases