### PR TITLE
docs: refine security levels and add localization configuration examples

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -53,6 +53,32 @@ $config = new ApivalkConfiguration(
 
 When a container is provided, Apivalk will use it to instantiate your controllers. If no container is provided, it will simply use `new $controllerClass()`.
 
+## Localization
+
+You can configure locale support by passing a `LocalizationConfiguration` to `ApivalkConfiguration`. This enables automatic locale resolution from the `Accept-Language` header on every request.
+
+```php
+use apivalk\apivalk\ApivalkConfiguration;
+use apivalk\apivalk\Http\i18n\Locale;
+use apivalk\apivalk\Http\i18n\LocalizationConfiguration;
+
+$localization = new LocalizationConfiguration(Locale::en());
+$localization->addSupportedLocale(Locale::en());
+$localization->addSupportedLocale(Locale::de());
+$localization->addSupportedLocale(Locale::deDe());
+
+$config = new ApivalkConfiguration(
+    $router,
+    null,              // renderer
+    null,              // exception handler
+    null,              // container
+    null,              // logger
+    $localization      // localization configuration
+);
+```
+
+If no `LocalizationConfiguration` is provided, Apivalk defaults to English (`en`). See the [Localization](/http/localization) guide for full details.
+
 ## Middleware Stack
 
 You can register global middlewares via the configuration.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -53,7 +53,8 @@
               "http/response",
               "http/pagination",
               "http/filtering",
-              "http/sorting"
+              "http/sorting",
+              "http/localization"
             ]
           },
           {

--- a/docs/http/localization.mdx
+++ b/docs/http/localization.mdx
@@ -1,0 +1,176 @@
+---
+title: "Localization"
+description: "Apivalk provides built-in locale resolution from the Accept-Language header, with BCP 47 compliant locale handling."
+---
+
+Apivalk includes a localization system that resolves the client's preferred language from the `Accept-Language` HTTP header and makes it available throughout the request lifecycle.
+
+## Configuration
+
+Set up localization via `LocalizationConfiguration` when bootstrapping your application. Pass it as the last argument to `ApivalkConfiguration`.
+
+```php
+use apivalk\apivalk\ApivalkConfiguration;
+use apivalk\apivalk\Http\i18n\Locale;
+use apivalk\apivalk\Http\i18n\LocalizationConfiguration;
+
+// 1. Create localization config with a default locale
+$localization = new LocalizationConfiguration(Locale::en());
+
+// 2. Add supported locales
+$localization->addSupportedLocale(Locale::en());
+$localization->addSupportedLocale(Locale::de());
+$localization->addSupportedLocale(Locale::deDe());
+$localization->addSupportedLocale(Locale::enUs());
+$localization->addSupportedLocale(Locale::fr());
+
+// 3. Pass to ApivalkConfiguration
+$configuration = new ApivalkConfiguration(
+    $router,
+    null,                    // renderer
+    $exceptionHandler,       // exception handler
+    $container,              // PSR-11 container
+    $logger,                 // PSR-3 logger
+    $localization            // localization configuration
+);
+```
+
+If no `LocalizationConfiguration` is provided, Apivalk defaults to English (`en`).
+
+## The Locale Object
+
+The `Locale` class is a BCP 47 compliant value object. It normalizes locale tags automatically (e.g., `de_DE` becomes `de-DE`).
+
+```php
+use apivalk\apivalk\Http\i18n\Locale;
+
+// Using built-in factory methods
+$locale = Locale::de();      // "de"
+$locale = Locale::deDe();    // "de-DE"
+$locale = Locale::enGb();    // "en-GB"
+
+// Using the constructor directly
+$locale = new Locale('fr-CA');
+
+// Accessing parts
+$locale->getTag();           // "fr-CA"
+$locale->getLanguage();      // "fr" (ISO 639-1, lowercase)
+$locale->getRegion();        // "CA" (ISO 3166-1, uppercase)
+```
+
+### Available Factory Methods
+
+| Method | Tag |
+|---|---|
+| `Locale::en()` | `en` |
+| `Locale::de()` | `de` |
+| `Locale::fr()` | `fr` |
+| `Locale::enUs()` | `en-US` |
+| `Locale::enGb()` | `en-GB` |
+| `Locale::deDe()` | `de-DE` |
+| `Locale::deAt()` | `de-AT` |
+| `Locale::deCh()` | `de-CH` |
+
+For other locales, use the constructor: `new Locale('ja-JP')`.
+
+## Locale Resolution
+
+The `LocaleResolver` automatically resolves the locale from the `Accept-Language` HTTP header. The resolution follows this order:
+
+1. Parse the `Accept-Language` header and sort entries by quality weight (`q` value), then by order of appearance.
+2. For each entry, attempt to match against supported locales:
+   - First try an exact match (e.g., `de-DE` matches `de-DE`).
+   - Then try a language-only fallback (e.g., `de-DE` matches `de`).
+3. If no match is found, fall back to the default locale.
+
+### Example
+
+Given supported locales `en`, `de`, `de-DE` and default `en`:
+
+```http
+Accept-Language: de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7
+```
+
+Resolution: `de-DE` (exact match on the first entry).
+
+```http
+Accept-Language: fr-FR,fr;q=0.9
+```
+
+Resolution: `en` (no match found, falls back to default).
+
+## Accessing the Locale in Controllers
+
+The resolved locale is available on the request object:
+
+```php
+class MyController extends AbstractApivalkController
+{
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        $locale = $request->getLocale();
+
+        $message = $locale->getLanguage() === 'de'
+            ? 'Hallo Welt'
+            : 'Hello World';
+
+        return new OkApivalkResponse(['message' => $message]);
+    }
+}
+```
+
+## HTTP Headers
+
+### Request: Accept-Language
+
+Clients send their preferred language(s) via the standard `Accept-Language` header using BCP 47 language tags:
+
+```http
+Accept-Language: de-DE
+Accept-Language: de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7
+Accept-Language: en
+```
+
+### Response: Content-Language
+
+Apivalk returns the resolved locale via the `Content-Language` response header:
+
+```http
+Content-Language: de-DE
+```
+
+## OpenAPI Documentation
+
+The [OpenAPI Generator](/documentation/openapi-generator) automatically documents locale headers on every operation:
+
+- **Request**: An optional `Accept-Language` header parameter (BCP 47 language tag).
+- **Response**: A `Content-Language` header on every response, indicating the resolved locale.
+
+This can be disabled by passing `false` for the `$documentLocaleHeaders` parameter:
+
+```php
+$generator = new OpenAPIGenerator(
+    $apivalk,
+    $info,
+    [new ServerObject('http://localhost:8080', 'My local server')],
+    $components,
+    false // disable locale headers in the OpenAPI spec
+);
+```
+
+## What to Localize
+
+Localize human-readable message strings only:
+
+- `message` fields in success and error responses
+- Validation error messages
+- Human-readable descriptions
+
+Do **not** localize:
+
+- Field names or JSON keys
+- Error codes or error keys
+- Enum values
+- IDs, UUIDs, or technical identifiers
+
+See the [API Standards: Localization](/open-api-best-practices/06-localization-i18n) guide for more best practices.

--- a/docs/middleware/security.mdx
+++ b/docs/middleware/security.mdx
@@ -20,7 +20,26 @@ The current [Identity](/security/identity) must possess **all** the required sco
 
 ## Route Examples
 
-### Private Route (Authorization Required)
+### Public Route (No Authorization)
+A route that is accessible by anyone. When no `RouteAuthorization` is defined, the middleware passes the request through without any checks.
+
+```php
+$route = Route::get('/about')->description('About page');
+```
+
+### Authenticated Route (Any Valid Token)
+A route that requires the user to be authenticated but does not enforce any specific scopes or permissions. Pass only the security scheme name to `RouteAuthorization`. The middleware will return `401 Unauthorized` for anonymous users but allow any authenticated identity through.
+
+```php
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Security\RouteAuthorization;
+
+$route = Route::get('/me/profile')
+    ->description('Get my profile')
+    ->routeAuthorization(new RouteAuthorization('BearerAuth'));
+```
+
+### Scoped Route (Specific Scopes and Permissions)
 A route that requires a logged-in user with specific scopes and permissions.
 
 ```php
@@ -28,20 +47,14 @@ use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 
 $route = Route::get('/admin/dashboard')
-                ->description('Admin Dashboard')
-                ->routeAuthorization(new RouteAuthorization('BearerAuth', ['admin'], ['admin:dashboard:read']))
-
+    ->description('Admin Dashboard')
+    ->routeAuthorization(
+        new RouteAuthorization('BearerAuth', ['admin'], ['admin:dashboard:read'])
+    );
 ```
 
-### Public Route (No Authorization)
-A route that is accessible by anyone.
-
-```php
-$route = Route::get('/about')->description('About page');
-```
-
-### Optional Security (Public with Authorization)
-Currently, optional security (where a route is public but can optionally take a token) is handled by not defining a `RouteAuthorization` on the route, or by custom middleware logic. If a `RouteAuthorization` is present, it will be enforced.
+### Optional Security (Public with Identity)
+If you want a route to be public but also optionally use identity information when a token is provided, leave `RouteAuthorization` as `null`. The `AuthenticationMiddleware` will still populate the identity if a valid token is present — you can check `$request->getAuthIdentity()->isAuthenticated()` in your controller to adapt behavior.
 
 ## Status Codes
 

--- a/docs/routing/route.mdx
+++ b/docs/routing/route.mdx
@@ -31,23 +31,45 @@ These parameters are automatically identified and converted into capture groups 
 
 Security requirements are defined on a per-route basis using the `RouteAuthorization` object. This allows you to specify which authentication scheme (e.g., Bearer, OAuth2) is required and what granular scopes and permissions the user must have.
 
-### Basic Security Example
+### Public Route
 
-To make a route private, you add a `RouteAuthorization` to the route's constructor:
+If no `RouteAuthorization` is provided (default), the route is fully public. Anyone can access it.
 
 ```php
-use apivalk\apivalk\Router\Route;
+Route::get('/about')->description('About page');
+```
+
+### Authenticated Route (No Specific Scopes)
+
+To require authentication without enforcing specific scopes or permissions, pass only the security scheme name. The `SecurityMiddleware` will reject anonymous users with a `401 Unauthorized` but allow any authenticated identity through.
+
+```php
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Security\RouteAuthorization;
+
+Route::get('/me/profile')
+    ->description('Get my profile')
+    ->routeAuthorization(new RouteAuthorization('BearerAuth'));
+```
+
+### Scoped Route (Specific Scopes and Permissions)
+
+To require both authentication and specific scopes/permissions:
+
+```php
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 
 Route::post('/orders')
-       ->description('Create order')
-       ->routeAuthorization(new RouteAuthorization('apiKey', ['accounting:orders'], ['accounting:orders:create']));
+    ->description('Create order')
+    ->routeAuthorization(
+        new RouteAuthorization('apiKey', ['accounting:orders'], ['accounting:orders:create'])
+    );
 ```
 
-### Public and Optional Security
+### Optional Security (Public with Identity)
 
-* **Public Route**: If no security requirements are provided (default), the route is public.
-* **Optional Security**: Currently, if you want a route to be public but also optionally use identity information if provided, you leave `RouteAuthorization` as `null`. The `SecurityMiddleware` only enforces authorization if a `RouteAuthorization` is defined.
+If you want a route to be public but optionally use identity information when a token is provided, leave `RouteAuthorization` as `null`. The `AuthenticationMiddleware` will still populate the identity if a valid token is present, so you can check `$request->getAuthIdentity()->isAuthenticated()` in your controller.
 
 For more details on how the security system works, check the [Security Overview](/security/index).
 

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -21,13 +21,51 @@ The security layer consists of four main pillars:
 3.  **Authorization**: The `SecurityMiddleware` compares the `AuthIdentity`'s granted scopes and permissions against the `RouteAuthorization` defined in the `Route`.
 4.  **Controller**: If authorized, the controller receives the request and can access the identity via `$request->getAuthIdentity()`.
 
-## Quick Example: Private Route
+## Route Security Levels
+
+Apivalk supports three levels of route security. The level is determined by whether a `RouteAuthorization` is present and what scopes/permissions it requires.
+
+### 1. Public Route (No Authentication)
+
+A route without a `RouteAuthorization` is fully public. Anyone can access it, including anonymous users. The `SecurityMiddleware` passes the request through without any checks.
+
+```php
+use apivalk\apivalk\Router\Route\Route;
+
+$route = Route::get('/about')->description('About page');
+```
+
+### 2. Authenticated Route (No Specific Scopes)
+
+A route that requires the user to be authenticated but does not require any specific scopes or permissions. This is useful for endpoints like "get my profile" where you just need to know the user is logged in.
+
+Pass a `RouteAuthorization` with only the security scheme name and omit (or pass empty arrays for) scopes and permissions. The `SecurityMiddleware` will still enforce that the user is authenticated (not a `GuestAuthIdentity`), returning a `401 Unauthorized` for anonymous requests.
 
 ```php
 use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 
-$route = Route::get('/admin/settings')->description('Admin Settings')->routeAuthorization(new RouteAuthorization('BearerAuth', ['admin:settings'], ['admin:settings:read']))
+$route = Route::get('/me/profile')
+    ->description('Get my profile')
+    ->routeAuthorization(new RouteAuthorization('BearerAuth'));
+```
+
+### 3. Scoped Route (Specific Scopes and/or Permissions)
+
+A route that requires the user to be authenticated **and** possess specific scopes and/or permissions. The `SecurityMiddleware` checks each required scope and permission against the user's identity:
+
+- Missing scope/permission + authenticated user = `403 Forbidden`
+- Missing scope/permission + anonymous user = `401 Unauthorized`
+
+```php
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Security\RouteAuthorization;
+
+$route = Route::get('/admin/settings')
+    ->description('Admin Settings')
+    ->routeAuthorization(
+        new RouteAuthorization('BearerAuth', ['admin:settings'], ['admin:settings:read'])
+    );
 ```
 
 In this example, the route requires a security scheme named `BearerAuth` with the `admin:settings` scope and `admin:settings:read` permission.
@@ -85,18 +123,28 @@ use apivalk\apivalk\Middleware\SecurityMiddleware;
 $configuration->addMiddleware(new SecurityMiddleware());
 ```
 
-### Full Example: Public and Private Routes
+### Full Example: All Three Security Levels
 
 Here is how you would define routes with different security requirements:
 
 ```php
-use apivalk\apivalk\Router\Route\Route;use apivalk\apivalk\Security\RouteAuthorization;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Security\RouteAuthorization;
 
-// PRIVATE: Requires 'write:orders' scope
-$privateRoute = Route::post('/orders')->description('Create order')->routeAuthorization(new RouteAuthorization('BearerAuth', ['order'], ['order:create']))
-
-// PUBLIC: No security requirements
+// PUBLIC: No security requirements — anyone can access
 $publicRoute = Route::get('/about')->description('About us');
+
+// AUTHENTICATED: Requires any valid token, no specific scopes
+$authenticatedRoute = Route::get('/me/profile')
+    ->description('Get my profile')
+    ->routeAuthorization(new RouteAuthorization('BearerAuth'));
+
+// SCOPED: Requires valid token with specific scopes and permissions
+$scopedRoute = Route::post('/orders')
+    ->description('Create order')
+    ->routeAuthorization(
+        new RouteAuthorization('BearerAuth', ['order'], ['order:create'])
+    );
 ```
 
 For more details on custom logic, check the [Custom Authentication](/middleware/authentication#custom-authentication-logic) section.


### PR DESCRIPTION
- Expand documentation on route security levels: Public, Authenticated, and Scoped routes.
- Update examples with consistent code snippets and explanations for each level.
- Introduce `LocalizationConfiguration` in configuration docs with usage examples.
- Adjust related sections for clarity and improved structure.
- Update `docs.json` to register the new localization guide.

Issue: #72