### PR TITLE
feat: introduce ordering support for routes

### DIFF
--- a/Documentation/DocBlock/DocBlockGenerator.php
+++ b/Documentation/DocBlock/DocBlockGenerator.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Documentation\DocBlock;
 
-use apivalk\apivalk\Util\ClassLocator;
+use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Util\ClassLocator;
 
 class DocBlockGenerator
 {
@@ -21,23 +22,37 @@ class DocBlockGenerator
 
         foreach ($classLocator->find() as $class) {
             $className = $class['className'];
-            $filePath = $class['path'];
 
-            if (!is_subclass_of($className, ApivalkRequestInterface::class)) {
+            if (!is_subclass_of($className, AbstractApivalkController::class)) {
                 continue;
             }
 
             try {
-                /** @var AbstractApivalkRequest $request */
-                $request = new $className();
+                /** @var class-string<AbstractApivalkController> $className */
+                $requestClass = $className::getRequestClass();
+                $route = $className::getRoute();
 
-                $docBlockRequest = $generator->generate($request);
+                if (!is_subclass_of($requestClass, ApivalkRequestInterface::class)) {
+                    continue;
+                }
+
+                $reflection = new \ReflectionClass($requestClass);
+                $filePath = $reflection->getFileName();
+
+                if (!$filePath) {
+                    continue;
+                }
+
+                /** @var AbstractApivalkRequest $request */
+                $request = new $requestClass();
+
+                $docBlockRequest = $generator->generate($request, $route);
 
                 $this->rewriteRequestFileWithDocblocks($filePath, $docBlockRequest);
 
-                echo "✔ DocBlocks & Shapes generated for {$className}\n";
+                echo "✔ DocBlocks & Shapes generated for {$requestClass} (from {$className})\n";
             } catch (\Throwable $e) {
-                echo "⚠ Error in class {$className}: {$e->getMessage()}\n";
+                echo "⚠ Error in controller {$className}: {$e->getMessage()}\n";
             }
         }
     }
@@ -106,6 +121,14 @@ class DocBlockGenerator
             ) ===
             false) {
             throw new \RuntimeException('Failed to write body shape file');
+        }
+
+        if (file_put_contents(
+                $filenames['ordering'],
+                $docBlockRequest->getOrderingShape()->toString($shapeNamespace)
+            ) ===
+            false) {
+            throw new \RuntimeException('Failed to write ordering shape file');
         }
     }
 }

--- a/Documentation/DocBlock/DocBlockRequest.php
+++ b/Documentation/DocBlock/DocBlockRequest.php
@@ -12,15 +12,19 @@ class DocBlockRequest
     private $pathShape;
     /** @var DocBlockShape */
     private $queryShape;
+    /** @var DocBlockShape */
+    private $orderingShape;
 
     public function __construct(
         DocBlockShape $bodyShape,
         DocBlockShape $pathShape,
-        DocBlockShape $queryShape
+        DocBlockShape $queryShape,
+        DocBlockShape $orderingShape
     ) {
         $this->bodyShape = $bodyShape;
         $this->pathShape = $pathShape;
         $this->queryShape = $queryShape;
+        $this->orderingShape = $orderingShape;
     }
 
     public function getBodyShape(): DocBlockShape
@@ -38,6 +42,11 @@ class DocBlockRequest
         return $this->queryShape;
     }
 
+    public function getOrderingShape(): DocBlockShape
+    {
+        return $this->orderingShape;
+    }
+
     public function getRequestDocBlockOnly(string $shapeNamespace): string
     {
         $string = <<<'PHP'
@@ -45,15 +54,17 @@ class DocBlockRequest
  * @method \apivalk\apivalk\Http\Request\Parameter\ParameterBag|\{{QUERY_SHAPE_CLASS}} query()
  * @method \apivalk\apivalk\Http\Request\Parameter\ParameterBag|\{{PATH_SHAPE_CLASS}} path()
  * @method \apivalk\apivalk\Http\Request\Parameter\ParameterBag|\{{BODY_SHAPE_CLASS}} body()
+ * @method \apivalk\apivalk\Router\Route\Order\OrderBag|\{{ORDERING_SHAPE_CLASS}} ordering()
  */
 PHP;
 
         return str_replace(
-            ['{{QUERY_SHAPE_CLASS}}', '{{PATH_SHAPE_CLASS}}', '{{BODY_SHAPE_CLASS}}'],
+            ['{{QUERY_SHAPE_CLASS}}', '{{PATH_SHAPE_CLASS}}', '{{BODY_SHAPE_CLASS}}', '{{ORDERING_SHAPE_CLASS}}'],
             [
                 $shapeNamespace . '\\' . $this->queryShape->getClassName(),
                 $shapeNamespace . '\\' . $this->pathShape->getClassName(),
                 $shapeNamespace . '\\' . $this->bodyShape->getClassName(),
+                $shapeNamespace . '\\' . $this->orderingShape->getClassName(),
             ],
             $string
         );
@@ -70,6 +81,7 @@ PHP;
             'path' => \sprintf('%s/Shape/%s.php', $requestFolder, $this->pathShape->getClassName()),
             'query' => \sprintf('%s/Shape/%s.php', $requestFolder, $this->queryShape->getClassName()),
             'body' => \sprintf('%s/Shape/%s.php', $requestFolder, $this->bodyShape->getClassName()),
+            'ordering' => \sprintf('%s/Shape/%s.php', $requestFolder, $this->orderingShape->getClassName()),
         ];
     }
 }

--- a/Documentation/DocBlock/DocBlockRequestGenerator.php
+++ b/Documentation/DocBlock/DocBlockRequestGenerator.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Documentation\DocBlock;
 
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Router\Route\Order\Order;
+use apivalk\apivalk\Router\Route\Route;
 
 final class DocBlockRequestGenerator
 {
-    public function generate(AbstractApivalkRequest $abstractApivalkRequest): DocBlockRequest
+    public function generate(AbstractApivalkRequest $abstractApivalkRequest, Route $route): DocBlockRequest
     {
         $documentation = $abstractApivalkRequest::getDocumentation();
 
@@ -17,6 +19,7 @@ final class DocBlockRequestGenerator
         $bodyShape = new DocBlockShape($requestName, 'Body');
         $pathShape = new DocBlockShape($requestName, 'Path');
         $queryShape = new DocBlockShape($requestName, 'Query');
+        $orderingShape = new DocBlockShape($requestName, 'Ordering');
 
         foreach ($documentation->getBodyProperties() as $property) {
             $bodyShape->addProperty($property);
@@ -30,10 +33,15 @@ final class DocBlockRequestGenerator
             $queryShape->addProperty($property);
         }
 
+        foreach ($route->getOrderings() as $ordering) {
+            $orderingShape->addCustomField($ordering->getField(), '\\' . Order::class . '|null');
+        }
+
         return new DocBlockRequest(
             $bodyShape,
             $pathShape,
-            $queryShape
+            $queryShape,
+            $orderingShape
         );
     }
 }

--- a/Documentation/DocBlock/DocBlockShape.php
+++ b/Documentation/DocBlock/DocBlockShape.php
@@ -10,6 +10,8 @@ class DocBlockShape
 {
     /** @var AbstractProperty[] */
     private $properties = [];
+    /** @var array<string, string> - example: ["status" => array, "message" => string] */
+    private $customFields = [];
     /** @var string */
     private $type;
     /** @var string */
@@ -24,6 +26,11 @@ class DocBlockShape
     public function addProperty(AbstractProperty $property): void
     {
         $this->properties[] = $property;
+    }
+
+    public function addCustomField(string $fieldName, string $fieldType): void
+    {
+        $this->customFields[$fieldName] = $fieldType;
     }
 
     public function getClassName(): string
@@ -70,11 +77,20 @@ PHP;
             }
 
             $propertiesString[] = \sprintf(
-                '@property-read %s $%s',
+                '@property-read %s $%s %s',
                 $property->isRequired()
                     ? $type
                     : \sprintf('%s|null', $type),
-                $property->getPropertyName()
+                $property->getPropertyName(),
+                $property->getPropertyDescription()
+            );
+        }
+
+        foreach ($this->customFields as $fieldName => $fieldType) {
+            $propertiesString[] = \sprintf(
+                '@property-read %s $%s',
+                $fieldType,
+                $fieldName
             );
         }
 

--- a/Documentation/OpenAPI/Generator/OperationGenerator.php
+++ b/Documentation/OpenAPI/Generator/OperationGenerator.php
@@ -6,13 +6,15 @@ namespace apivalk\apivalk\Documentation\OpenAPI\Generator;
 
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Documentation\OpenAPI\Object\OperationObject;
+use apivalk\apivalk\Documentation\Property\ArrayProperty;
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\BadValidationApivalkResponse;
 use apivalk\apivalk\Http\Response\MethodNotAllowedApivalkResponse;
 use apivalk\apivalk\Http\Response\NotFoundApivalkResponse;
 use apivalk\apivalk\Http\Response\TooManyRequestsApivalkResponse;
 use apivalk\apivalk\Http\Response\UnauthorizedApivalkResponse;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 
 class OperationGenerator
 {
@@ -32,6 +34,11 @@ class OperationGenerator
 
         foreach ($requestDocumentation->getQueryProperties() as $pathProperty) {
             $parameters[] = $parameterGenerator->generate($pathProperty, 'query');
+        }
+
+        $orderProperty = $this->getOrderProperty($route);
+        if ($orderProperty !== null) {
+            $parameters[] = $parameterGenerator->generate($orderProperty, 'query');
         }
 
         $responses = [];
@@ -75,5 +82,45 @@ class OperationGenerator
             $responses,
             $route->getRouteAuthorization()
         );
+    }
+
+    private function getOrderProperty(Route $route): ?StringProperty
+    {
+        if (\count($route->getOrderings()) === 0) {
+            return null;
+        }
+
+        $fields = [];
+
+        foreach ($route->getOrderings() as $ordering) {
+            $fields[] = preg_quote($ordering->getField(), '/');
+        }
+
+        $group = implode('|', $fields);
+
+        $regex = \sprintf(
+            '^([+-](%s))(,([+-](%s)))*$',
+            $group,
+            $group
+        );
+
+        $orderProperty = new StringProperty(
+            'order_by',
+            'Comma-separated list of fields prefixed with + (asc) or - (desc)'
+        );
+
+        $exampleParts = [];
+        foreach ($fields as $index => $field) {
+            $prefix = $index === 0 ? '+' : '-';
+            $exampleParts[] = $prefix . $field;
+        }
+
+        $example = implode(',', $exampleParts);
+
+        $orderProperty->setPattern($regex);
+        $orderProperty->setIsRequired(false);
+        $orderProperty->setExample($example);
+
+        return $orderProperty;
     }
 }

--- a/Documentation/OpenAPI/Generator/ParameterGenerator.php
+++ b/Documentation/OpenAPI/Generator/ParameterGenerator.php
@@ -12,12 +12,6 @@ class ParameterGenerator
 {
     public function generate(AbstractProperty $property, string $in): ParameterObject
     {
-        return new ParameterObject(
-            $property->getPropertyName(),
-            $in,
-            $property->getPropertyDescription(),
-            $property->isRequired(),
-            new SingleSchemaObject($property->getPropertyName(), $property->getType(), $property->isRequired())
-        );
+        return new ParameterObject($in, $property);
     }
 }

--- a/Documentation/OpenAPI/Generator/PathItemGenerator.php
+++ b/Documentation/OpenAPI/Generator/PathItemGenerator.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Documentation\OpenAPI\Generator;
 
-use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Documentation\OpenAPI\Object\PathItemObject;
+use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Http\Method\DeleteMethod;
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Method\PatchMethod;
 use apivalk\apivalk\Http\Method\PostMethod;
 use apivalk\apivalk\Http\Method\PutMethod;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 
 class PathItemGenerator
 {

--- a/Documentation/OpenAPI/Generator/PathsGenerator.php
+++ b/Documentation/OpenAPI/Generator/PathsGenerator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Documentation\OpenAPI\Generator;
 
 use apivalk\apivalk\Documentation\OpenAPI\Object\PathsObject;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 
 class PathsGenerator
 {

--- a/Documentation/OpenAPI/Generator/RequestBodyGenerator.php
+++ b/Documentation/OpenAPI/Generator/RequestBodyGenerator.php
@@ -7,7 +7,7 @@ namespace apivalk\apivalk\Documentation\OpenAPI\Generator;
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Documentation\OpenAPI\Object\RequestBodyObject;
 use apivalk\apivalk\Documentation\OpenAPI\Object\SchemaObject;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 
 class RequestBodyGenerator
 {

--- a/Documentation/OpenAPI/Object/ParameterObject.php
+++ b/Documentation/OpenAPI/Object/ParameterObject.php
@@ -4,38 +4,37 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Documentation\OpenAPI\Object;
 
+use apivalk\apivalk\Documentation\Property\AbstractProperty;
+
 /**
  * Class ParameterObject
  *
- * @see     https://swagger.io/specification/#parameter-object
- *
- * @package apivalk\apivalk\Documentation\OpenAPI\Object
+ * @see https://swagger.io/specification/#parameter-object
  */
 class ParameterObject implements ObjectInterface
 {
     /** @var string */
     private $name;
+
     /** @var string */
     private $in;
+
     /** @var string|null */
     private $description;
+
     /** @var bool */
     private $required;
-    /** @var SingleSchemaObject|null */
-    private $singleSchemaObject;
 
-    public function __construct(
-        string $name,
-        string $in,
-        ?string $description = null,
-        bool $required = true,
-        ?SingleSchemaObject $singleSchemaObject = null
-    ) {
-        $this->name = $name;
+    /** @var AbstractProperty */
+    private $property;
+
+    public function __construct(string $in, AbstractProperty $property)
+    {
+        $this->name = $property->getPropertyName();
         $this->in = $in;
-        $this->description = $description;
-        $this->required = $required;
-        $this->singleSchemaObject = $singleSchemaObject;
+        $this->description = $property->getPropertyDescription();
+        $this->required = $property->isRequired();
+        $this->property = $property;
     }
 
     public function getName(): string
@@ -58,15 +57,24 @@ class ParameterObject implements ObjectInterface
         return $this->required;
     }
 
+    public function getProperty(): ?AbstractProperty
+    {
+        return $this->property;
+    }
+
     public function toArray(): array
     {
-        return [
-            'name' => $this->name,
-            'in' => $this->in,
-            'description' => $this->description,
-            'required' => $this->required,
-            'schema' => $this->singleSchemaObject instanceof SingleSchemaObject ? $this->singleSchemaObject->toArray()
-                : null,
-        ];
+        return array_filter(
+            [
+                'name' => $this->name,
+                'in' => $this->in,
+                'description' => $this->description,
+                'required' => $this->required,
+                'schema' => $this->property->getDocumentationArray(),
+            ],
+            static function ($value) {
+                return $value !== null;
+            }
+        );
     }
 }

--- a/Http/Controller/AbstractApivalkController.php
+++ b/Http/Controller/AbstractApivalkController.php
@@ -6,7 +6,7 @@ namespace apivalk\apivalk\Http\Controller;
 
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 
 abstract class AbstractApivalkController
 {

--- a/Http/Request/AbstractApivalkRequest.php
+++ b/Http/Request/AbstractApivalkRequest.php
@@ -12,7 +12,9 @@ use apivalk\apivalk\Http\Request\File\FileBagFactory;
 use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
 use apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory;
 use apivalk\apivalk\Router\RateLimit\RateLimitResult;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Order\Order;
+use apivalk\apivalk\Router\Route\Order\OrderBag;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity;
 use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
 use apivalk\apivalk\Util\IpResolver;
@@ -39,12 +41,16 @@ abstract class AbstractApivalkRequest implements ApivalkRequestInterface
     private $rateLimitResult;
     /** @var Locale */
     private $locale;
+    /** @var OrderBag */
+    private $orderBag;
 
     abstract public static function getDocumentation(): ApivalkRequestDocumentation;
 
     public function populate(Route $route): void
     {
         $documentation = static::getDocumentation();
+
+        // ToDo: Write Populator Logic/Strategy for this, it gets messy by now
 
         $this->method = $route->getMethod();
         $this->headerBag = ParameterBagFactory::createHeaderBag();
@@ -54,6 +60,38 @@ abstract class AbstractApivalkRequest implements ApivalkRequestInterface
         $this->fileBag = FileBagFactory::create();
         $this->authIdentity = new GuestAuthIdentity([]);
         $this->ip = IpResolver::getClientIp();
+        $this->orderBag = new OrderBag();
+
+        $this->populateOrderBag();
+    }
+
+    private function populateOrderBag(): void
+    {
+        $orderBy = $this->queryParameterBag->get('order_by');
+
+        if ($orderBy !== null) {
+            foreach (explode(',', $orderBy->getRawValue()) as $curOrderByField) {
+                $curOrderByField = trim($curOrderByField);
+
+                if ($curOrderByField === '') {
+                    continue;
+                }
+
+                if ($curOrderByField[0] !== '+' && $curOrderByField[0] !== '-') {
+                    $direction = '+';
+                    $field = $curOrderByField;
+                } else {
+                    $direction = $curOrderByField[0];
+                    $field = substr($curOrderByField, 1);
+                }
+
+                if ($field === '') {
+                    continue;
+                }
+
+                $this->orderBag->set($direction === '-' ? Order::desc($field) : Order::asc($field));
+            }
+        }
     }
 
     public function getMethod(): MethodInterface
@@ -89,6 +127,11 @@ abstract class AbstractApivalkRequest implements ApivalkRequestInterface
     public function file(): FileBag
     {
         return $this->fileBag;
+    }
+
+    public function ordering(): OrderBag
+    {
+        return $this->orderBag;
     }
 
     public function getAuthIdentity(): AbstractAuthIdentity

--- a/Http/Request/ApivalkRequestInterface.php
+++ b/Http/Request/ApivalkRequestInterface.php
@@ -10,7 +10,8 @@ use apivalk\apivalk\Http\Method\MethodInterface;
 use apivalk\apivalk\Http\Request\File\FileBag;
 use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
 use apivalk\apivalk\Router\RateLimit\RateLimitResult;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Order\OrderBag;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity;
 
 interface ApivalkRequestInterface
@@ -30,6 +31,8 @@ interface ApivalkRequestInterface
     public function body(): ParameterBag;
 
     public function path(): ParameterBag;
+
+    public function ordering(): OrderBag;
 
     public function file(): FileBag;
 

--- a/Http/Request/Parameter/ParameterBagFactory.php
+++ b/Http/Request/Parameter/ParameterBagFactory.php
@@ -7,7 +7,7 @@ namespace apivalk\apivalk\Http\Request\Parameter;
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Documentation\Property\AbstractProperty;
 use apivalk\apivalk\Documentation\Property\ArrayProperty;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 
 final class ParameterBagFactory
 {
@@ -45,6 +45,16 @@ final class ParameterBagFactory
                     $key,
                     self::typeCastValueByProperty($value, $properties[$key]),
                     $value
+                )
+            );
+        }
+
+        if ($_GET['order_by'] !== null) {
+            $queryBag->set(
+                new Parameter(
+                    'order_by',
+                    $_GET['order_by'],
+                    $_GET['order_by']
                 )
             );
         }

--- a/Router/AbstractRouter.php
+++ b/Router/AbstractRouter.php
@@ -6,10 +6,12 @@ namespace apivalk\apivalk\Router;
 
 use apivalk\apivalk\Apivalk;
 use apivalk\apivalk\Cache\CacheInterface;
-use apivalk\apivalk\Http\Controller\ApivalkControllerFactoryInterface;
 use apivalk\apivalk\Http\Controller\ApivalkControllerFactory;
+use apivalk\apivalk\Http\Controller\ApivalkControllerFactoryInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Middleware\MiddlewareStack;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\RouteCacheFactory;
 use apivalk\apivalk\Util\ClassLocator;
 
 abstract class AbstractRouter

--- a/Router/RateLimit/RateLimitContext.php
+++ b/Router/RateLimit/RateLimitContext.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Router\RateLimit;
 
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity;
 
 class RateLimitContext

--- a/Router/Route/Order/Order.php
+++ b/Router/Route/Order/Order.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Router\Route\Order;
+
+class Order
+{
+    /** @var bool */
+    private $asc = true;
+    /** @var string */
+    private $field;
+
+    public function __construct(string $field)
+    {
+        $this->field = $field;
+    }
+
+    public static function asc(string $field): self
+    {
+        $order = new self($field);
+
+        $order->asc = true;
+
+        return $order;
+    }
+
+    public static function desc(string $field): self
+    {
+        $order = new self($field);
+
+        $order->asc = false;
+
+        return $order;
+    }
+
+    public function isAsc(): bool
+    {
+        return $this->asc;
+    }
+
+    public function isDesc(): bool
+    {
+        return !$this->asc;
+    }
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
+}

--- a/Router/Route/Order/OrderBag.php
+++ b/Router/Route/Order/OrderBag.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Router\Route\Order;
+
+/**
+ * @implements \IteratorAggregate<string, Order>
+ */
+class OrderBag implements \IteratorAggregate, \Countable
+{
+    /** @var Order[] */
+    private $orders = [];
+
+    public function set(Order $order): void
+    {
+        $this->orders[$order->getField()] = $order;
+    }
+
+    public function has(string $field): bool
+    {
+        return isset($this->orders[$field]);
+    }
+
+    public function get(string $field): ?Order
+    {
+        return $this->orders[$field] ?? null;
+    }
+
+    /**
+     * @return \Iterator<int|string, Order>
+     */
+    public function getIterator(): \Iterator
+    {
+        return new \ArrayIterator($this->orders);
+    }
+
+    public function count(): int
+    {
+        return \count($this->orders);
+    }
+
+    /**
+     * Magic getter to direct access values of an order bag.
+     *
+     * $orderBag->status is the same as $oderBag->get('status')
+     *
+     * In requests, you can access it like this:
+     * $request->ordering()->status -> Order|null
+     *
+     * @return Order|null
+     */
+    public function __get(string $key): ?Order
+    {
+        $order = $this->get($key);
+        if ($order === null) {
+            return null;
+        }
+
+        return $order;
+    }
+}

--- a/Router/Route/Route.php
+++ b/Router/Route/Route.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace apivalk\apivalk\Router;
+namespace apivalk\apivalk\Router\Route;
 
 use apivalk\apivalk\Documentation\OpenAPI\Object\TagObject;
 use apivalk\apivalk\Http\Method\DeleteMethod;
@@ -12,6 +12,7 @@ use apivalk\apivalk\Http\Method\PatchMethod;
 use apivalk\apivalk\Http\Method\PostMethod;
 use apivalk\apivalk\Http\Method\PutMethod;
 use apivalk\apivalk\Router\RateLimit\RateLimitInterface;
+use apivalk\apivalk\Router\Route\Order\Order;
 use apivalk\apivalk\Security\RouteAuthorization;
 
 class Route
@@ -30,6 +31,8 @@ class Route
     private $tags;
     /** @var null|RateLimitInterface */
     private $rateLimit;
+    /** @var Order[] */
+    private $orderings;
 
     /**
      * @param string                  $url
@@ -39,6 +42,7 @@ class Route
      * @param TagObject[]             $tags
      * @param RouteAuthorization|null $routeAuthorization
      * @param RateLimitInterface|null $rateLimit
+     * @param Order[]|null            $orderings
      */
     public function __construct(
         string $url,
@@ -47,7 +51,8 @@ class Route
         ?string $summary = null,
         ?array $tags = null,
         ?RouteAuthorization $routeAuthorization = null,
-        ?RateLimitInterface $rateLimit = null
+        ?RateLimitInterface $rateLimit = null,
+        ?array $orderings = null
     ) {
         $this->url = $url;
         $this->method = $method;
@@ -56,6 +61,7 @@ class Route
         $this->tags = $tags ?? [];
         $this->routeAuthorization = $routeAuthorization;
         $this->rateLimit = $rateLimit;
+        $this->orderings = $orderings ?? [];
     }
 
     public static function get(string $url): self
@@ -109,6 +115,16 @@ class Route
         return $this;
     }
 
+    /**
+     * @param Order[] $orderings
+     */
+    public function ordering(array $orderings): self
+    {
+        $this->orderings = $orderings;
+
+        return $this;
+    }
+
     public function description(string $description): self
     {
         $this->description = $description;
@@ -157,5 +173,13 @@ class Route
     public function getRateLimit(): ?RateLimitInterface
     {
         return $this->rateLimit;
+    }
+
+    /**
+     * @return Order[]
+     */
+    public function getOrderings(): array
+    {
+        return $this->orderings;
     }
 }

--- a/Router/Route/RouteCacheFactory.php
+++ b/Router/Route/RouteCacheFactory.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
-namespace apivalk\apivalk\Router;
+namespace apivalk\apivalk\Router\Route;
 
 use apivalk\apivalk\Cache\CacheItem;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
+use apivalk\apivalk\Router\AbstractRouter;
 
 class RouteCacheFactory
 {

--- a/Router/Route/RouteJsonSerializer.php
+++ b/Router/Route/RouteJsonSerializer.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace apivalk\apivalk\Router;
+namespace apivalk\apivalk\Router\Route;
 
 use apivalk\apivalk\Documentation\OpenAPI\Object\TagObject;
 use apivalk\apivalk\Http\Method\MethodFactory;
 use apivalk\apivalk\Router\RateLimit\RateLimitInterface;
+use apivalk\apivalk\Router\Route\Order\Order;
 use apivalk\apivalk\Security\RouteAuthorization;
 
 class RouteJsonSerializer
@@ -60,6 +61,13 @@ class RouteJsonSerializer
             ];
         }
 
+        $orderings = $route->getOrderings();
+        if (\count($orderings) > 0) {
+            foreach ($orderings as $curOrdering) {
+                $orderingsData[] = ['field' => $curOrdering->getField(), 'asc' => $curOrdering->isAsc()];
+            }
+        }
+
         return [
             'url' => $route->getUrl(),
             'method' => $route->getMethod()->getName(),
@@ -68,6 +76,7 @@ class RouteJsonSerializer
             'tags' => $tags,
             'routeAuthorization' => $routeAuthorizationData ?? null,
             'rateLimit' => $rateLimitData ?? null,
+            'orderings' => $orderingsData ?? null,
         ];
     }
 
@@ -110,6 +119,18 @@ class RouteJsonSerializer
             );
         }
 
+        $orderings = [];
+        $orderingsData = $jsonArray['orderings'] ?? null;
+        if ($orderingsData !== null) {
+            foreach ($orderingsData as $ordering) {
+                if ($ordering['asc']) {
+                    $orderings[] = Order::asc($ordering['field']);
+                } else {
+                    $orderings[] = Order::desc($ordering['field']);
+                }
+            }
+        }
+
         return new Route(
             $jsonArray['url'],
             MethodFactory::create($jsonArray['method']),
@@ -117,7 +138,8 @@ class RouteJsonSerializer
             $jsonArray['summary'] ?? null,
             $tags,
             $routeAuthorization,
-            $rateLimit
+            $rateLimit,
+            $orderings
         );
     }
 }

--- a/Router/Route/RouteRegexFactory.php
+++ b/Router/Route/RouteRegexFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace apivalk\apivalk\Router;
+namespace apivalk\apivalk\Router\Route;
 
 class RouteRegexFactory
 {

--- a/Router/Router.php
+++ b/Router/Router.php
@@ -13,6 +13,8 @@ use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\MethodNotAllowedApivalkResponse;
 use apivalk\apivalk\Http\Response\NotFoundApivalkResponse;
 use apivalk\apivalk\Middleware\MiddlewareStack;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\RouteJsonSerializer;
 
 class Router extends AbstractRouter
 {

--- a/Tests/PhpUnit/AbstractApiControllerTest.php
+++ b/Tests/PhpUnit/AbstractApiControllerTest.php
@@ -7,7 +7,7 @@ namespace apivalk\apivalk\Tests\PhpUnit;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity;
 use PHPUnit\Framework\TestCase;
 

--- a/Tests/PhpUnit/Documentation/DocBlock/DocBlockGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/DocBlock/DocBlockGeneratorTest.php
@@ -40,9 +40,9 @@ class DocBlockGeneratorTest extends TestCase
 
     public function testRun(): void
     {
-        $uniqueClassName = 'TestRequest_' . str_replace('.', '_', uniqid('', true));
-        $requestFile = $this->tempDir . '/Request/' . $uniqueClassName . '.php';
-        $content = <<<PHP
+        $uniqueRequestClassName = 'TestRequest_' . str_replace('.', '_', uniqid('', true));
+        $requestFile = $this->tempDir . '/Request/' . $uniqueRequestClassName . '.php';
+        $requestContent = <<<PHP
 <?php
 
 namespace TestNamespace\Request;
@@ -50,7 +50,7 @@ namespace TestNamespace\Request;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 
-class {$uniqueClassName} extends AbstractApivalkRequest
+class {$uniqueRequestClassName} extends AbstractApivalkRequest
 {
     public static function getDocumentation(): ApivalkRequestDocumentation
     {
@@ -58,30 +58,54 @@ class {$uniqueClassName} extends AbstractApivalkRequest
     }
 }
 PHP;
-        file_put_contents($requestFile, $content);
+        file_put_contents($requestFile, $requestContent);
         require_once $requestFile;
+
+        $uniqueControllerClassName = 'TestController_' . str_replace('.', '_', uniqid('', true));
+        $controllerFile = $this->tempDir . '/' . $uniqueControllerClassName . '.php';
+        $controllerContent = <<<PHP
+<?php
+
+namespace TestNamespace;
+
+use apivalk\apivalk\Http\Controller\AbstractApivalkController;
+use apivalk\apivalk\Http\Method\GetMethod;use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Router\Route\Route;
+use TestNamespace\Request\\{$uniqueRequestClassName};
+
+class {$uniqueControllerClassName} extends AbstractApivalkController
+{
+    public static function getRoute(): Route { return new Route('', new GetMethod(), ''); }
+    public static function getRequestClass(): string { return {$uniqueRequestClassName}::class; }
+    public static function getResponseClasses(): array { return []; }
+    public function __invoke(ApivalkRequestInterface \$request): AbstractApivalkResponse { throw new \Exception(); }
+}
+PHP;
+        file_put_contents($controllerFile, $controllerContent);
+        require_once $controllerFile;
 
         $generator = new DocBlockGenerator();
         
         // We need to use output buffering because the generator echoes stuff
         ob_start();
-        $generator->run($this->tempDir . '/Request', 'TestNamespace\\Request');
+        $generator->run($this->tempDir, 'TestNamespace');
         $output = ob_get_clean();
 
         $this->assertStringContainsString('✔ DocBlocks & Shapes generated', $output);
+        $this->assertStringContainsString($uniqueRequestClassName, $output);
+        $this->assertStringContainsString($uniqueControllerClassName, $output);
         
         // Verify request file was updated
         $updatedContent = file_get_contents($requestFile);
         $this->assertStringContainsString('/**', $updatedContent);
         $this->assertStringContainsString('@method', $updatedContent);
-        $this->assertStringContainsString('query()', $updatedContent);
-        $this->assertStringContainsString('path()', $updatedContent);
-        $this->assertStringContainsString('body()', $updatedContent);
 
         // Verify shape files were created
-        $this->assertFileExists($this->tempDir . '/Request/Shape/' . $uniqueClassName . 'PathShape.php');
-        $this->assertFileExists($this->tempDir . '/Request/Shape/' . $uniqueClassName . 'QueryShape.php');
-        $this->assertFileExists($this->tempDir . '/Request/Shape/' . $uniqueClassName . 'BodyShape.php');
+        $this->assertFileExists($this->tempDir . '/Request/Shape/' . $uniqueRequestClassName . 'PathShape.php');
+        $this->assertFileExists($this->tempDir . '/Request/Shape/' . $uniqueRequestClassName . 'QueryShape.php');
+        $this->assertFileExists($this->tempDir . '/Request/Shape/' . $uniqueRequestClassName . 'BodyShape.php');
+        $this->assertFileExists($this->tempDir . '/Request/Shape/' . $uniqueRequestClassName . 'OrderingShape.php');
     }
 
     public function testRunInvalidDirectory(): void

--- a/Tests/PhpUnit/Documentation/DocBlock/DocBlockRequestGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/DocBlock/DocBlockRequestGeneratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Documentation\DocBlock;
 
+use apivalk\apivalk\Router\Route\Route;
 use PHPUnit\Framework\TestCase;
 use apivalk\apivalk\Documentation\DocBlock\DocBlockRequestGenerator;
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
@@ -27,12 +28,14 @@ class DocBlockRequestGeneratorTest extends TestCase
     {
         $generator = new DocBlockRequestGenerator();
         $request = new TestRequest();
+        $route = Route::get('test');
 
-        $docBlockRequest = $generator->generate($request);
+        $docBlockRequest = $generator->generate($request, $route);
 
         $this->assertEquals('TestRequestBodyShape', $docBlockRequest->getBodyShape()->getClassName());
         $this->assertEquals('TestRequestPathShape', $docBlockRequest->getPathShape()->getClassName());
         $this->assertEquals('TestRequestQueryShape', $docBlockRequest->getQueryShape()->getClassName());
+        $this->assertEquals('TestRequestOrderingShape', $docBlockRequest->getOrderingShape()->getClassName());
 
         $bodyString = $docBlockRequest->getBodyShape()->toString('App\\Shape');
         $this->assertStringContainsString('@property-read string $name', $bodyString);
@@ -42,5 +45,7 @@ class DocBlockRequestGeneratorTest extends TestCase
 
         $pathString = $docBlockRequest->getPathShape()->toString('App\\Shape');
         $this->assertStringContainsString('@property-read string $slug', $pathString);
+
+        $orderingString = $docBlockRequest->getOrderingShape()->toString('App\\Shape');
     }
 }

--- a/Tests/PhpUnit/Documentation/DocBlock/DocBlockRequestTest.php
+++ b/Tests/PhpUnit/Documentation/DocBlock/DocBlockRequestTest.php
@@ -15,12 +15,14 @@ class DocBlockRequestTest extends TestCase
         $bodyShape = new DocBlockShape('User', 'Body');
         $pathShape = new DocBlockShape('User', 'Path');
         $queryShape = new DocBlockShape('User', 'Query');
+        $orderingShape = new DocBlockShape('User', 'Ordering');
 
-        $request = new DocBlockRequest($bodyShape, $pathShape, $queryShape);
+        $request = new DocBlockRequest($bodyShape, $pathShape, $queryShape, $orderingShape);
 
         $this->assertSame($bodyShape, $request->getBodyShape());
         $this->assertSame($pathShape, $request->getPathShape());
         $this->assertSame($queryShape, $request->getQueryShape());
+        $this->assertSame($orderingShape, $request->getOrderingShape());
     }
 
     public function testGetRequestDocBlockOnly(): void
@@ -28,14 +30,24 @@ class DocBlockRequestTest extends TestCase
         $bodyShape = new DocBlockShape('User', 'Body');
         $pathShape = new DocBlockShape('User', 'Path');
         $queryShape = new DocBlockShape('User', 'Query');
+        $orderingShape = new DocBlockShape('User', 'Ordering');
 
-        $request = new DocBlockRequest($bodyShape, $pathShape, $queryShape);
+        $request = new DocBlockRequest($bodyShape, $pathShape, $queryShape, $orderingShape);
 
         $docBlock = $request->getRequestDocBlockOnly('App\\Api\\Shape');
 
-        $this->assertStringContainsString('@method \apivalk\apivalk\Http\Request\Parameter\ParameterBag|\\App\\Api\\Shape\\UserQueryShape query()', $docBlock);
-        $this->assertStringContainsString('@method \apivalk\apivalk\Http\Request\Parameter\ParameterBag|\\App\\Api\\Shape\\UserPathShape path()', $docBlock);
-        $this->assertStringContainsString('@method \apivalk\apivalk\Http\Request\Parameter\ParameterBag|\\App\\Api\\Shape\\UserBodyShape body()', $docBlock);
+        $this->assertStringContainsString(
+            '@method \apivalk\apivalk\Http\Request\Parameter\ParameterBag|\\App\\Api\\Shape\\UserQueryShape query()',
+            $docBlock
+        );
+        $this->assertStringContainsString(
+            '@method \apivalk\apivalk\Http\Request\Parameter\ParameterBag|\\App\\Api\\Shape\\UserPathShape path()',
+            $docBlock
+        );
+        $this->assertStringContainsString(
+            '@method \apivalk\apivalk\Http\Request\Parameter\ParameterBag|\\App\\Api\\Shape\\UserBodyShape body()',
+            $docBlock
+        );
     }
 
     public function testGetShapeNamespace(): void
@@ -43,8 +55,9 @@ class DocBlockRequestTest extends TestCase
         $bodyShape = new DocBlockShape('User', 'Body');
         $pathShape = new DocBlockShape('User', 'Path');
         $queryShape = new DocBlockShape('User', 'Query');
+        $orderingShape = new DocBlockShape('User', 'Ordering');
 
-        $request = new DocBlockRequest($bodyShape, $pathShape, $queryShape);
+        $request = new DocBlockRequest($bodyShape, $pathShape, $queryShape, $orderingShape);
 
         $this->assertEquals('App\\Api\\Shape', $request->getShapeNamespace('App\\Api'));
     }
@@ -54,13 +67,15 @@ class DocBlockRequestTest extends TestCase
         $bodyShape = new DocBlockShape('User', 'Body');
         $pathShape = new DocBlockShape('User', 'Path');
         $queryShape = new DocBlockShape('User', 'Query');
+        $orderingShape = new DocBlockShape('User', 'Ordering');
 
-        $request = new DocBlockRequest($bodyShape, $pathShape, $queryShape);
+        $request = new DocBlockRequest($bodyShape, $pathShape, $queryShape, $orderingShape);
 
         $filenames = $request->getShapeFilenames('src/Api');
 
         $this->assertEquals('src/Api/Shape/UserPathShape.php', $filenames['path']);
         $this->assertEquals('src/Api/Shape/UserQueryShape.php', $filenames['query']);
         $this->assertEquals('src/Api/Shape/UserBodyShape.php', $filenames['body']);
+        $this->assertEquals('src/Api/Shape/UserOrderingShape.php', $filenames['ordering']);
     }
 }

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/OperationGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/OperationGeneratorTest.php
@@ -4,22 +4,33 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Documentation\OpenAPI\Generator;
 
-use PHPUnit\Framework\TestCase;
-use apivalk\apivalk\Documentation\OpenAPI\Generator\OperationGenerator;
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Documentation\OpenAPI\Generator\OperationGenerator;
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Router\Route\Order\Order;
+use apivalk\apivalk\Router\Route\Route;
+use PHPUnit\Framework\TestCase;
 
-class TestResponse extends AbstractApivalkResponse {
-    public static function getDocumentation(): ApivalkResponseDocumentation {
+class TestResponse extends AbstractApivalkResponse
+{
+    public static function getDocumentation(): ApivalkResponseDocumentation
+    {
         $doc = new ApivalkResponseDocumentation();
         $doc->setDescription('Success');
         return $doc;
     }
-    public static function getStatusCode(): int { return 200; }
-    public function toArray(): array { return []; }
+
+    public static function getStatusCode(): int
+    {
+        return 200;
+    }
+
+    public function toArray(): array
+    {
+        return [];
+    }
 }
 
 class OperationGeneratorTest extends TestCase
@@ -27,26 +38,87 @@ class OperationGeneratorTest extends TestCase
     public function testOperationGenerator(): void
     {
         $generator = new OperationGenerator();
-        
+
         $method = $this->createMock(GetMethod::class);
         $method->method('getName')->willReturn('GET');
-        
+
         $route = $this->createMock(Route::class);
         $route->method('getMethod')->willReturn($method);
         $route->method('getDescription')->willReturn('Route desc');
         $route->method('getUrl')->willReturn('/test');
         $route->method('getTags')->willReturn([]);
         $route->method('getRouteAuthorization')->willReturn(null);
-        
+        $route->method('getOrderings')->willReturn(
+            [
+                Order::asc('id'),
+                Order::desc('price')
+            ]
+        );
+
         $requestDoc = $this->createMock(ApivalkRequestDocumentation::class);
         $requestDoc->method('getPathProperties')->willReturn([]);
         $requestDoc->method('getQueryProperties')->willReturn([]);
         $requestDoc->method('getBodyProperties')->willReturn([]);
-        
+
         $operation = $generator->generate($route, $requestDoc, [TestResponse::class]);
-        
+
         $this->assertEquals('Route desc', $operation->getDescription());
         $this->assertNull($operation->getSummary());
         $this->assertCount(6, $operation->getResponses()); // 1 custom + 5 default
+
+        $parameters = $operation->getParameters();
+        $this->assertNotEmpty($parameters);
+
+        $orderByParameter = null;
+
+        foreach ($parameters as $parameter) {
+            if ($parameter->getName() === 'order_by') {
+                $orderByParameter = $parameter;
+                break;
+            }
+        }
+
+        $this->assertNotNull($orderByParameter, 'Expected order_by parameter to be generated.');
+        $this->assertEquals('query', $orderByParameter->getIn());
+
+        $this->assertEquals(
+            'Comma-separated list of fields prefixed with + (asc) or - (desc)',
+            $orderByParameter->getDescription()
+        );
+        $this->assertFalse($orderByParameter->isRequired());
+        $this->assertEquals('+id,-price', $orderByParameter->toArray()['schema']['example']);
+        $this->assertEquals(
+            '^([+-](id|price))(,([+-](id|price)))*$',
+            $orderByParameter->toArray()['schema']['pattern']
+        );
+    }
+
+    public function testOperationGeneratorWithoutOrder(): void
+    {
+        $generator = new OperationGenerator();
+
+        $method = $this->createMock(GetMethod::class);
+        $method->method('getName')->willReturn('GET');
+
+        $route = $this->createMock(Route::class);
+        $route->method('getMethod')->willReturn($method);
+        $route->method('getDescription')->willReturn('Route desc');
+        $route->method('getUrl')->willReturn('/test');
+        $route->method('getTags')->willReturn([]);
+        $route->method('getRouteAuthorization')->willReturn(null);
+        $route->method('getOrderings')->willReturn([]);
+
+        $requestDoc = $this->createMock(ApivalkRequestDocumentation::class);
+        $requestDoc->method('getPathProperties')->willReturn([]);
+        $requestDoc->method('getQueryProperties')->willReturn([]);
+        $requestDoc->method('getBodyProperties')->willReturn([]);
+
+        $operation = $generator->generate($route, $requestDoc, [TestResponse::class]);
+
+        $this->assertEquals('Route desc', $operation->getDescription());
+        $this->assertNull($operation->getSummary());
+        $this->assertCount(6, $operation->getResponses()); // 1 custom + 5 default
+
+        $this->assertEmpty($operation->getParameters());
     }
 }

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/PathItemGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/PathItemGeneratorTest.php
@@ -11,7 +11,8 @@ use apivalk\apivalk\Http\i18n\Locale;
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Router\RateLimit\RateLimitResult;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Order\OrderBag;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
 use PHPUnit\Framework\TestCase;
 
@@ -127,6 +128,11 @@ class PathItemTestRequest implements ApivalkRequestInterface
 
     public function setLocale(Locale $locale): void
     {
+    }
+
+    public function ordering(): OrderBag
+    {
+        return new OrderBag();
     }
 }
 

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/PathsGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/PathsGeneratorTest.php
@@ -11,7 +11,8 @@ use apivalk\apivalk\Http\i18n\Locale;
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Router\RateLimit\RateLimitResult;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Order\OrderBag;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
 use PHPUnit\Framework\TestCase;
 
@@ -127,6 +128,11 @@ class PathsTestRequest implements ApivalkRequestInterface
 
     public function setLocale(Locale $locale): void
     {
+    }
+
+    public function ordering(): OrderBag
+    {
+        return new OrderBag();
     }
 }
 

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/RequestBodyGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/RequestBodyGeneratorTest.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Documentation\OpenAPI\Generator;
 
-use PHPUnit\Framework\TestCase;
-use apivalk\apivalk\Documentation\OpenAPI\Generator\RequestBodyGenerator;
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
-use apivalk\apivalk\Router\Route;
-use apivalk\apivalk\Http\Method\GetMethod;
+use apivalk\apivalk\Documentation\OpenAPI\Generator\RequestBodyGenerator;
+use apivalk\apivalk\Router\Route\Route;
+use PHPUnit\Framework\TestCase;
 
 class RequestBodyGeneratorTest extends TestCase
 {

--- a/Tests/PhpUnit/Documentation/OpenAPI/Object/ParameterObjectTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Object/ParameterObjectTest.php
@@ -4,17 +4,61 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Documentation\OpenAPI\Object;
 
-use PHPUnit\Framework\TestCase;
 use apivalk\apivalk\Documentation\OpenAPI\Object\ParameterObject;
-use apivalk\apivalk\Documentation\OpenAPI\Object\SingleSchemaObject;
+use apivalk\apivalk\Documentation\Property\AbstractProperty;
+use PHPUnit\Framework\TestCase;
+
+class TestProperty extends AbstractProperty
+{
+    /** @var array<string, mixed> */
+    private $documentationArray;
+
+    /**
+     * @param array<string, mixed> $documentationArray
+     */
+    public function __construct(
+        string $propertyName,
+        ?string $propertyDescription,
+        bool $required,
+        array $documentationArray
+    ) {
+        parent::__construct($propertyName, $propertyDescription);
+        $this->isRequired = $required;
+        $this->documentationArray = $documentationArray;
+    }
+
+    public function getDocumentationArray(): array
+    {
+        return $this->documentationArray;
+    }
+
+    public function getType(): string
+    {
+        return 'string';
+    }
+
+    public function getPhpType(): string
+    {
+        return 'string';
+    }
+}
 
 class ParameterObjectTest extends TestCase
 {
     public function testToArray(): void
     {
-        $schema = new SingleSchemaObject('id', 'integer');
-        $parameter = new ParameterObject('id', 'path', 'User ID', true, $schema);
-        
+        $property = new TestProperty(
+            'id',
+            'User ID',
+            true,
+            [
+                'type' => 'integer',
+                'required' => ['id'],
+            ]
+        );
+
+        $parameter = new ParameterObject('path', $property);
+
         $expected = [
             'name' => 'id',
             'in' => 'path',
@@ -22,8 +66,8 @@ class ParameterObjectTest extends TestCase
             'required' => true,
             'schema' => [
                 'type' => 'integer',
-                'required' => ['id']
-            ]
+                'required' => ['id'],
+            ],
         ];
 
         $this->assertEquals($expected, $parameter->toArray());
@@ -31,14 +75,25 @@ class ParameterObjectTest extends TestCase
 
     public function testToArrayMinimal(): void
     {
-        $parameter = new ParameterObject('id', 'query');
-        
+        $property = new TestProperty(
+            'id',
+            '',
+            true,
+            [
+                'type' => 'string',
+            ]
+        );
+
+        $parameter = new ParameterObject('query', $property);
+
         $expected = [
             'name' => 'id',
             'in' => 'query',
-            'description' => null,
+            'description' => '',
             'required' => true,
-            'schema' => null
+            'schema' => [
+                'type' => 'string',
+            ],
         ];
 
         $this->assertEquals($expected, $parameter->toArray());

--- a/Tests/PhpUnit/Documentation/OpenAPI/OpenAPIGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/OpenAPIGeneratorTest.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Documentation\OpenAPI;
 
-use PHPUnit\Framework\TestCase;
-use apivalk\apivalk\Documentation\OpenAPI\OpenAPIGenerator;
 use apivalk\apivalk\Apivalk;
-use apivalk\apivalk\Router\AbstractRouter;
-use apivalk\apivalk\Router\Route;
-use apivalk\apivalk\Http\Method\GetMethod;
+use apivalk\apivalk\Documentation\OpenAPI\Object\ComponentsObject;
 use apivalk\apivalk\Documentation\OpenAPI\Object\InfoObject;
 use apivalk\apivalk\Documentation\OpenAPI\Object\ServerObject;
-use apivalk\apivalk\Documentation\OpenAPI\Object\ComponentsObject;
+use apivalk\apivalk\Documentation\OpenAPI\OpenAPIGenerator;
+use apivalk\apivalk\Http\Method\GetMethod;
+use apivalk\apivalk\Router\AbstractRouter;
+use apivalk\apivalk\Router\Route\Route;
+use PHPUnit\Framework\TestCase;
 
 class OpenAPIGeneratorTest extends TestCase
 {
@@ -21,7 +21,8 @@ class OpenAPIGeneratorTest extends TestCase
         $route = new Route('/test', new GetMethod());
         
         if (!class_exists('TestControllerForOpenAPI')) {
-            eval('
+            eval(
+            '
                 class TestRequestForOpenAPI extends apivalk\apivalk\Http\Request\AbstractApivalkRequest {
                     public static function getDocumentation(): apivalk\apivalk\Documentation\ApivalkRequestDocumentation {
                         return new apivalk\apivalk\Documentation\ApivalkRequestDocumentation();
@@ -37,10 +38,11 @@ class OpenAPIGeneratorTest extends TestCase
                     };
                     return $response;
                 }
-                public static function getRoute(): \apivalk\apivalk\Router\Route { return new \apivalk\apivalk\Router\Route("/test", new \apivalk\apivalk\Http\Method\GetMethod()); }
+                public static function getRoute(): \apivalk\apivalk\Router\Route\Route { return new \apivalk\apivalk\Router\Route\Route("/test", new \apivalk\apivalk\Http\Method\GetMethod()); }
                 public static function getRequestClass(): string { return "TestRequestForOpenAPI"; }
                 public static function getResponseClasses(): array { return []; }
-            }');
+            }'
+            );
         }
         $controllerClass = 'TestControllerForOpenAPI';
 

--- a/Tests/PhpUnit/Http/Controller/AbstractApivalkControllerTest.php
+++ b/Tests/PhpUnit/Http/Controller/AbstractApivalkControllerTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Http\Controller;
 
-use PHPUnit\Framework\TestCase;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
+use PHPUnit\Framework\TestCase;
 
 class AbstractApivalkControllerTest extends TestCase
 {

--- a/Tests/PhpUnit/Http/Controller/ApivalkControllerFactoryTest.php
+++ b/Tests/PhpUnit/Http/Controller/ApivalkControllerFactoryTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Http\Controller;
 
-use PHPUnit\Framework\TestCase;
-use apivalk\apivalk\Http\Controller\ApivalkControllerFactory;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
+use apivalk\apivalk\Http\Controller\ApivalkControllerFactory;
+use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 class ApivalkControllerFactoryTest extends TestCase
@@ -30,7 +30,7 @@ class ApivalkControllerFactoryTest extends TestCase
         
         // Use an anonymous class that exists
         $controllerClass = get_class(new class extends AbstractApivalkController {
-            public static function getRoute(): \apivalk\apivalk\Router\Route { return new \apivalk\apivalk\Router\Route('/', new \apivalk\apivalk\Http\Method\GetMethod()); }
+            public static function getRoute(): \apivalk\apivalk\Router\Route\Route { return new \apivalk\apivalk\Router\Route\Route('/', new \apivalk\apivalk\Http\Method\GetMethod()); }
             public static function getRequestClass(): string { return ''; }
             public static function getResponseClasses(): array { return []; }
             public function __invoke(\apivalk\apivalk\Http\Request\ApivalkRequestInterface $request): \apivalk\apivalk\Http\Response\AbstractApivalkResponse { return $this->createMock(\apivalk\apivalk\Http\Response\AbstractApivalkResponse::class); }

--- a/Tests/PhpUnit/Http/Request/AbstractApivalkRequestTest.php
+++ b/Tests/PhpUnit/Http/Request/AbstractApivalkRequestTest.php
@@ -7,7 +7,8 @@ namespace apivalk\apivalk\Tests\PhpUnit\Http\Request;
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Http\Method\MethodInterface;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Order\OrderBag;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
 use PHPUnit\Framework\TestCase;
 
@@ -50,5 +51,6 @@ class AbstractApivalkRequestTest extends TestCase
         $this->assertInstanceOf(\apivalk\apivalk\Http\Request\Parameter\ParameterBag::class, $request->body());
         $this->assertInstanceOf(\apivalk\apivalk\Http\Request\Parameter\ParameterBag::class, $request->path());
         $this->assertInstanceOf(\apivalk\apivalk\Http\Request\File\FileBag::class, $request->file());
+        $this->assertInstanceOf(OrderBag::class, $request->ordering());
     }
 }

--- a/Tests/PhpUnit/Http/Request/Parameter/ParameterBagFactoryTest.php
+++ b/Tests/PhpUnit/Http/Request/Parameter/ParameterBagFactoryTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Http\Request\Parameter;
 
-use PHPUnit\Framework\TestCase;
-use apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory;
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
-use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Documentation\Property\NumberProperty;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Documentation\Property\StringProperty;
+use apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory;
+use apivalk\apivalk\Router\Route\Route;
+use PHPUnit\Framework\TestCase;
 
 class ParameterBagFactoryTest extends TestCase
 {

--- a/Tests/PhpUnit/Middleware/RateLimitMiddlewareTest.php
+++ b/Tests/PhpUnit/Middleware/RateLimitMiddlewareTest.php
@@ -11,8 +11,7 @@ use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\TooManyRequestsApivalkResponse;
 use apivalk\apivalk\Middleware\RateLimitMiddleware;
 use apivalk\apivalk\Router\RateLimit\RateLimitInterface;
-use apivalk\apivalk\Router\RateLimit\RateLimitResult;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 use PHPUnit\Framework\TestCase;
 
 class RateLimitMiddlewareTest extends TestCase

--- a/Tests/PhpUnit/Middleware/RequestValidationMiddlewareTest.php
+++ b/Tests/PhpUnit/Middleware/RequestValidationMiddlewareTest.php
@@ -17,6 +17,7 @@ use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\BadValidationApivalkResponse;
 use apivalk\apivalk\Middleware\RequestValidationMiddleware;
 use apivalk\apivalk\Router\RateLimit\RateLimitResult;
+use apivalk\apivalk\Router\Route\Order\OrderBag;
 use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
 use PHPUnit\Framework\TestCase;
 
@@ -60,7 +61,7 @@ class RequestValidationMiddlewareTest extends TestCase
                 return self::$d;
             }
 
-            public function populate(\apivalk\apivalk\Router\Route $route): void
+            public function populate(\apivalk\apivalk\Router\Route\Route $route): void
             {
             }
 
@@ -126,6 +127,11 @@ class RequestValidationMiddlewareTest extends TestCase
 
             public function setLocale(Locale $locale): void
             {
+            }
+
+            public function ordering(): OrderBag
+            {
+                return new OrderBag();
             }
         };
 
@@ -179,7 +185,7 @@ class RequestValidationMiddlewareTest extends TestCase
                 return self::$d;
             }
 
-            public function populate(\apivalk\apivalk\Router\Route $route): void
+            public function populate(\apivalk\apivalk\Router\Route\Route $route): void
             {
             }
 
@@ -246,6 +252,11 @@ class RequestValidationMiddlewareTest extends TestCase
 
             public function setLocale(Locale $locale): void
             {
+            }
+
+            public function ordering(): OrderBag
+            {
+                return new OrderBag();
             }
         };
 

--- a/Tests/PhpUnit/Middleware/SecurityMiddlewareTest.php
+++ b/Tests/PhpUnit/Middleware/SecurityMiddlewareTest.php
@@ -11,7 +11,7 @@ use apivalk\apivalk\Http\Response\ForbiddenApivalkResponse;
 use apivalk\apivalk\Http\Response\NotFoundApivalkResponse;
 use apivalk\apivalk\Http\Response\UnauthorizedApivalkResponse;
 use apivalk\apivalk\Middleware\SecurityMiddleware;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity;
 use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
 use apivalk\apivalk\Security\RouteAuthorization;

--- a/Tests/PhpUnit/Router/RateLimit/RateLimitContextTest.php
+++ b/Tests/PhpUnit/Router/RateLimit/RateLimitContextTest.php
@@ -7,7 +7,7 @@ namespace apivalk\apivalk\Tests\PhpUnit\Router\RateLimit;
 use apivalk\apivalk\Http\Method\MethodInterface;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Router\RateLimit\RateLimitContext;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity;
 use PHPUnit\Framework\TestCase;
 

--- a/Tests/PhpUnit/Router/Route/Order/OrderBagTest.php
+++ b/Tests/PhpUnit/Router/Route/Order/OrderBagTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Router\Route\Order;
+
+use apivalk\apivalk\Router\Route\Order\Order;
+use apivalk\apivalk\Router\Route\Order\OrderBag;
+use PHPUnit\Framework\TestCase;
+
+class OrderBagTest extends TestCase
+{
+    public function testSetAndGet(): void
+    {
+        $orderBag = new OrderBag();
+        $order = Order::asc('status');
+
+        $orderBag->set($order);
+
+        $this->assertTrue($orderBag->has('status'));
+        $this->assertSame($order, $orderBag->get('status'));
+    }
+
+    public function testGetReturnsNullForUnknownField(): void
+    {
+        $orderBag = new OrderBag();
+
+        $this->assertFalse($orderBag->has('unknown'));
+        $this->assertNull($orderBag->get('unknown'));
+    }
+
+    public function testCount(): void
+    {
+        $orderBag = new OrderBag();
+
+        $this->assertCount(0, $orderBag);
+
+        $orderBag->set(Order::asc('status'));
+        $this->assertCount(1, $orderBag);
+
+        $orderBag->set(Order::desc('price'));
+        $this->assertCount(2, $orderBag);
+    }
+
+    public function testSetOverridesExistingField(): void
+    {
+        $orderBag = new OrderBag();
+
+        $orderBag->set(Order::asc('status'));
+        $orderBag->set(Order::desc('status'));
+
+        $this->assertCount(1, $orderBag);
+        $this->assertTrue($orderBag->has('status'));
+        $this->assertTrue($orderBag->get('status')->isDesc());
+        $this->assertFalse($orderBag->get('status')->isAsc());
+    }
+
+    public function testIterator(): void
+    {
+        $orderBag = new OrderBag();
+        $statusOrder = Order::asc('status');
+        $priceOrder = Order::desc('price');
+
+        $orderBag->set($statusOrder);
+        $orderBag->set($priceOrder);
+
+        $orders = iterator_to_array($orderBag->getIterator());
+
+        $this->assertArrayHasKey('status', $orders);
+        $this->assertArrayHasKey('price', $orders);
+        $this->assertSame($statusOrder, $orders['status']);
+        $this->assertSame($priceOrder, $orders['price']);
+    }
+
+    public function testMagicGet(): void
+    {
+        $orderBag = new OrderBag();
+        $order = Order::asc('status');
+
+        $orderBag->set($order);
+
+        $this->assertSame($order, $orderBag->status);
+    }
+
+    public function testMagicGetReturnsNullForUnknownField(): void
+    {
+        $orderBag = new OrderBag();
+
+        $this->assertNull($orderBag->unknown);
+    }
+}

--- a/Tests/PhpUnit/Router/Route/Order/OrderTest.php
+++ b/Tests/PhpUnit/Router/Route/Order/OrderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Router\Route\Order;
+
+use apivalk\apivalk\Router\Route\Order\Order;
+use PHPUnit\Framework\TestCase;
+
+class OrderTest extends TestCase
+{
+    public function testAscFactory(): void
+    {
+        $order = Order::asc('status');
+
+        $this->assertInstanceOf(Order::class, $order);
+        $this->assertTrue($order->isAsc());
+        $this->assertFalse($order->isDesc());
+        $this->assertSame('status', $order->getField());
+    }
+
+    public function testDescFactory(): void
+    {
+        $order = Order::desc('price');
+
+        $this->assertInstanceOf(Order::class, $order);
+        $this->assertFalse($order->isAsc());
+        $this->assertTrue($order->isDesc());
+        $this->assertSame('price', $order->getField());
+    }
+
+    public function testConstructorDefaultsToAsc(): void
+    {
+        $order = new Order('id');
+
+        $this->assertTrue($order->isAsc());
+        $this->assertFalse($order->isDesc());
+        $this->assertSame('id', $order->getField());
+    }
+
+    public function testIsDescIsInverseOfIsAsc(): void
+    {
+        $ascOrder = Order::asc('foo');
+        $descOrder = Order::desc('bar');
+
+        $this->assertSame(!$ascOrder->isAsc(), $ascOrder->isDesc());
+        $this->assertSame(!$descOrder->isAsc(), $descOrder->isDesc());
+    }
+}

--- a/Tests/PhpUnit/Router/RouteCacheFactoryTest.php
+++ b/Tests/PhpUnit/Router/RouteCacheFactoryTest.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Router;
 
-use PHPUnit\Framework\TestCase;
-use apivalk\apivalk\Router\RouteCacheFactory;
-use apivalk\apivalk\Router\AbstractRouter;
 use apivalk\apivalk\Cache\CacheInterface;
 use apivalk\apivalk\Cache\CacheItem;
-use apivalk\apivalk\Util\ClassLocator;
-use apivalk\apivalk\Router\Route;
-use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
+use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Router\AbstractRouter;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\RouteCacheFactory;
+use apivalk\apivalk\Util\ClassLocator;
+use PHPUnit\Framework\TestCase;
 
 class RouteCacheFactoryTest extends TestCase
 {

--- a/Tests/PhpUnit/Router/RouteJsonSerializerTest.php
+++ b/Tests/PhpUnit/Router/RouteJsonSerializerTest.php
@@ -6,8 +6,8 @@ namespace apivalk\apivalk\Tests\PhpUnit\Router;
 
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Router\RateLimit\IpRateLimit;
-use apivalk\apivalk\Router\Route;
-use apivalk\apivalk\Router\RouteJsonSerializer;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\RouteJsonSerializer;
 use PHPUnit\Framework\TestCase;
 
 class RouteJsonSerializerTest extends TestCase

--- a/Tests/PhpUnit/Router/RouteRegexFactoryTest.php
+++ b/Tests/PhpUnit/Router/RouteRegexFactoryTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Router;
 
 use apivalk\apivalk\Http\Method\GetMethod;
-use apivalk\apivalk\Router\Route;
-use apivalk\apivalk\Router\RouteRegexFactory;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\RouteRegexFactory;
 use PHPUnit\Framework\TestCase;
 
 class RouteRegexFactoryTest extends TestCase

--- a/Tests/PhpUnit/Router/RouteTest.php
+++ b/Tests/PhpUnit/Router/RouteTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Router;
 
+use apivalk\apivalk\Documentation\OpenAPI\Object\TagObject;
+use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Method\PostMethod;
 use apivalk\apivalk\Router\RateLimit\IpRateLimit;
-use apivalk\apivalk\Router\RouteJsonSerializer;
-use PHPUnit\Framework\TestCase;
-use apivalk\apivalk\Router\Route;
-use apivalk\apivalk\Http\Method\GetMethod;
-use apivalk\apivalk\Documentation\OpenAPI\Object\TagObject;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\RouteJsonSerializer;
 use apivalk\apivalk\Security\RouteAuthorization;
+use PHPUnit\Framework\TestCase;
 
 class RouteTest extends TestCase
 {

--- a/Tests/PhpUnit/Router/RouterTest.php
+++ b/Tests/PhpUnit/Router/RouterTest.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Router;
 
-use apivalk\apivalk\Router\RouteJsonSerializer;
-use apivalk\apivalk\Router\RouteRegexFactory;
-use PHPUnit\Framework\TestCase;
-use apivalk\apivalk\Router\Router;
 use apivalk\apivalk\Cache\CacheInterface;
 use apivalk\apivalk\Cache\CacheItem;
-use apivalk\apivalk\Util\ClassLocator;
-use apivalk\apivalk\Router\AbstractRouter;
-use apivalk\apivalk\Router\Route;
-use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Controller\ApivalkControllerFactoryInterface;
+use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
-use apivalk\apivalk\Http\Response\NotFoundApivalkResponse;
 use apivalk\apivalk\Http\Response\MethodNotAllowedApivalkResponse;
+use apivalk\apivalk\Http\Response\NotFoundApivalkResponse;
 use apivalk\apivalk\Middleware\MiddlewareStack;
+use apivalk\apivalk\Router\AbstractRouter;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\RouteJsonSerializer;
+use apivalk\apivalk\Router\Route\RouteRegexFactory;
+use apivalk\apivalk\Router\Router;
+use apivalk\apivalk\Util\ClassLocator;
+use PHPUnit\Framework\TestCase;
 
 class RouterTest extends TestCase
 {
@@ -98,7 +98,7 @@ class RouterTest extends TestCase
 
                 class TestControllerForRouterTest extends apivalk\apivalk\Http\Controller\AbstractApivalkController {
                 public function __invoke(\apivalk\apivalk\Http\Request\ApivalkRequestInterface $request): \apivalk\apivalk\Http\Response\AbstractApivalkResponse { return new apivalk\apivalk\Http\Response\NotFoundApivalkResponse(); }
-                public static function getRoute(): \apivalk\apivalk\Router\Route { return new \apivalk\apivalk\Router\Route("/", new \apivalk\apivalk\Http\Method\GetMethod()); }
+                public static function getRoute(): \apivalk\apivalk\Router\Route\Route { return new \apivalk\apivalk\Router\Route\Route("/", new \apivalk\apivalk\Http\Method\GetMethod()); }
                 public static function getRequestClass(): string { return "TestRequestForRouterTest"; }
                 public static function getResponseClasses(): array { return []; }
             }'

--- a/docs/documentation/docblock-generator.mdx
+++ b/docs/documentation/docblock-generator.mdx
@@ -11,10 +11,10 @@ In Apivalk, request data is populated into bags. While you can access data using
 
 The `DocBlockGenerator` automates the creation of this metadata. It performs the following steps for every Request class in your project:
 
-1. **Discovery**: Scans your API directories for classes extending `AbstractApivalkRequest`.
-2. **Extraction**: Executes the `getRequestDocumentation()` method on the associated Controller to find all defined properties.
-3. **Shape Generation**: Creates "Shape" classes (e.g., `GetUserBodyShape`) in a `Shape/` subdirectory. These classes contain public properties representing your documentation.
-4. **Rewrite**: Updates the original Request class file with `@property` tags pointing to these Shape classes.
+1. **Discovery**: Scans your API directories for classes extending `AbstractApivalkController`.
+2. **Extraction**: Executes the `getRequestClass()` and `getRoute()` methods on the Controller to find the associated Request class and its properties.
+3. **Shape Generation**: Creates "Shape" classes (e.g., `GetUserBodyShape`, `GetUserOrderingShape`) in a `Shape/` subdirectory. These classes contain public properties representing your documentation and route-defined ordering.
+4. **Rewrite**: Updates the original Request class file with `@method` tags pointing to these Shape classes.
 
 ## Example Result
 
@@ -30,9 +30,10 @@ After running `DocBlockGenerator`, it is automatically updated to:
 
 ```php
 /**
- * @property GetUserBodyShape $body
- * @property GetUserQueryShape $query
- * @property GetUserPathShape $path
+ * @method \apivalk\apivalk\Http\Request\Parameter\ParameterBag|Shape\GetUserQueryShape query()
+ * @method \apivalk\apivalk\Http\Request\Parameter\ParameterBag|Shape\GetUserPathShape path()
+ * @method \apivalk\apivalk\Http\Request\Parameter\ParameterBag|Shape\GetUserBodyShape body()
+ * @method \apivalk\apivalk\Router\Route\Order\OrderBag|Shape\GetUserOrderingShape ordering()
  */
 class GetUserRequest extends AbstractApivalkRequest {
     // Still empty, but now with IDE support!
@@ -59,5 +60,5 @@ $generator->run(
 
 * `DocBlockGenerator`: The main entry point that iterates over classes.
 * `DocBlockRequestGenerator`: Converts an `AbstractApivalkRequest` into a `DocBlockRequest` data object.
-* `DocBlockRequest`: Holds the metadata for the three shapes (Body, Query, Path).
+* `DocBlockRequest`: Holds the metadata for the four shapes (Body, Query, Path, Ordering).
 * `DocBlockShape`: Generates the PHP code for the Shape classes.

--- a/docs/http/controller.mdx
+++ b/docs/http/controller.mdx
@@ -20,7 +20,7 @@ namespace App\Http\Controller\Pet;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Http\Method\GetMethod;
 use App\Http\Request\Pet\GetPetRequest;
 use App\Http\Response\Pet\GetPetResponse;
@@ -50,6 +50,15 @@ class GetPetController extends AbstractApivalkController
     {
         // $request is already populated and validated!
         $id = $request->path()->id;
+
+        // Access populated ordering filters
+        foreach ($request->ordering()->all() as $order) {
+            $field = $order->getField();
+            $direction = $order->getDirection();
+        }
+
+        // or directly access populated filters (when user did not pass order_by=+/-status then the magic getter on status returns null)
+        $field = $request->ordering()->status->isAsc();
 
         $pet = $this->petRepository->find($id);
 

--- a/docs/http/request.mdx
+++ b/docs/http/request.mdx
@@ -62,6 +62,12 @@ public function __invoke(ApivalkRequestInterface $request): AbstractApivalkRespo
     
     // Access uploaded files (returns File object)
     $image = $request->file()->get('avatar');
+
+    // Access populated ordering (as defined in Route)
+    foreach ($request->ordering()->all() as $order) {
+        $field = $order->getField();
+        $isAsc = $order->isAsc();
+    }
 }
 ```
 
@@ -73,6 +79,14 @@ public function __invoke(ApivalkRequestInterface $request): AbstractApivalkRespo
 $name = $request->body()->name;
 $userId = $request->path()->id;
 ```
+
+## Automatic Query Documentation
+
+When a route has [ordering defined](/routing/route#ordering), the framework automatically documents the `order_by` query parameter in your OpenAPI specification. This includes:
+
+- **Regex Validation**: Ensuring that only allowed fields and correct sorting prefixes (`+` or `-`) are used.
+- **Example list**: A generated example showcasing the allowed ordering fields.
+- **Allowed values**: A comprehensive list of fields that can be used for sorting.
 
 ## Validation
 

--- a/docs/middleware/security.mdx
+++ b/docs/middleware/security.mdx
@@ -24,7 +24,7 @@ The current [Identity](/security/identity) must possess **all** the required sco
 A route that requires a logged-in user with specific scopes and permissions.
 
 ```php
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 
 $route = Route::get('/admin/dashboard')

--- a/docs/open-api-best-practices/04-pagination-filtering-sorting.mdx
+++ b/docs/open-api-best-practices/04-pagination-filtering-sorting.mdx
@@ -52,11 +52,13 @@ Example response snippet:
 
 ### Sorting
 
-Use '+' (ASC) or '-' (DESC) as a prefix for each field. If not specified, default is ASC.
+Use '+' (ASC) or '-' (DESC) as a prefix for each field. If not specified, default is ASC. Multiple fields can be separated by a comma.
 
 ```http
 GET /users?order_by=+id,-price
 ```
+
+In Apivalk, this `order_by` parameter automatically populates the `ordering()` bag on the request object, based on the fields allowed in the `Route` definition.
 
 ### Filtering
 

--- a/docs/routing/route.mdx
+++ b/docs/routing/route.mdx
@@ -13,6 +13,7 @@ A `Route` instance contains the following information:
 * **Tags**: A collection of `TagObject` instances used for grouping endpoints in documentation.
 * **Security Requirements**: A `RouteAuthorization` instance defining the authentication and authorization needed for the route.
 * **Rate Limit**: An optional `RateLimitInterface` implementation defining the rate limiting rules for the endpoint.
+* **Ordering**: A collection of `Order` instances defining allowed sorting fields for the endpoint.
 
 ## Path Parameters
 
@@ -84,5 +85,23 @@ public static function getRoute(): Route
 ```
 
 For more details on available rate limiting strategies, see the [Rate Limit](/routing/rate-limit) documentation.
+
+## Ordering
+
+You can define which fields are allowed for sorting by using the `ordering()` method. This takes an array of `Order` objects:
+
+```php
+use apivalk\apivalk\Router\Route\Order\Order;
+
+public static function getRoute(): Route
+{
+    return Route::get('/v1/users')
+                  ->description('List users')
+                  ->ordering([
+                      Order::asc('id'),
+                      Order::desc('created_at')
+                  ]);
+}
+```
 
 The framework's automated discovery system then picks up these definitions and registers them with the router.

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -24,7 +24,7 @@ The security layer consists of four main pillars:
 ## Quick Example: Private Route
 
 ```php
-use apivalk\apivalk\Router\Route;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 
 $route = Route::get('/admin/settings')->description('Admin Settings')->authorization(new RouteAuthorization('BearerAuth', ['admin:settings'], ['admin:settings:read']))
@@ -85,8 +85,7 @@ $configuration->addMiddleware(new SecurityMiddleware());
 Here is how you would define routes with different security requirements:
 
 ```php
-use apivalk\apivalk\Router\Route;
-use apivalk\apivalk\Security\RouteAuthorization;
+use apivalk\apivalk\Router\Route\Route;use apivalk\apivalk\Security\RouteAuthorization;
 
 // PRIVATE: Requires 'write:orders' scope
 $privateRoute = Route::post('/orders')->description('Create order')->authorization(new RouteAuthorization('BearerAuth', ['order'], ['order:create']))


### PR DESCRIPTION
- Implement `Order` and `OrderBag` classes for configurable route sorting.
- Extend `Route` with ordering functionality and serializer/deserializer adjustments.
- Update query parameter handling to support "order_by" operations.
- Introduce unit tests for ordering logic and serialization.
- Restructure namespaces under `Router\Route` for consistency.

Issue: #45