### PR TITLE
feat: document locale and rate limit headers in OpenAPI generation

### DIFF
--- a/Documentation/OpenAPI/Generator/OperationGenerator.php
+++ b/Documentation/OpenAPI/Generator/OperationGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Documentation\OpenAPI\Generator;
 
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Documentation\OpenAPI\Object\HeaderObject;
 use apivalk\apivalk\Documentation\OpenAPI\Object\OperationObject;
 use apivalk\apivalk\Documentation\Property\AbstractProperty;
 use apivalk\apivalk\Documentation\Property\IntegerProperty;
@@ -20,6 +21,14 @@ use apivalk\apivalk\Router\Route\Route;
 
 class OperationGenerator
 {
+    /** @var bool */
+    private $documentLocaleHeaders;
+
+    public function __construct(bool $documentLocaleHeaders = true)
+    {
+        $this->documentLocaleHeaders = $documentLocaleHeaders;
+    }
+
     public function generate(
         Route $route,
         ApivalkRequestDocumentation $requestDocumentation,
@@ -53,6 +62,18 @@ class OperationGenerator
             $parameters[] = $parameterGenerator->generate($filterProperty, 'query');
         }
 
+        if ($this->documentLocaleHeaders) {
+            $acceptLanguageProperty = new StringProperty(
+                'Accept-Language',
+                'BCP 47 language tag for content negotiation (e.g. en, de-DE).'
+            );
+            $acceptLanguageProperty->setIsRequired(false);
+            $acceptLanguageProperty->setExample('en');
+            $parameters[] = $parameterGenerator->generate($acceptLanguageProperty, 'header');
+        }
+
+        $responseHeaders = $this->getResponseHeaders($route);
+
         $responses = [];
 
         /** @var AbstractApivalkResponse $responseClass */
@@ -61,34 +82,45 @@ class OperationGenerator
                 $responseGenerator->generate(
                     (int)$responseClass::getStatusCode(),
                     $responseClass::getDocumentation(),
-                    $route
+                    $route,
+                    $responseHeaders
                 );
         }
 
         // Todo: Maybe define the default responses in all operations in apivalk configuration
         $responses[] = $responseGenerator->generate(
             BadValidationApivalkResponse::getStatusCode(),
-            BadValidationApivalkResponse::getDocumentation()
+            BadValidationApivalkResponse::getDocumentation(),
+            null,
+            $responseHeaders
         );
 
         $responses[] = $responseGenerator->generate(
             MethodNotAllowedApivalkResponse::getStatusCode(),
-            MethodNotAllowedApivalkResponse::getDocumentation()
+            MethodNotAllowedApivalkResponse::getDocumentation(),
+            null,
+            $responseHeaders
         );
 
         $responses[] = $responseGenerator->generate(
             NotFoundApivalkResponse::getStatusCode(),
-            NotFoundApivalkResponse::getDocumentation()
+            NotFoundApivalkResponse::getDocumentation(),
+            null,
+            $responseHeaders
         );
 
         $responses[] = $responseGenerator->generate(
             TooManyRequestsApivalkResponse::getStatusCode(),
-            TooManyRequestsApivalkResponse::getDocumentation()
+            TooManyRequestsApivalkResponse::getDocumentation(),
+            null,
+            $responseHeaders
         );
 
         $responses[] = $responseGenerator->generate(
             UnauthorizedApivalkResponse::getStatusCode(),
-            UnauthorizedApivalkResponse::getDocumentation()
+            UnauthorizedApivalkResponse::getDocumentation(),
+            null,
+            $responseHeaders
         );
 
         return new OperationObject(
@@ -230,12 +262,44 @@ class OperationGenerator
         if (\count($route->getFilters()) === 0) {
             return [];
         }
-    
+
         $properties = [];
         foreach ($route->getFilters() as $filter) {
             $properties[] = $filter->getProperty();
         }
-    
+
         return $properties;
+    }
+
+    /**
+     * @return array<string, HeaderObject>
+     */
+    private function getResponseHeaders(Route $route): array
+    {
+        $headers = [];
+
+        if ($this->documentLocaleHeaders) {
+            $headers['Content-Language'] = new HeaderObject('The locale of the response content (BCP 47 language tag).');
+        }
+
+        if ($route->getRateLimit() !== null) {
+            $headers['X-RateLimit-Limit'] = new HeaderObject(
+                \sprintf(
+                    'The maximum number of requests allowed within the time window (%d seconds).',
+                    $route->getRateLimit()->getWindowInSeconds()
+                )
+            );
+            $headers['X-RateLimit-Remaining'] = new HeaderObject(
+                'The number of requests remaining in the current time window.'
+            );
+            $headers['X-RateLimit-Reset'] = new HeaderObject(
+                'The UTC epoch timestamp (in seconds) when the rate limit window resets.'
+            );
+            $headers['Retry-After'] = new HeaderObject(
+                'The UTC epoch timestamp (in seconds) after which the client may retry. Present only when the rate limit has been exceeded.'
+            );
+        }
+
+        return $headers;
     }
 }

--- a/Documentation/OpenAPI/Generator/PathItemGenerator.php
+++ b/Documentation/OpenAPI/Generator/PathItemGenerator.php
@@ -16,6 +16,14 @@ use apivalk\apivalk\Router\Route\Route;
 
 class PathItemGenerator
 {
+    /** @var bool */
+    private $documentLocaleHeaders;
+
+    public function __construct(bool $documentLocaleHeaders = true)
+    {
+        $this->documentLocaleHeaders = $documentLocaleHeaders;
+    }
+
     /**
      * @param array<int, array{controllerClass: string, route: Route}> $routes All routes with controller class name that have the same URL pattern but different methods. Example: ['controllerClass' => 'CreateController', 'route' => $createControllerRoute]
      *
@@ -23,7 +31,7 @@ class PathItemGenerator
      */
     public function generate(array $routes): PathItemObject
     {
-        $operationGenerator = new OperationGenerator();
+        $operationGenerator = new OperationGenerator($this->documentLocaleHeaders);
 
         $get = null;
         $put = null;

--- a/Documentation/OpenAPI/Generator/PathsGenerator.php
+++ b/Documentation/OpenAPI/Generator/PathsGenerator.php
@@ -9,6 +9,14 @@ use apivalk\apivalk\Router\Route\Route;
 
 class PathsGenerator
 {
+    /** @var bool */
+    private $documentLocaleHeaders;
+
+    public function __construct(bool $documentLocaleHeaders = true)
+    {
+        $this->documentLocaleHeaders = $documentLocaleHeaders;
+    }
+
     /**
      * @param string                                                       $url
      * @param array<int, array{controllerClass: string, route: Route}> $routes All routes with controller class name that have the same URL pattern but different methods. Example: ['controllerClass' => 'CreateController', 'route' => $createControllerRoute]
@@ -17,7 +25,7 @@ class PathsGenerator
      */
     public function generate(string $url, array $routes): PathsObject
     {
-        $pathItemGenerator = new PathItemGenerator();
+        $pathItemGenerator = new PathItemGenerator($this->documentLocaleHeaders);
 
         return new PathsObject($url, $pathItemGenerator->generate($routes));
     }

--- a/Documentation/OpenAPI/Generator/ResponseGenerator.php
+++ b/Documentation/OpenAPI/Generator/ResponseGenerator.php
@@ -5,16 +5,26 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Documentation\OpenAPI\Generator;
 
 use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use apivalk\apivalk\Documentation\OpenAPI\Object\HeaderObject;
 use apivalk\apivalk\Documentation\OpenAPI\Object\ResponseObject;
 use apivalk\apivalk\Documentation\OpenAPI\Object\SchemaObject;
 use apivalk\apivalk\Router\Route\Route;
 
 class ResponseGenerator
 {
+    /**
+     * @param int                            $statusCode
+     * @param ApivalkResponseDocumentation   $responseDocumentation
+     * @param Route|null                     $route
+     * @param array<string, HeaderObject>    $headers
+     *
+     * @return ResponseObject
+     */
     public function generate(
         int $statusCode,
         ApivalkResponseDocumentation $responseDocumentation,
-        ?Route $route = null
+        ?Route $route = null,
+        array $headers = []
     ): ResponseObject {
         $mediaTypeGenerator = new MediaTypeGenerator();
 
@@ -22,14 +32,14 @@ class ResponseGenerator
             'object',
             true,
             $responseDocumentation->getProperties(),
-            $route !== null ? $route->getPagination() : null
+            $route instanceof Route ? $route->getPagination() : null
         );
 
         return new ResponseObject(
             $statusCode,
             $mediaTypeGenerator->generate('application/json', $schema),
             $responseDocumentation->getDescription(),
-            []
+            $headers
         );
     }
 }

--- a/Documentation/OpenAPI/Object/ResponseObject.php
+++ b/Documentation/OpenAPI/Object/ResponseObject.php
@@ -56,11 +56,15 @@ class ResponseObject implements ObjectInterface
 
     public function toArray(): array
     {
+        $headers = array_map(static function ($headerObject) {
+            return $headerObject->toArray();
+        }, $this->headers);
+
         return [
             $this->statusCode => array_filter(
                 [
                     'description' => $this->description ?? '',
-                    'headers' => $this->headers,
+                    'headers' => $headers,
                     'content' => $this->content !== null ? array_filter($this->content->toArray()) : null,
                 ]
             )

--- a/Documentation/OpenAPI/OpenAPIGenerator.php
+++ b/Documentation/OpenAPI/OpenAPIGenerator.php
@@ -16,6 +16,8 @@ class OpenAPIGenerator
     private $apivalk;
     /** @var OpenAPI */
     private $openApi;
+    /** @var bool */
+    private $documentLocaleHeaders;
 
     public const FORMAT_JSON = 'json';
 
@@ -24,15 +26,18 @@ class OpenAPIGenerator
      * @param InfoObject|null       $infoObject
      * @param ServerObject[]        $servers
      * @param ComponentsObject|null $componentsObject
+     * @param bool                  $documentLocaleHeaders
      */
     public function __construct(
         Apivalk $apivalk,
         ?InfoObject $infoObject = null,
         array $servers = [],
-        ?ComponentsObject $componentsObject = null
+        ?ComponentsObject $componentsObject = null,
+        bool $documentLocaleHeaders = true
     ) {
         $this->apivalk = $apivalk;
         $this->openApi = new OpenAPI();
+        $this->documentLocaleHeaders = $documentLocaleHeaders;
 
         if ($infoObject !== null) {
             $this->openApi->setInfo($infoObject);
@@ -60,7 +65,7 @@ class OpenAPIGenerator
 
     private function generatePaths(): void
     {
-        $pathsGenerator = new PathsGenerator();
+        $pathsGenerator = new PathsGenerator($this->documentLocaleHeaders);
         $routeMapping = [];
 
         foreach ($this->apivalk->getRouter()->getRoutes() as $route) {

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/OperationGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/OperationGeneratorTest.php
@@ -10,6 +10,7 @@ use apivalk\apivalk\Documentation\OpenAPI\Generator\OperationGenerator;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Router\RateLimit\RateLimitInterface;
 use apivalk\apivalk\Router\Route\Filter\StringFilter;
 use apivalk\apivalk\Router\Route\Sort\Sort;
 use apivalk\apivalk\Router\Route\Route;
@@ -37,44 +38,54 @@ class TestResponse extends AbstractApivalkResponse
 
 class OperationGeneratorTest extends TestCase
 {
-    public function testOperationGenerator(): void
+    private function createRouteMock(array $overrides = []): Route
     {
-        $generator = new OperationGenerator();
-
         $method = $this->createMock(GetMethod::class);
         $method->method('getName')->willReturn('GET');
 
         $route = $this->createMock(Route::class);
-        $route->method('getMethod')->willReturn($method);
-        $route->method('getDescription')->willReturn('Route desc');
-        $route->method('getUrl')->willReturn('/test');
-        $route->method('getTags')->willReturn([]);
-        $route->method('getRouteAuthorization')->willReturn(null);
-        $route->method('getSortings')->willReturn(
-            [
-                Sort::asc('id'),
-                Sort::desc('price')
-            ]
-        );
-        $route->method('getFilters')->willReturn(
-            [
-                StringFilter::equals(new StringProperty('status'))
-            ]
-        );
+        $route->method('getMethod')->willReturn($overrides['method'] ?? $method);
+        $route->method('getDescription')->willReturn($overrides['description'] ?? 'Route desc');
+        $route->method('getUrl')->willReturn($overrides['url'] ?? '/test');
+        $route->method('getTags')->willReturn($overrides['tags'] ?? []);
+        $route->method('getRouteAuthorization')->willReturn($overrides['routeAuthorization'] ?? null);
+        $route->method('getSortings')->willReturn($overrides['sortings'] ?? []);
+        $route->method('getFilters')->willReturn($overrides['filters'] ?? []);
+        $route->method('getPagination')->willReturn($overrides['pagination'] ?? null);
+        $route->method('getRateLimit')->willReturn($overrides['rateLimit'] ?? null);
+        $route->method('getSummary')->willReturn($overrides['summary'] ?? null);
 
+        return $route;
+    }
+
+    private function createRequestDocMock(): ApivalkRequestDocumentation
+    {
         $requestDoc = $this->createMock(ApivalkRequestDocumentation::class);
         $requestDoc->method('getPathProperties')->willReturn([]);
         $requestDoc->method('getQueryProperties')->willReturn([]);
         $requestDoc->method('getBodyProperties')->willReturn([]);
 
-        $operation = $generator->generate($route, $requestDoc, [TestResponse::class]);
+        return $requestDoc;
+    }
+
+    public function testOperationGenerator(): void
+    {
+        $generator = new OperationGenerator();
+
+        $route = $this->createRouteMock([
+            'sortings' => [Sort::asc('id'), Sort::desc('price')],
+            'filters' => [StringFilter::equals(new StringProperty('status'))],
+        ]);
+
+        $operation = $generator->generate($route, $this->createRequestDocMock(), [TestResponse::class]);
 
         $this->assertEquals('Route desc', $operation->getDescription());
         $this->assertNull($operation->getSummary());
         $this->assertCount(6, $operation->getResponses()); // 1 custom + 5 default
 
         $parameters = $operation->getParameters();
-        $this->assertCount(2, $parameters); // order_by + status
+        // order_by + status + Accept-Language
+        $this->assertCount(3, $parameters);
 
         $orderByParameter = null;
         $statusParameter = null;
@@ -98,7 +109,6 @@ class OperationGeneratorTest extends TestCase
             $orderByParameter->getDescription()
         );
         $this->assertFalse($orderByParameter->isRequired());
-        // $this->assertEquals('+id,-price', $orderByParameter->toArray()['schema']['example']); // Skip problematic assertion for now
         $this->assertEquals(
             '^([+-](id|price))(,([+-](id|price)))*$',
             $orderByParameter->toArray()['schema']['pattern']
@@ -108,30 +118,200 @@ class OperationGeneratorTest extends TestCase
     public function testOperationGeneratorWithoutOrder(): void
     {
         $generator = new OperationGenerator();
+        $route = $this->createRouteMock();
 
-        $method = $this->createMock(GetMethod::class);
-        $method->method('getName')->willReturn('GET');
-
-        $route = $this->createMock(Route::class);
-        $route->method('getMethod')->willReturn($method);
-        $route->method('getDescription')->willReturn('Route desc');
-        $route->method('getUrl')->willReturn('/test');
-        $route->method('getTags')->willReturn([]);
-        $route->method('getRouteAuthorization')->willReturn(null);
-        $route->method('getSortings')->willReturn([]);
-        $route->method('getFilters')->willReturn([]);
-
-        $requestDoc = $this->createMock(ApivalkRequestDocumentation::class);
-        $requestDoc->method('getPathProperties')->willReturn([]);
-        $requestDoc->method('getQueryProperties')->willReturn([]);
-        $requestDoc->method('getBodyProperties')->willReturn([]);
-
-        $operation = $generator->generate($route, $requestDoc, [TestResponse::class]);
+        $operation = $generator->generate($route, $this->createRequestDocMock(), [TestResponse::class]);
 
         $this->assertEquals('Route desc', $operation->getDescription());
         $this->assertNull($operation->getSummary());
         $this->assertCount(6, $operation->getResponses()); // 1 custom + 5 default
 
-        $this->assertEmpty($operation->getParameters());
+        // Only Accept-Language header parameter
+        $this->assertCount(1, $operation->getParameters());
+        $this->assertEquals('Accept-Language', $operation->getParameters()[0]->getName());
+    }
+
+    public function testAcceptLanguageHeaderParameterIsAlwaysPresent(): void
+    {
+        $generator = new OperationGenerator();
+        $route = $this->createRouteMock();
+
+        $operation = $generator->generate($route, $this->createRequestDocMock(), [TestResponse::class]);
+
+        $acceptLanguageParam = null;
+        foreach ($operation->getParameters() as $parameter) {
+            if ($parameter->getName() === 'Accept-Language') {
+                $acceptLanguageParam = $parameter;
+            }
+        }
+
+        $this->assertNotNull($acceptLanguageParam, 'Expected Accept-Language parameter to be generated.');
+        $this->assertEquals('header', $acceptLanguageParam->getIn());
+        $this->assertFalse($acceptLanguageParam->isRequired());
+        $this->assertStringContainsString('BCP 47', $acceptLanguageParam->getDescription());
+    }
+
+    public function testContentLanguageHeaderIsAlwaysPresentInResponses(): void
+    {
+        $generator = new OperationGenerator();
+        $route = $this->createRouteMock();
+
+        $operation = $generator->generate($route, $this->createRequestDocMock(), [TestResponse::class]);
+
+        foreach ($operation->getResponses() as $response) {
+            $headers = $response->getHeaders();
+            $this->assertArrayHasKey('Content-Language', $headers, \sprintf(
+                'Expected Content-Language header in response %d.',
+                $response->getStatusCode()
+            ));
+        }
+    }
+
+    public function testRateLimitHeadersNotPresentWhenNoRateLimit(): void
+    {
+        $generator = new OperationGenerator();
+        $route = $this->createRouteMock();
+
+        $operation = $generator->generate($route, $this->createRequestDocMock(), [TestResponse::class]);
+
+        foreach ($operation->getResponses() as $response) {
+            $headers = $response->getHeaders();
+            $this->assertArrayNotHasKey('X-RateLimit-Limit', $headers);
+            $this->assertArrayNotHasKey('X-RateLimit-Remaining', $headers);
+            $this->assertArrayNotHasKey('X-RateLimit-Reset', $headers);
+            $this->assertArrayNotHasKey('Retry-After', $headers);
+        }
+    }
+
+    public function testRateLimitHeadersPresentWhenRateLimitApplied(): void
+    {
+        $generator = new OperationGenerator();
+
+        $rateLimit = $this->createMock(RateLimitInterface::class);
+        $rateLimit->method('getWindowInSeconds')->willReturn(60);
+        $rateLimit->method('getMaxAttempts')->willReturn(100);
+
+        $route = $this->createRouteMock(['rateLimit' => $rateLimit]);
+
+        $operation = $generator->generate($route, $this->createRequestDocMock(), [TestResponse::class]);
+
+        foreach ($operation->getResponses() as $response) {
+            $headers = $response->getHeaders();
+            $this->assertArrayHasKey('X-RateLimit-Limit', $headers, \sprintf(
+                'Expected X-RateLimit-Limit header in response %d.',
+                $response->getStatusCode()
+            ));
+            $this->assertArrayHasKey('X-RateLimit-Remaining', $headers);
+            $this->assertArrayHasKey('X-RateLimit-Reset', $headers);
+            $this->assertArrayHasKey('Retry-After', $headers);
+            $this->assertArrayHasKey('Content-Language', $headers);
+        }
+    }
+
+    public function testRateLimitHeaderDescriptionIncludesWindowSeconds(): void
+    {
+        $generator = new OperationGenerator();
+
+        $rateLimit = $this->createMock(RateLimitInterface::class);
+        $rateLimit->method('getWindowInSeconds')->willReturn(120);
+        $rateLimit->method('getMaxAttempts')->willReturn(50);
+
+        $route = $this->createRouteMock(['rateLimit' => $rateLimit]);
+
+        $operation = $generator->generate($route, $this->createRequestDocMock(), [TestResponse::class]);
+
+        $firstResponse = $operation->getResponses()[0];
+        $rateLimitHeader = $firstResponse->getHeaders()['X-RateLimit-Limit'];
+
+        $this->assertStringContainsString('120 seconds', $rateLimitHeader->getDescription());
+    }
+
+    public function testResponseHeadersSerializeCorrectlyInToArray(): void
+    {
+        $generator = new OperationGenerator();
+
+        $rateLimit = $this->createMock(RateLimitInterface::class);
+        $rateLimit->method('getWindowInSeconds')->willReturn(60);
+        $rateLimit->method('getMaxAttempts')->willReturn(100);
+
+        $route = $this->createRouteMock(['rateLimit' => $rateLimit]);
+
+        $operation = $generator->generate($route, $this->createRequestDocMock(), [TestResponse::class]);
+
+        $firstResponse = $operation->getResponses()[0];
+        $responseArray = $firstResponse->toArray();
+
+        $statusCode = $firstResponse->getStatusCode();
+        $this->assertArrayHasKey('headers', $responseArray[$statusCode]);
+
+        $headersArray = $responseArray[$statusCode]['headers'];
+        $this->assertArrayHasKey('Content-Language', $headersArray);
+        $this->assertArrayHasKey('description', $headersArray['Content-Language']);
+        $this->assertArrayHasKey('required', $headersArray['Content-Language']);
+
+        $this->assertArrayHasKey('X-RateLimit-Limit', $headersArray);
+        $this->assertArrayHasKey('description', $headersArray['X-RateLimit-Limit']);
+    }
+
+    public function testLocaleHeadersDisabled(): void
+    {
+        $generator = new OperationGenerator(false);
+        $route = $this->createRouteMock();
+
+        $operation = $generator->generate($route, $this->createRequestDocMock(), [TestResponse::class]);
+
+        foreach ($operation->getParameters() as $parameter) {
+            $this->assertNotEquals(
+                'Accept-Language',
+                $parameter->getName(),
+                'Accept-Language parameter should not be present when locale headers are disabled.'
+            );
+        }
+
+        foreach ($operation->getResponses() as $response) {
+            $this->assertArrayNotHasKey('Content-Language', $response->getHeaders());
+        }
+    }
+
+    public function testLocaleHeadersDisabledStillIncludesRateLimitHeaders(): void
+    {
+        $rateLimit = $this->createMock(RateLimitInterface::class);
+        $rateLimit->method('getWindowInSeconds')->willReturn(60);
+        $rateLimit->method('getMaxAttempts')->willReturn(100);
+
+        $generator = new OperationGenerator(false);
+        $route = $this->createRouteMock(['rateLimit' => $rateLimit]);
+
+        $operation = $generator->generate($route, $this->createRequestDocMock(), [TestResponse::class]);
+
+        foreach ($operation->getResponses() as $response) {
+            $headers = $response->getHeaders();
+            $this->assertArrayNotHasKey('Content-Language', $headers);
+            $this->assertArrayHasKey('X-RateLimit-Limit', $headers);
+            $this->assertArrayHasKey('X-RateLimit-Remaining', $headers);
+            $this->assertArrayHasKey('X-RateLimit-Reset', $headers);
+            $this->assertArrayHasKey('Retry-After', $headers);
+        }
+    }
+
+    public function testLocaleHeadersEnabledByDefault(): void
+    {
+        $generator = new OperationGenerator();
+        $route = $this->createRouteMock();
+
+        $operation = $generator->generate($route, $this->createRequestDocMock(), [TestResponse::class]);
+
+        $hasAcceptLanguage = false;
+        foreach ($operation->getParameters() as $parameter) {
+            if ($parameter->getName() === 'Accept-Language') {
+                $hasAcceptLanguage = true;
+            }
+        }
+
+        $this->assertTrue($hasAcceptLanguage, 'Accept-Language should be present by default.');
+
+        foreach ($operation->getResponses() as $response) {
+            $this->assertArrayHasKey('Content-Language', $response->getHeaders());
+        }
     }
 }

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/ResponseGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/ResponseGeneratorTest.php
@@ -6,6 +6,7 @@ namespace apivalk\apivalk\Tests\PhpUnit\Documentation\OpenAPI\Generator;
 
 use PHPUnit\Framework\TestCase;
 use apivalk\apivalk\Documentation\OpenAPI\Generator\ResponseGenerator;
+use apivalk\apivalk\Documentation\OpenAPI\Object\HeaderObject;
 use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
 
 class ResponseGeneratorTest extends TestCase
@@ -17,10 +18,32 @@ class ResponseGeneratorTest extends TestCase
         $doc->method('getDescription')->willReturn('Response desc');
         $doc->method('getProperties')->willReturn([]);
         $doc->method('hasResponsePagination')->willReturn(false);
-        
+
         $response = $generator->generate(200, $doc);
-        
+
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('Response desc', $response->getDescription());
+        $this->assertEmpty($response->getHeaders());
+    }
+
+    public function testResponseGeneratorWithHeaders(): void
+    {
+        $generator = new ResponseGenerator();
+        $doc = $this->createMock(ApivalkResponseDocumentation::class);
+        $doc->method('getDescription')->willReturn('Response with headers');
+        $doc->method('getProperties')->willReturn([]);
+        $doc->method('hasResponsePagination')->willReturn(false);
+
+        $headers = [
+            'Content-Language' => new HeaderObject('The locale of the response content.'),
+            'X-RateLimit-Limit' => new HeaderObject('Max requests allowed.'),
+        ];
+
+        $response = $generator->generate(200, $doc, null, $headers);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertCount(2, $response->getHeaders());
+        $this->assertArrayHasKey('Content-Language', $response->getHeaders());
+        $this->assertArrayHasKey('X-RateLimit-Limit', $response->getHeaders());
     }
 }

--- a/Tests/PhpUnit/Documentation/OpenAPI/Object/ResponseObjectTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Object/ResponseObjectTest.php
@@ -19,23 +19,27 @@ class ResponseObjectTest extends TestCase
                 'schema' => ['type' => 'object']
             ]
         ]);
-        
-        $header = $this->createMock(HeaderObject::class);
-        
+
+        $header = new HeaderObject('Test header description');
+
         $response = new ResponseObject(
             200,
             $mediaType,
             'OK',
             ['X-Test' => $header]
         );
-        
+
         $result = $response->toArray();
 
         $this->assertArrayHasKey(200, $result);
         $this->assertEquals('OK', $result[200]['description']);
         $this->assertArrayHasKey('X-Test', $result[200]['headers']);
+        $this->assertEquals(
+            ['description' => 'Test header description', 'required' => false],
+            $result[200]['headers']['X-Test']
+        );
         $this->assertArrayHasKey('content', $result[200]);
-        
+
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('OK', $response->getDescription());
         $this->assertSame($mediaType, $response->getContent());

--- a/docs/documentation/openapi-generator.mdx
+++ b/docs/documentation/openapi-generator.mdx
@@ -165,6 +165,42 @@ $generator = new OpenAPIGenerator(
 );
 ```
 
+## Automated Headers
+
+### Locale Headers (Accept-Language / Content-Language)
+
+By default, the generator documents localization headers on every operation:
+
+- **Request**: An optional `Accept-Language` header parameter (BCP 47 language tag).
+- **Response**: A `Content-Language` header on every response, indicating the resolved locale.
+
+This matches the runtime behavior of the `MiddlewareStack`, which always resolves the locale from the `Accept-Language` header and returns `Content-Language`.
+
+You can disable locale header documentation by passing `false` for the `$documentLocaleHeaders` parameter:
+
+```php
+$generator = new OpenAPIGenerator(
+    $apivalk,
+    $info,
+    [new ServerObject('http://localhost:8080', 'My local server')],
+    $components,
+    false // disable locale headers in the OpenAPI spec
+);
+```
+
+### Rate Limit Headers
+
+When a route has a rate limit defined (via `Route::rateLimit()`), the generator automatically documents the following response headers on every response for that operation:
+
+| Header | Description |
+|---|---|
+| `X-RateLimit-Limit` | Maximum requests allowed in the time window. |
+| `X-RateLimit-Remaining` | Requests remaining in the current window. |
+| `X-RateLimit-Reset` | UTC epoch timestamp when the window resets. |
+| `Retry-After` | UTC epoch timestamp after which the client may retry (present only when the limit is exceeded). |
+
+The header descriptions include the configured window duration from the `RateLimitInterface`. Routes without a rate limit will not have these headers in their documentation.
+
 ## Automated Pagination Envelope
 
 If a response documentation has `setHasResponsePagination(true)`, the generator automatically wraps the properties in a standard pagination envelope containing `data`, `total`, `page`, `limit`, etc.

--- a/docs/http/filtering.mdx
+++ b/docs/http/filtering.mdx
@@ -51,7 +51,7 @@ Apivalk provides specialized filter classes for different property types. Each f
 
 Benefits:
 -   **OpenAPI Accuracy**: The documentation reflects the correct data type (e.g., `number`, `integer`, `string`).
--   **Automatic Casting**: `getValue()` returns the correct PHP type (`string`, `int`, `float`, or `\DateTime`).
+-   **Automatic Casting**: `getValue()` returns the correct PHP type (`string`, `int`, `float`, or `\DateTime`), or `null` if the filter was not provided by the client.
 -   **Detailed Documentation**: You can add custom descriptions, examples, and constraints to your filters.
 
 ```php

--- a/docs/open-api-best-practices/06-localization-i18n.mdx
+++ b/docs/open-api-best-practices/06-localization-i18n.mdx
@@ -57,3 +57,7 @@ Must not be localized:
 - Error keys or error codes
 - Enum values
 - IDs, UUIDs, technical identifiers
+
+### OpenAPI documentation
+
+The OpenAPI generator automatically documents an optional `Accept-Language` request header parameter and a `Content-Language` response header on every operation. This can be disabled by passing `documentLocaleHeaders: false` to the `OpenAPIGenerator` constructor.

--- a/docs/routing/rate-limit.mdx
+++ b/docs/routing/rate-limit.mdx
@@ -57,6 +57,10 @@ class UserRateLimit implements RateLimitInterface
 }
 ```
 
+## OpenAPI Documentation
+
+When a route has a rate limit defined, the OpenAPI generator automatically documents `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, and `Retry-After` response headers on every response for that operation. No manual configuration is needed.
+
 ## Enforcement
 
 Rate limits defined on routes are not enforced automatically. You must add the `RateLimitMiddleware` to your middleware stack to enable enforcement.


### PR DESCRIPTION
- Automatically include `Accept-Language` and `Content-Language` headers in operation documentation.
- Add rate limit headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `Retry-After`) for routes with rate limits.
- Provide an option to disable locale header documentation via constructor.
- Update tests to cover locale and rate limit header behavior.