### PR TITLE
refactor: rename edit mode to update mode and adjust tests/documentat…

### DIFF
--- a/Documentation/Property/AbstractPropertyCollection.php
+++ b/Documentation/Property/AbstractPropertyCollection.php
@@ -9,7 +9,7 @@ abstract class AbstractPropertyCollection implements \IteratorAggregate
     /** @var string */
     public const MODE_LIST = 'list';
     /** @var string */
-    public const MODE_EDIT = 'edit';
+    public const MODE_UPDATE = 'update';
     /** @var string */
     public const MODE_VIEW = 'view';
     /** @var string */

--- a/Tests/PhpUnit/Middleware/SecurityMiddlewareTest.php
+++ b/Tests/PhpUnit/Middleware/SecurityMiddlewareTest.php
@@ -134,12 +134,12 @@ class SecurityMiddlewareTest extends TestCase
 
     public function testMissingPermission_returnsForbidden_forAuthenticated(): void
     {
-        $routeAuthorization = new RouteAuthorization('Bearer', [], ['asset:edit']);
+        $routeAuthorization = new RouteAuthorization('Bearer', [], ['asset:update']);
         $route = $this->mockRoute($routeAuthorization);
 
         $identity = $this->createMock(AbstractAuthIdentity::class);
         $identity->method('isAuthenticated')->willReturn(true);
-        $identity->method('isPermissionGranted')->with('asset:edit')->willReturn(false);
+        $identity->method('isPermissionGranted')->with('asset:update')->willReturn(false);
 
         $request = $this->createMock(ApivalkRequestInterface::class);
         $request->method('getAuthIdentity')->willReturn($identity);
@@ -157,7 +157,7 @@ class SecurityMiddlewareTest extends TestCase
 
     public function testMissingPermission_returnsUnauthorized_forGuest(): void
     {
-        $routeAuthorization = new RouteAuthorization('Bearer', [], ['asset:edit']);
+        $routeAuthorization = new RouteAuthorization('Bearer', [], ['asset:update']);
         $route = $this->mockRoute($routeAuthorization);
 
         $request = $this->createMock(ApivalkRequestInterface::class);

--- a/Tests/PhpUnit/Router/RouteJsonSerializerTest.php
+++ b/Tests/PhpUnit/Router/RouteJsonSerializerTest.php
@@ -102,8 +102,8 @@ class RouteJsonSerializerTest extends TestCase
         $property->setMinLength(2)->setMaxLength(100)->setPattern('^[a-zA-Z]+$')->setDefault('John');
 
         $route = $this->createRouteWithFilters([
-            StringFilter::equals($property),
-        ]);
+                                                   StringFilter::equals($property),
+                                               ]);
 
         $deserialized = $this->serializeAndDeserialize($route);
 
@@ -129,8 +129,8 @@ class RouteJsonSerializerTest extends TestCase
         $property->setDefault('active');
 
         $route = $this->createRouteWithFilters([
-            EnumFilter::equals($property),
-        ]);
+                                                   EnumFilter::equals($property),
+                                               ]);
 
         $deserialized = $this->serializeAndDeserialize($route);
 
@@ -153,8 +153,8 @@ class RouteJsonSerializerTest extends TestCase
         $property->setDefault('2000-01-01');
 
         $route = $this->createRouteWithFilters([
-            DateFilter::equals($property),
-        ]);
+                                                   DateFilter::equals($property),
+                                               ]);
 
         $deserialized = $this->serializeAndDeserialize($route);
 
@@ -176,8 +176,8 @@ class RouteJsonSerializerTest extends TestCase
         $property->setDefault('2024-01-01T00:00:00Z');
 
         $route = $this->createRouteWithFilters([
-            DateTimeFilter::equals($property),
-        ]);
+                                                   DateTimeFilter::equals($property),
+                                               ]);
 
         $deserialized = $this->serializeAndDeserialize($route);
 
@@ -199,8 +199,8 @@ class RouteJsonSerializerTest extends TestCase
         $property->setMinLength(4)->setMaxLength(1024)->setPattern('^[A-Za-z0-9+/=]+$')->setDefault('dGVzdA==');
 
         $route = $this->createRouteWithFilters([
-            ByteFilter::equals($property),
-        ]);
+                                                   ByteFilter::equals($property),
+                                               ]);
 
         $deserialized = $this->serializeAndDeserialize($route);
 
@@ -225,8 +225,8 @@ class RouteJsonSerializerTest extends TestCase
         $property->setMinLength(1)->setMaxLength(2048)->setPattern('^.+$')->setDefault('data');
 
         $route = $this->createRouteWithFilters([
-            BinaryFilter::equals($property),
-        ]);
+                                                   BinaryFilter::equals($property),
+                                               ]);
 
         $deserialized = $this->serializeAndDeserialize($route);
 
@@ -254,8 +254,8 @@ class RouteJsonSerializerTest extends TestCase
             ->setIsExclusiveMaximum(false);
 
         $route = $this->createRouteWithFilters([
-            IntegerFilter::greaterThan($property),
-        ]);
+                                                   IntegerFilter::greaterThan($property),
+                                               ]);
 
         $deserialized = $this->serializeAndDeserialize($route);
 
@@ -284,8 +284,8 @@ class RouteJsonSerializerTest extends TestCase
             ->setIsExclusiveMaximum(true);
 
         $route = $this->createRouteWithFilters([
-            FloatFilter::lessThan($property),
-        ]);
+                                                   FloatFilter::lessThan($property),
+                                               ]);
 
         $deserialized = $this->serializeAndDeserialize($route);
 
@@ -299,8 +299,8 @@ class RouteJsonSerializerTest extends TestCase
         $this->assertInstanceOf(FloatProperty::class, $restoredProperty);
         $this->assertEquals('price', $restoredProperty->getPropertyName());
         $this->assertEquals('float', $restoredProperty->getFormat());
-        $this->assertEquals(0.01, $restoredProperty->getMinimumValue(), '', 0.001);
-        $this->assertEquals(9999.99, $restoredProperty->getMaximumValue(), '', 0.001);
+        $this->assertEqualsWithDelta(0.01, $restoredProperty->getMinimumValue(), 0.001);
+        $this->assertEqualsWithDelta(9999.99, $restoredProperty->getMaximumValue(), 0.001);
         $this->assertFalse($restoredProperty->isExclusiveMinimum());
         $this->assertTrue($restoredProperty->isExclusiveMaximum());
     }

--- a/docs/documentation/property-collection.mdx
+++ b/docs/documentation/property-collection.mdx
@@ -9,13 +9,13 @@ A `PropertyCollection` is an iterable container for `AbstractProperty` instances
 
 ## Modes
 
-One of the most powerful features of property collections is the concept of **Modes**. Often, the data you send to an API (CREATE/EDIT) is slightly different from the data you receive (VIEW).
+One of the most powerful features of property collections is the concept of **Modes**. Often, the data you send to an API (CREATE/UPDATE) is slightly different from the data you receive (VIEW).
 
 For example, a `User` object might:
 
 * **VIEW**: Include `id`, `email`, `createdAt`, and `updatedAt`.
 * **CREATE**: Include `email` and `password`, but NOT `id` or timestamps.
-* **EDIT**: Include `email`, but NOT `password` or `id`.
+* **UPDATE**: Include `email`, but NOT `password` or `id`.
 
 By passing a `mode` to the collection's constructor, you can conditionally add properties.
 
@@ -26,7 +26,7 @@ The `AbstractPropertyCollection` class provides the following constants:
 * `MODE_LIST`: Used for data returned in list responses.
 * `MODE_VIEW`: Used for data returned in responses.
 * `MODE_CREATE`: Used for data sent when creating a resource.
-* `MODE_EDIT`: Used for data sent when updating a resource.
+* `MODE_UPDATE`: Used for data sent when updating a resource.
 * `MODE_DELETE`: Used for data related to deletion (rarely used for properties).
 
 ## Implementing a Property Collection


### PR DESCRIPTION
…ion accordingly

- Replace `MODE_EDIT` with `MODE_UPDATE` across codebase.
- Update `AbstractPropertyCollection` class and related documentation.
- Adjust tests to reflect permission change from `asset:edit` to `asset:update`.
- Minor code formatting improvements in `RouteJsonSerializerTest`.

Issue: #97