### PR TITLE
feat: include route-specific sorting logic in `AbstractApivalkRequest`

### DIFF
--- a/Documentation/DocBlock/DocBlockRequestGenerator.php
+++ b/Documentation/DocBlock/DocBlockRequestGenerator.php
@@ -34,7 +34,7 @@ final class DocBlockRequestGenerator
         }
 
         foreach ($route->getOrderings() as $ordering) {
-            $orderingShape->addCustomField($ordering->getField(), '\\' . Order::class . '|null');
+            $orderingShape->addCustomField($ordering->getField(), '\\' . Order::class);
         }
 
         return new DocBlockRequest(

--- a/Http/Request/AbstractApivalkRequest.php
+++ b/Http/Request/AbstractApivalkRequest.php
@@ -62,35 +62,43 @@ abstract class AbstractApivalkRequest implements ApivalkRequestInterface
         $this->ip = IpResolver::getClientIp();
         $this->orderBag = new OrderBag();
 
-        $this->populateOrderBag();
+        $this->populateOrderBag($route);
     }
 
-    private function populateOrderBag(): void
+    private function populateOrderBag(Route $route): void
     {
+        foreach ($route->getOrderings() as $ordering) {
+            if (!$this->orderBag->has($ordering->getField())) {
+                $this->orderBag->set($ordering);
+            }
+        }
+
         $orderBy = $this->queryParameterBag->get('order_by');
 
-        if ($orderBy !== null) {
-            foreach (explode(',', $orderBy->getRawValue()) as $curOrderByField) {
-                $curOrderByField = trim($curOrderByField);
+        if ($orderBy === null) {
+            return;
+        }
 
-                if ($curOrderByField === '') {
-                    continue;
-                }
+        foreach (explode(',', $orderBy->getRawValue()) as $curOrderByField) {
+            $curOrderByField = trim($curOrderByField);
 
-                if ($curOrderByField[0] !== '+' && $curOrderByField[0] !== '-') {
-                    $direction = '+';
-                    $field = $curOrderByField;
-                } else {
-                    $direction = $curOrderByField[0];
-                    $field = substr($curOrderByField, 1);
-                }
-
-                if ($field === '') {
-                    continue;
-                }
-
-                $this->orderBag->set($direction === '-' ? Order::desc($field) : Order::asc($field));
+            if ($curOrderByField === '') {
+                continue;
             }
+
+            if ($curOrderByField[0] !== '+' && $curOrderByField[0] !== '-') {
+                $direction = '+';
+                $field = $curOrderByField;
+            } else {
+                $direction = $curOrderByField[0];
+                $field = substr($curOrderByField, 1);
+            }
+
+            if ($field === '') {
+                continue;
+            }
+
+            $this->orderBag->set($direction === '-' ? Order::desc($field) : Order::asc($field));
         }
     }
 

--- a/docs/http/controller.mdx
+++ b/docs/http/controller.mdx
@@ -51,14 +51,18 @@ class GetPetController extends AbstractApivalkController
         // $request is already populated and validated!
         $id = $request->path()->id;
 
-        // Access populated ordering filters
+        // Access populated ordering filters.
+        // The ordering bag is always populated: if the user does not provide order_by,
+        // it contains the default sorting from the route.
         foreach ($request->ordering()->all() as $order) {
             $field = $order->getField();
             $direction = $order->getDirection();
         }
 
-        // or directly access populated filters (when user did not pass order_by=+/-status then the magic getter on status returns null)
-        $field = $request->ordering()->status->isAsc();
+        // or directly access populated filters.
+        // If the user did not pass order_by=+status or -status, the magic getter returns
+        // the default Order object for status if it was defined on the route.
+        $isAsc = $request->ordering()->status->isAsc();
 
         $pet = $this->petRepository->find($id);
 

--- a/docs/http/request.mdx
+++ b/docs/http/request.mdx
@@ -63,7 +63,9 @@ public function __invoke(ApivalkRequestInterface $request): AbstractApivalkRespo
     // Access uploaded files (returns File object)
     $image = $request->file()->get('avatar');
 
-    // Access populated ordering (as defined in Route)
+    // Access populated ordering (as defined in Route).
+    // Note: The ordering bag is always populated. If the user does not provide an order_by parameter,
+    // the bag will contain the default sorting defined on the route.
     foreach ($request->ordering()->all() as $order) {
         $field = $order->getField();
         $isAsc = $order->isAsc();
@@ -87,6 +89,8 @@ When a route has [ordering defined](/routing/route#ordering), the framework auto
 - **Regex Validation**: Ensuring that only allowed fields and correct sorting prefixes (`+` or `-`) are used.
 - **Example list**: A generated example showcasing the allowed ordering fields.
 - **Allowed values**: A comprehensive list of fields that can be used for sorting.
+
+Additionally, the framework ensures that the `ordering()` bag is never empty if ordering is defined on the route. If a user does not provide an `order_by` parameter, the bag is automatically post-populated with the default sorting defined in the route's `ordering()` method.
 
 ## Validation
 

--- a/docs/routing/route.mdx
+++ b/docs/routing/route.mdx
@@ -104,4 +104,4 @@ public static function getRoute(): Route
 }
 ```
 
-The framework's automated discovery system then picks up these definitions and registers them with the router.
+The `ordering()` method also defines the **default sorting** for the route. If a user does not provide an `order_by` query parameter, the `ordering()` bag on the request object will be automatically populated with these defined values.


### PR DESCRIPTION
- Refactor `populateOrderBag` to incorporate route-defined orderings.
- Enhance ordering functionality by ensuring fallback to route-level defaults.
- Update `DocBlockRequestGenerator` to simplify ordering type annotations.

Issue: #83