### PR TITLE
feat: extend `RouteJsonSerializer` to support orderings in serialization

### DIFF
--- a/Router/Route/RouteJsonSerializer.php
+++ b/Router/Route/RouteJsonSerializer.php
@@ -32,7 +32,11 @@ class RouteJsonSerializer
      *          name: string,
      *          maxAttempts: int,
      *          windowSeconds: int
-     *      }|null
+     *      }|null,
+     *     orderings: array<int, array{
+     *            field: string,
+     *            asc: bool
+     *        }>|null
      * }
      */
     public static function serialize(Route $route): array


### PR DESCRIPTION
- Update `serialize` DocBlock to include `orderings` structure.

Issue: #86