### PR TITLE
feat(resource): add resource controllers, responses, and documentation

### DIFF
--- a/Documentation/ApivalkRequestDocumentation.php
+++ b/Documentation/ApivalkRequestDocumentation.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Documentation;
 
 use apivalk\apivalk\Documentation\Property\AbstractProperty;
-use apivalk\apivalk\Documentation\Property\IntegerProperty;
 
 class ApivalkRequestDocumentation
 {
@@ -15,6 +14,8 @@ class ApivalkRequestDocumentation
     private $queryProperties = [];
     /** @var array<string, AbstractProperty> */
     private $pathProperties = [];
+    /** @var string[] */
+    private $availableSortFields = [];
 
     public function addBodyProperty(AbstractProperty $property): void
     {
@@ -46,12 +47,14 @@ class ApivalkRequestDocumentation
         return $this->pathProperties;
     }
 
-    public function addPaginationQueryProperties(): void
+    public function addAvailableSortField(string $field): void
     {
-        $pageProperty = new IntegerProperty('page', 'Page', IntegerProperty::FORMAT_INT32);
-        $pageProperty->setIsRequired(false);
-        $pageProperty->setExample('1');
+        $this->availableSortFields[] = $field;
+    }
 
-        $this->addQueryProperty($pageProperty);
+    /** @return string[] */
+    public function getAvailableSortFields(): array
+    {
+        return $this->availableSortFields;
     }
 }

--- a/Documentation/ApivalkResponseDocumentation.php
+++ b/Documentation/ApivalkResponseDocumentation.php
@@ -12,17 +12,10 @@ class ApivalkResponseDocumentation
     private $description;
     /** @var AbstractProperty[] */
     private $properties = [];
-    /** @var bool */
-    private $hasResponsePagination = false;
 
     public function addProperty(AbstractProperty $property): void
     {
         $this->properties[] = $property->init();
-    }
-
-    public function setHasResponsePagination(bool $hasResponsePagination): void
-    {
-        $this->hasResponsePagination = $hasResponsePagination;
     }
 
     public function getProperties(): array
@@ -33,11 +26,6 @@ class ApivalkResponseDocumentation
     public function getDescription(): ?string
     {
         return $this->description;
-    }
-
-    public function hasResponsePagination(): bool
-    {
-        return $this->hasResponsePagination;
     }
 
     public function setDescription(string $description): void

--- a/Documentation/DocBlock/DocBlockGenerator.php
+++ b/Documentation/DocBlock/DocBlockGenerator.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Documentation\DocBlock;
 
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
+use apivalk\apivalk\Http\Controller\Resource\AbstractListResourceController;
+use apivalk\apivalk\Http\Controller\Resource\AbstractResourceController;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Request\Resource\ResourceRequest;
+use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Util\ClassLocator;
 
 class DocBlockGenerator
@@ -19,6 +23,9 @@ class DocBlockGenerator
 
         $classLocator = new ClassLocator($apiDirectory, $namespace);
         $generator = new DocBlockRequestGenerator();
+        $resourceGenerator = new DocBlockResourceGenerator();
+        $resourceRequestGenerator = new DocBlockResourceRequestGenerator();
+        $processedResources = [];
 
         foreach ($classLocator->find() as $class) {
             $className = $class['className'];
@@ -29,32 +36,123 @@ class DocBlockGenerator
 
             try {
                 /** @var class-string<AbstractApivalkController> $className */
-                $requestClass = $className::getRequestClass();
-                $route = $className::getRoute();
 
-                if (!is_subclass_of($requestClass, ApivalkRequestInterface::class)) {
+                if (is_subclass_of($className, AbstractResourceController::class)) {
+                    /** @var class-string<AbstractResourceController<AbstractResource>> $className */
+                    $this->processResourceController($className, $processedResources, $resourceGenerator, $resourceRequestGenerator);
                     continue;
                 }
 
-                $reflection = new \ReflectionClass($requestClass);
-                $filePath = $reflection->getFileName();
-
-                if (!$filePath) {
-                    continue;
-                }
-
-                /** @var AbstractApivalkRequest $request */
-                $request = new $requestClass();
-
-                $docBlockRequest = $generator->generate($request, $route);
-
-                $this->rewriteRequestFileWithDocblocks($filePath, $docBlockRequest);
-
-                echo "✔ DocBlocks & Shapes generated for {$requestClass} (from {$className})\n";
+                $this->processRegularController($className, $generator);
             } catch (\Throwable $e) {
                 echo "⚠ Error in controller {$className}: {$e->getMessage()}\n";
             }
         }
+    }
+
+    /**
+     * @param class-string<AbstractResourceController<AbstractResource>> $className
+     * @param array<string, bool>                                        $processedResources
+     */
+    private function processResourceController(
+        string $className,
+        array &$processedResources,
+        DocBlockResourceGenerator $resourceGenerator,
+        DocBlockResourceRequestGenerator $resourceRequestGenerator
+    ): void {
+        $resourceClass = $className::getResourceClass();
+
+        if (!isset($processedResources[$resourceClass])) {
+            $processedResources[$resourceClass] = true;
+
+            /** @var AbstractResource $resource */
+            $resource = new $resourceClass();
+            $docBlockResource = $resourceGenerator->generate($resource);
+
+            $resourceReflection = new \ReflectionClass($resourceClass);
+            $resourceFilePath = $resourceReflection->getFileName();
+
+            if ($resourceFilePath) {
+                $this->rewriteResourceFileWithDocblocks($resourceFilePath, $docBlockResource);
+                echo "✔ Resource @property docblocks generated for {$resourceClass}\n";
+            }
+        }
+
+        if (!is_subclass_of($className, AbstractListResourceController::class)) {
+            return;
+        }
+
+        /** @var class-string<AbstractListResourceController<AbstractResource>> $className */
+        $controllerReflection = new \ReflectionClass($className);
+        $controllerFilePath = $controllerReflection->getFileName();
+
+        if (!$controllerFilePath) {
+            return;
+        }
+
+        $controllerNamespace = $controllerReflection->getNamespaceName();
+        $resourceBaseNamespace = substr($controllerNamespace, 0, strrpos($controllerNamespace, '\\'));
+        $resourceBaseDir = dirname(dirname($controllerFilePath));
+
+        $docBlockResourceRequest = $resourceRequestGenerator->generate($className);
+
+        $resource = $className::getEmptyResource();
+        $requestClassName = \ucfirst($resource->getName()) . 'ListRequest';
+        $requestNamespace = $resourceBaseNamespace . '\\Request';
+        $requestFilePath = $resourceBaseDir . '/Request/' . $requestClassName . '.php';
+
+        $this->rewriteResourceRequestFileWithDocblocks(
+            $requestFilePath,
+            $requestNamespace,
+            $requestClassName,
+            $docBlockResourceRequest
+        );
+
+        echo "✔ Resource request shapes generated for {$requestClassName} (from {$className})\n";
+    }
+
+    /**
+     * @param class-string<AbstractApivalkController> $className
+     */
+    private function processRegularController(string $className, DocBlockRequestGenerator $generator): void
+    {
+        $requestClass = $className::getRequestClass();
+        $route = $className::getRoute();
+
+        if (!is_subclass_of($requestClass, ApivalkRequestInterface::class)) {
+            return;
+        }
+
+        $reflection = new \ReflectionClass($requestClass);
+        $filePath = $reflection->getFileName();
+
+        if (!$filePath) {
+            return;
+        }
+
+        /** @var AbstractApivalkRequest $request */
+        $request = new $requestClass();
+
+        if ($request instanceof ResourceRequest) {
+            return;
+        }
+
+        $docBlockRequest = $generator->generate($request, $route);
+
+        $this->rewriteRequestFileWithDocblocks($filePath, $docBlockRequest);
+
+        echo "✔ DocBlocks & Shapes generated for {$requestClass} (from {$className})\n";
+    }
+
+    private function rewriteResourceFileWithDocblocks(
+        string $filePath,
+        DocBlockResource $docBlockResource
+    ): void {
+        $this->rewriteClassDocblock(
+            $filePath,
+            $docBlockResource->getResourceDocBlock(),
+            true
+        );
     }
 
     private function rewriteRequestFileWithDocblocks(
@@ -70,28 +168,9 @@ class DocBlockGenerator
             throw new \RuntimeException("Unable to detect namespace in $filePath");
         }
 
-        $requestNamespace = trim($namespaceMatch[1]);
-        $shapeNamespace = $docBlockRequest->getShapeNamespace($requestNamespace);
+        $shapeNamespace = $docBlockRequest->getShapeNamespace(trim($namespaceMatch[1]));
 
-        if (!preg_match('/^\s*class\s+([A-Za-z0-9_]+)/m', $content, $matches, PREG_OFFSET_CAPTURE)) {
-            throw new \RuntimeException("Could not find class declaration in $filePath");
-        }
-
-        $classOffset = (int)$matches[0][1];
-
-        $beforeClass = substr($content, 0, $classOffset);
-        $afterClass = substr($content, $classOffset);
-
-        $beforeClass = preg_replace('/\/\*\*(?:[^*]|\*(?!\/))*\*\//s', '', $beforeClass);
-        $beforeClass = rtrim($beforeClass) . "\n\n";
-
-        $requestDoc = $docBlockRequest->getRequestDocBlockOnly($shapeNamespace);
-
-        $newContent = $beforeClass . $requestDoc . "\n" . ltrim($afterClass);
-
-        if (file_put_contents($filePath, $newContent) === false) {
-            throw new \RuntimeException(\sprintf('Failed to write file: %s', $filePath));
-        }
+        $this->rewriteClassDocblock($filePath, $docBlockRequest->getRequestDocBlockOnly($shapeNamespace));
 
         $shapeDir = dirname($filePath) . '/Shape';
         if (!is_dir($shapeDir) && !mkdir($shapeDir) && !is_dir($shapeDir)) {
@@ -100,43 +179,94 @@ class DocBlockGenerator
 
         $filenames = $docBlockRequest->getShapeFilenames(dirname($filePath));
 
-        if (file_put_contents(
-                $filenames['path'],
-                $docBlockRequest->getPathShape()->toString($shapeNamespace)
-            ) === false) {
-            throw new \RuntimeException('Failed to write path shape file');
+        foreach ([
+            'path'      => [$docBlockRequest->getPathShape(), $shapeNamespace],
+            'query'     => [$docBlockRequest->getQueryShape(), $shapeNamespace],
+            'body'      => [$docBlockRequest->getBodyShape(), $shapeNamespace],
+            'sorting'   => [$docBlockRequest->getSortingShape(), $shapeNamespace],
+            'filtering' => [$docBlockRequest->getFilteringShape(), $shapeNamespace],
+        ] as $key => [$shape, $ns]) {
+            if (file_put_contents($filenames[$key], $shape->toString($ns)) === false) {
+                throw new \RuntimeException(\sprintf('Failed to write %s shape file', $key));
+            }
+        }
+    }
+
+    private function rewriteResourceRequestFileWithDocblocks(
+        string $filePath,
+        string $requestNamespace,
+        string $requestClassName,
+        DocBlockResourceRequest $docBlockResourceRequest
+    ): void {
+        $requestDir = dirname($filePath);
+
+        if (!is_dir($requestDir) && !mkdir($requestDir, 0755, true) && !is_dir($requestDir)) {
+            throw new \RuntimeException(\sprintf('Directory "%s" was not created', $requestDir));
         }
 
-        if (file_put_contents(
-                $filenames['query'],
-                $docBlockRequest->getQueryShape()->toString($shapeNamespace)
-            ) ===
-            false) {
-            throw new \RuntimeException('Failed to write query shape file');
+        $shapeNamespace = $docBlockResourceRequest->getShapeNamespace($requestNamespace);
+        $docBlock = $docBlockResourceRequest->getDocBlockOnly($shapeNamespace);
+
+        if (!file_exists($filePath)) {
+            $baseClass = '\\' . $docBlockResourceRequest->getBaseRequestClass();
+
+            $stub = <<<PHP
+<?php
+
+declare(strict_types=1);
+
+namespace {$requestNamespace};
+
+{$docBlock}
+class {$requestClassName} extends {$baseClass}
+{
+}
+PHP;
+
+            if (file_put_contents($filePath, $stub) === false) {
+                throw new \RuntimeException(\sprintf('Failed to write file: %s', $filePath));
+            }
+        } else {
+            $this->rewriteClassDocblock($filePath, $docBlock);
         }
 
-        if (file_put_contents(
-                $filenames['body'],
-                $docBlockRequest->getBodyShape()->toString($shapeNamespace)
-            ) ===
-            false) {
-            throw new \RuntimeException('Failed to write body shape file');
+        $shapeDir = $requestDir . '/Shape';
+        if (!is_dir($shapeDir) && !mkdir($shapeDir) && !is_dir($shapeDir)) {
+            throw new \RuntimeException(\sprintf('Directory "%s" was not created', $shapeDir));
         }
 
-        if (file_put_contents(
-                $filenames['sorting'],
-                $docBlockRequest->getSortingShape()->toString($shapeNamespace)
-            ) ===
-            false) {
+        $filenames = $docBlockResourceRequest->getShapeFilenames($requestDir);
+
+        if (file_put_contents($filenames['sorting'], $docBlockResourceRequest->getSortingShape()->toString($shapeNamespace)) === false) {
             throw new \RuntimeException('Failed to write sorting shape file');
         }
 
-        if (file_put_contents(
-                $filenames['filtering'],
-                $docBlockRequest->getFilteringShape()->toString($shapeNamespace)
-            ) ===
-            false) {
+        if (file_put_contents($filenames['filtering'], $docBlockResourceRequest->getFilteringShape()->toString($shapeNamespace)) === false) {
             throw new \RuntimeException('Failed to write filtering shape file');
+        }
+    }
+
+    private function rewriteClassDocblock(string $filePath, string $newDocBlock, bool $allowModifiers = false): void
+    {
+        $content = file_get_contents($filePath);
+        if (!$content) {
+            throw new \RuntimeException("Unable to read file: $filePath");
+        }
+
+        $classPattern = $allowModifiers
+            ? '/^\s*(?:abstract\s+|final\s+)?class\s+([A-Za-z0-9_]+)/m'
+            : '/^\s*class\s+([A-Za-z0-9_]+)/m';
+
+        if (!preg_match($classPattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
+            throw new \RuntimeException("Could not find class declaration in $filePath");
+        }
+
+        $classOffset = (int)$matches[0][1];
+        $beforeClass = preg_replace('/\/\*\*(?:[^*]|\*(?!\/))*\*\//s', '', substr($content, 0, $classOffset));
+        $afterClass = substr($content, $classOffset);
+
+        if (file_put_contents($filePath, rtrim($beforeClass) . "\n\n" . $newDocBlock . "\n" . ltrim($afterClass)) === false) {
+            throw new \RuntimeException(\sprintf('Failed to write file: %s', $filePath));
         }
     }
 }

--- a/Documentation/DocBlock/DocBlockResource.php
+++ b/Documentation/DocBlock/DocBlockResource.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Documentation\DocBlock;
+
+use apivalk\apivalk\Documentation\Property\AbstractProperty;
+
+class DocBlockResource
+{
+    /** @var AbstractProperty[] */
+    private $properties = [];
+
+    public function addProperty(AbstractProperty $property): void
+    {
+        $this->properties[$property->getPropertyName()] = $property;
+    }
+
+    /** @return AbstractProperty[] */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    public function getResourceDocBlock(): string
+    {
+        $lines = [];
+
+        foreach ($this->properties as $property) {
+            $type = $property->getPhpType();
+            if (strpos($type, '\\') !== false && $type[0] !== '\\') {
+                $type = '\\' . $type;
+            }
+
+            if (!$property->isRequired()) {
+                $type = \sprintf('%s|null', $type);
+            }
+
+            $line = \sprintf('@property %s $%s', $type, $property->getPropertyName());
+
+            $description = $property->getPropertyDescription();
+            if ($description !== '') {
+                $line .= ' ' . $description;
+            }
+
+            $lines[] = $line;
+        }
+
+        if (empty($lines)) {
+            $body = ' * (no properties)';
+        } else {
+            $body = ' * ' . implode("\n * ", $lines);
+        }
+
+        return "/**\n" . $body . "\n */";
+    }
+}

--- a/Documentation/DocBlock/DocBlockResourceGenerator.php
+++ b/Documentation/DocBlock/DocBlockResourceGenerator.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Documentation\DocBlock;
+
+use apivalk\apivalk\Resource\AbstractResource;
+
+final class DocBlockResourceGenerator
+{
+    public function generate(AbstractResource $resource): DocBlockResource
+    {
+        $docBlockResource = new DocBlockResource();
+
+        $docBlockResource->addProperty($resource->getIdentifierProperty());
+
+        foreach ($resource->getProperties() as $property) {
+            $docBlockResource->addProperty($property);
+        }
+
+        return $docBlockResource;
+    }
+}

--- a/Documentation/DocBlock/DocBlockResourceRequest.php
+++ b/Documentation/DocBlock/DocBlockResourceRequest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Documentation\DocBlock;
+
+use apivalk\apivalk\Router\Route\Filter\FilterBag;
+use apivalk\apivalk\Router\Route\Sort\SortBag;
+
+class DocBlockResourceRequest
+{
+    /** @var DocBlockShape */
+    private $sortingShape;
+    /** @var DocBlockShape */
+    private $filteringShape;
+    /** @var string|null */
+    private $paginatorClass;
+    /** @var string */
+    private $baseRequestClass;
+
+    public function __construct(
+        DocBlockShape $sortingShape,
+        DocBlockShape $filteringShape,
+        ?string $paginatorClass,
+        string $baseRequestClass
+    ) {
+        $this->sortingShape = $sortingShape;
+        $this->filteringShape = $filteringShape;
+        $this->paginatorClass = $paginatorClass;
+        $this->baseRequestClass = $baseRequestClass;
+    }
+
+    public function getSortingShape(): DocBlockShape
+    {
+        return $this->sortingShape;
+    }
+
+    public function getFilteringShape(): DocBlockShape
+    {
+        return $this->filteringShape;
+    }
+
+    public function getBaseRequestClass(): string
+    {
+        return $this->baseRequestClass;
+    }
+
+    public function getShapeNamespace(string $requestNamespace): string
+    {
+        return $requestNamespace . '\\Shape';
+    }
+
+    /** @return array<string, string> */
+    public function getShapeFilenames(string $requestFolder): array
+    {
+        return [
+            'sorting'   => \sprintf('%s/Shape/%s.php', $requestFolder, $this->sortingShape->getClassName()),
+            'filtering' => \sprintf('%s/Shape/%s.php', $requestFolder, $this->filteringShape->getClassName()),
+        ];
+    }
+
+    public function getDocBlockOnly(string $shapeNamespace): string
+    {
+        $lines = [
+            ' * @method \\' . SortBag::class . '|\\' . $shapeNamespace . '\\' . $this->sortingShape->getClassName() . ' sorting()',
+            ' * @method \\' . FilterBag::class . '|\\' . $shapeNamespace . '\\' . $this->filteringShape->getClassName() . ' filtering()',
+        ];
+
+        if ($this->paginatorClass !== null) {
+            $lines[] = ' * @method \\' . $this->paginatorClass . '|null paginator()';
+        }
+
+        return "/**\n" . implode("\n", $lines) . "\n */";
+    }
+}

--- a/Documentation/DocBlock/DocBlockResourceRequestGenerator.php
+++ b/Documentation/DocBlock/DocBlockResourceRequestGenerator.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Documentation\DocBlock;
+
+use apivalk\apivalk\Http\Controller\Resource\AbstractListResourceController;
+use apivalk\apivalk\Http\Request\Pagination\CursorPaginator;
+use apivalk\apivalk\Http\Request\Pagination\OffsetPaginator;
+use apivalk\apivalk\Http\Request\Pagination\PagePaginator;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use apivalk\apivalk\Router\Route\Pagination\Pagination;
+use apivalk\apivalk\Router\Route\Sort\Sort;
+
+final class DocBlockResourceRequestGenerator
+{
+    /**
+     * @param class-string<AbstractListResourceController<AbstractResource>> $controllerClass
+     */
+    public function generate(string $controllerClass): DocBlockResourceRequest
+    {
+        $resource = $controllerClass::getEmptyResource();
+        $requestName = \ucfirst($resource->getName()) . \ucfirst($controllerClass::getMode());
+
+        $sortingShape = new DocBlockShape($requestName, 'Sorting');
+        $filteringShape = new DocBlockShape($requestName, 'Filtering');
+
+        foreach ($resource->availableSortings() as $sorting) {
+            $sortingShape->addCustomField($sorting->getField(), '\\' . Sort::class);
+        }
+
+        /** @var FilterInterface $filter */
+        foreach ($resource->availableFilters() as $filter) {
+            $filteringShape->addCustomField($filter->getField(), '\\' . \get_class($filter));
+        }
+
+        $paginatorClass = null;
+        $pagination = $controllerClass::pagination();
+
+        if ($pagination !== null) {
+            switch ($pagination->getType()) {
+                case Pagination::TYPE_PAGE:
+                    $paginatorClass = PagePaginator::class;
+                    break;
+                case Pagination::TYPE_OFFSET:
+                    $paginatorClass = OffsetPaginator::class;
+                    break;
+                case Pagination::TYPE_CURSOR:
+                    $paginatorClass = CursorPaginator::class;
+                    break;
+            }
+        }
+
+        return new DocBlockResourceRequest(
+            $sortingShape,
+            $filteringShape,
+            $paginatorClass,
+            $controllerClass::getRequestClass()
+        );
+    }
+}

--- a/Documentation/OpenAPI/Generator/OperationGenerator.php
+++ b/Documentation/OpenAPI/Generator/OperationGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Documentation\OpenAPI\Generator;
 
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
 use apivalk\apivalk\Documentation\OpenAPI\Object\HeaderObject;
 use apivalk\apivalk\Documentation\OpenAPI\Object\OperationObject;
 use apivalk\apivalk\Documentation\Property\AbstractProperty;
@@ -34,6 +35,64 @@ class OperationGenerator
         ApivalkRequestDocumentation $requestDocumentation,
         array $responseClasses
     ): OperationObject {
+        $responseHeaders = $this->getResponseHeaders($route);
+
+        $responseDocumentations = [];
+
+        /** @var AbstractApivalkResponse $responseClass */
+        foreach ($responseClasses as $responseClass) {
+            $responseDocumentations[] = [
+                'statusCode' => (int)$responseClass::getStatusCode(),
+                'documentation' => $responseClass::getDocumentation(),
+            ];
+        }
+
+        return $this->generateOperation(
+            $route,
+            $requestDocumentation,
+            $responseDocumentations,
+            $responseHeaders
+        );
+    }
+
+    /**
+     * Generate an operation using pre-built response documentation.
+     *
+     * @param Route                                                                           $route
+     * @param ApivalkRequestDocumentation                                                     $requestDocumentation
+     * @param array<int, array{statusCode: int, documentation: ApivalkResponseDocumentation}> $responseDocumentations
+     *
+     * @return OperationObject
+     */
+    public function generateFromDocumentation(
+        Route $route,
+        ApivalkRequestDocumentation $requestDocumentation,
+        array $responseDocumentations
+    ): OperationObject {
+        $responseHeaders = $this->getResponseHeaders($route);
+
+        return $this->generateOperation(
+            $route,
+            $requestDocumentation,
+            $responseDocumentations,
+            $responseHeaders
+        );
+    }
+
+    /**
+     * @param Route                                                                           $route
+     * @param ApivalkRequestDocumentation                                                     $requestDocumentation
+     * @param array<int, array{statusCode: int, documentation: ApivalkResponseDocumentation}> $responseDocumentations
+     * @param array<string, HeaderObject>                                                     $responseHeaders
+     *
+     * @return OperationObject
+     */
+    private function generateOperation(
+        Route $route,
+        ApivalkRequestDocumentation $requestDocumentation,
+        array $responseDocumentations,
+        array $responseHeaders
+    ): OperationObject {
         $parameterGenerator = new ParameterGenerator();
         $requestBodyGenerator = new RequestBodyGenerator();
         $responseGenerator = new ResponseGenerator();
@@ -47,18 +106,16 @@ class OperationGenerator
             $parameters[] = $parameterGenerator->generate($pathProperty, 'query');
         }
 
-        $orderProperty = $this->getOrderProperty($route);
+        $orderProperty = self::getOrderProperty($route);
         if ($orderProperty !== null) {
             $parameters[] = $parameterGenerator->generate($orderProperty, 'query');
         }
 
-        foreach ($this->getPaginationProperties($route) as $paginationProperty) {
+        foreach (self::getPaginationProperties($route) as $paginationProperty) {
             $parameters[] = $parameterGenerator->generate($paginationProperty, 'query');
         }
 
-        foreach ($this->getFilterProperties($route) as $filterProperty) {
-            $filterProperty->setIsRequired(false);
-
+        foreach (self::getFilterProperties($route) as $filterProperty) {
             $parameters[] = $parameterGenerator->generate($filterProperty, 'query');
         }
 
@@ -72,22 +129,17 @@ class OperationGenerator
             $parameters[] = $parameterGenerator->generate($acceptLanguageProperty, 'header');
         }
 
-        $responseHeaders = $this->getResponseHeaders($route);
-
         $responses = [];
 
-        /** @var AbstractApivalkResponse $responseClass */
-        foreach ($responseClasses as $responseClass) {
-            $responses[] =
-                $responseGenerator->generate(
-                    (int)$responseClass::getStatusCode(),
-                    $responseClass::getDocumentation(),
-                    $route,
-                    $responseHeaders
-                );
+        foreach ($responseDocumentations as $responseDoc) {
+            $responses[] = $responseGenerator->generate(
+                $responseDoc['statusCode'],
+                $responseDoc['documentation'],
+                $route,
+                $responseHeaders
+            );
         }
 
-        // Todo: Maybe define the default responses in all operations in apivalk configuration
         $responses[] = $responseGenerator->generate(
             BadValidationApivalkResponse::getStatusCode(),
             BadValidationApivalkResponse::getDocumentation(),
@@ -141,7 +193,7 @@ class OperationGenerator
      *
      * @return AbstractProperty[]
      */
-    private function getPaginationProperties(Route $route): array
+    public static function getPaginationProperties(Route $route): array
     {
         if ($route->getPagination() === null) {
             return [];
@@ -213,7 +265,7 @@ class OperationGenerator
         return $properties;
     }
 
-    private function getOrderProperty(Route $route): ?StringProperty
+    public static function getOrderProperty(Route $route): ?StringProperty
     {
         if (\count($route->getSortings()) === 0) {
             return null;
@@ -228,7 +280,7 @@ class OperationGenerator
         $group = implode('|', $fields);
 
         $regex = \sprintf(
-            '^([+-](%s))(,([+-](%s)))*$',
+            '/^([+-](%s))(,([+-](%s)))*$/',
             $group,
             $group
         );
@@ -248,6 +300,7 @@ class OperationGenerator
 
         $orderProperty->setPattern($regex);
         $orderProperty->setIsRequired(false);
+        $orderProperty->setExample($example);
 
         return $orderProperty;
     }
@@ -257,15 +310,19 @@ class OperationGenerator
      *
      * @return AbstractProperty[]
      */
-    private function getFilterProperties(Route $route): array
+    public static function getFilterProperties(Route $route): array
     {
         if (\count($route->getFilters()) === 0) {
             return [];
         }
 
         $properties = [];
+
         foreach ($route->getFilters() as $filter) {
-            $properties[] = $filter->getProperty();
+            $filterProperty = $filter->getProperty();
+            $filterProperty->setIsRequired(false);
+
+            $properties[] = $filterProperty;
         }
 
         return $properties;
@@ -279,7 +336,8 @@ class OperationGenerator
         $headers = [];
 
         if ($this->documentLocaleHeaders) {
-            $headers['Content-Language'] = new HeaderObject('The locale of the response content (BCP 47 language tag).');
+            $headers['Content-Language'] =
+                new HeaderObject('The locale of the response content (BCP 47 language tag).');
         }
 
         if ($route->getRateLimit() !== null) {

--- a/Documentation/OpenAPI/Generator/PathItemGenerator.php
+++ b/Documentation/OpenAPI/Generator/PathItemGenerator.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Documentation\OpenAPI\Generator;
 
+use apivalk\apivalk\Documentation\OpenAPI\Object\OperationObject;
 use apivalk\apivalk\Documentation\OpenAPI\Object\PathItemObject;
+use apivalk\apivalk\Documentation\Request\RequestDocumentationFactory;
+use apivalk\apivalk\Documentation\Response\ResponseDocumentationFactory;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
+use apivalk\apivalk\Http\Controller\Resource\AbstractDeleteResourceController;
+use apivalk\apivalk\Http\Controller\Resource\AbstractResourceController;
 use apivalk\apivalk\Http\Method\DeleteMethod;
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Method\PatchMethod;
 use apivalk\apivalk\Http\Method\PostMethod;
 use apivalk\apivalk\Http\Method\PutMethod;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\Route\Route;
 
 class PathItemGenerator
@@ -25,7 +31,7 @@ class PathItemGenerator
     }
 
     /**
-     * @param array<int, array{controllerClass: string, route: Route}> $routes All routes with controller class name that have the same URL pattern but different methods. Example: ['controllerClass' => 'CreateController', 'route' => $createControllerRoute]
+     * @param array<int, array{controllerClass: string, route: Route}> $routes All routes with controller class name that have the same URL pattern but different methods.
      *
      * @return PathItemObject
      */
@@ -47,48 +53,26 @@ class PathItemGenerator
             /** @var class-string<AbstractApivalkController> $controllerClass */
             $controllerClass = $routeContainer['controllerClass'];
 
-            /** @var class-string<ApivalkRequestInterface> $request */
-            $request = $controllerClass::getRequestClass();
-            $responseClasses = $controllerClass::getResponseClasses();
+            $operation = $this->generateOperation($operationGenerator, $route, $controllerClass);
 
             if ($route->getMethod() instanceof GetMethod) {
-                $get = $operationGenerator->generate(
-                    $route,
-                    $request::getDocumentation(),
-                    $responseClasses
-                );
+                $get = $operation;
             }
 
             if ($route->getMethod() instanceof PatchMethod) {
-                $patch = $operationGenerator->generate(
-                    $route,
-                    $request::getDocumentation(),
-                    $responseClasses
-                );
+                $patch = $operation;
             }
 
             if ($route->getMethod() instanceof DeleteMethod) {
-                $delete = $operationGenerator->generate(
-                    $route,
-                    $request::getDocumentation(),
-                    $responseClasses
-                );
+                $delete = $operation;
             }
 
             if ($route->getMethod() instanceof PostMethod) {
-                $post = $operationGenerator->generate(
-                    $route,
-                    $request::getDocumentation(),
-                    $responseClasses
-                );
+                $post = $operation;
             }
 
             if ($route->getMethod() instanceof PutMethod) {
-                $put = $operationGenerator->generate(
-                    $route,
-                    $request::getDocumentation(),
-                    $responseClasses
-                );
+                $put = $operation;
             }
         }
 
@@ -104,6 +88,76 @@ class PathItemGenerator
             $patch,
             $trace,
             []
+        );
+    }
+
+    /**
+     * @param OperationGenerator                      $operationGenerator
+     * @param Route                                   $route
+     * @param class-string<AbstractApivalkController> $controllerClass
+     *
+     * @return OperationObject
+     */
+    private function generateOperation(
+        OperationGenerator $operationGenerator,
+        Route $route,
+        string $controllerClass
+    ): OperationObject {
+        if (\is_subclass_of($controllerClass, AbstractResourceController::class)) {
+            return $this->generateResourceOperation($operationGenerator, $route, $controllerClass);
+        }
+
+        /** @var class-string<ApivalkRequestInterface> $requestClass */
+        $requestClass = $controllerClass::getRequestClass();
+        $responseClasses = $controllerClass::getResponseClasses();
+
+        return $operationGenerator->generate(
+            $route,
+            $requestClass::getDocumentation(),
+            $responseClasses
+        );
+    }
+
+    /**
+     * @param OperationGenerator                       $operationGenerator
+     * @param Route                                    $route
+     * @param class-string<AbstractResourceController<AbstractResource>> $controllerClass
+     *
+     * @return OperationObject
+     */
+    private function generateResourceOperation(
+        OperationGenerator $operationGenerator,
+        Route $route,
+        string $controllerClass
+    ): OperationObject {
+        $resource = $controllerClass::getEmptyResource();
+        $mode = $controllerClass::getMode();
+
+        $requestDocumentation = RequestDocumentationFactory::createRequestDocumentation($resource, $mode);
+        $responseDocumentation = ResponseDocumentationFactory::create($resource, $mode);
+
+        $responseDocumentations = [];
+
+        $isDeleteMode = \is_subclass_of($controllerClass, AbstractDeleteResourceController::class);
+
+        foreach ($controllerClass::getResponseClasses() as $responseClass) {
+            $statusCode = (int)$responseClass::getStatusCode();
+            $isSuccessResponse = $statusCode >= 200 && $statusCode < 300;
+
+            // For non-delete success responses, use resource-derived documentation.
+            // Delete success responses and all error responses use the class-declared documentation.
+            $useResourceDoc = $isSuccessResponse && !$isDeleteMode;
+
+            $responseDocumentations[] = [
+                'statusCode' => $statusCode,
+                'documentation' => $useResourceDoc ? $responseDocumentation : $responseClass::getDocumentation(),
+            ];
+        }
+
+        return $operationGenerator->generateFromDocumentation(
+            $route,
+            $requestDocumentation,
+            $responseDocumentations
         );
     }
 }

--- a/Documentation/Request/RequestDocumentationFactory.php
+++ b/Documentation/Request/RequestDocumentationFactory.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Documentation\Request;
+
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Documentation\OpenAPI\Generator\OperationGenerator;
+use apivalk\apivalk\Http\Controller\Resource\AbstractResourceController;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Router\Route\Route;
+
+final class RequestDocumentationFactory
+{
+    /**
+     * Request documentation for a resource in a given mode — path and body properties only.
+     * Route-derived query properties (pagination, sorting, filtering) are intentionally excluded
+     * so that OperationGenerator can add them without duplication when building OpenAPI specs.
+     *
+     * Use buildRuntimeDocumentation() when you need the fully merged documentation for request
+     * population and validation.
+     */
+    public static function createRequestDocumentation(
+        AbstractResource $resource,
+        string $mode
+    ): ApivalkRequestDocumentation {
+        $documentation = new ApivalkRequestDocumentation();
+
+        if ($mode === AbstractResource::MODE_VIEW
+            || $mode === AbstractResource::MODE_DELETE
+            || $mode === AbstractResource::MODE_UPDATE
+        ) {
+            $documentation->addPathProperty($resource->getIdentifierProperty());
+        }
+
+        if ($mode === AbstractResource::MODE_CREATE || $mode === AbstractResource::MODE_UPDATE) {
+            $excluded = $resource->excludeFromMode($mode);
+
+            foreach ($resource->getProperties() as $property) {
+                if (\in_array($property->getPropertyName(), $excluded, true)) {
+                    continue;
+                }
+
+                if ($mode === AbstractResource::MODE_UPDATE) {
+                    $property = clone $property;
+                    $property->setIsRequired(false);
+                }
+
+                $documentation->addBodyProperty($property);
+            }
+        }
+
+        return $documentation;
+    }
+
+    /**
+     * Fully merged documentation for request population and validation at runtime. Combines base
+     * request documentation, resource path/body properties, and route-derived query properties
+     * (pagination, sorting, filtering).
+     *
+     * @param Route  $route
+     * @param string $controllerClass class-string<\apivalk\apivalk\Http\Controller\AbstractApivalkController>
+     */
+    public static function buildRuntimeDocumentation(
+        Route $route,
+        string $controllerClass
+    ): ApivalkRequestDocumentation {
+        /** @var class-string<\apivalk\apivalk\Http\Request\ApivalkRequestInterface> $requestClass */
+        $requestClass = $controllerClass::getRequestClass();
+        $documentation = $requestClass::getDocumentation();
+
+        if (\is_subclass_of($controllerClass, AbstractResourceController::class)) {
+            $resource = $controllerClass::getEmptyResource();
+            $mode = $controllerClass::getMode();
+            $resourceDocumentation = self::createRequestDocumentation($resource, $mode);
+
+            foreach ($resourceDocumentation->getPathProperties() as $property) {
+                $documentation->addPathProperty($property);
+            }
+
+            foreach ($resourceDocumentation->getBodyProperties() as $property) {
+                $documentation->addBodyProperty($property);
+            }
+        }
+
+        foreach (OperationGenerator::getPaginationProperties($route) as $property) {
+            $documentation->addQueryProperty($property);
+        }
+
+        $orderProperty = OperationGenerator::getOrderProperty($route);
+        if ($orderProperty !== null) {
+            $documentation->addQueryProperty($orderProperty);
+        }
+
+        foreach (OperationGenerator::getFilterProperties($route) as $property) {
+            $documentation->addQueryProperty($property);
+        }
+
+        foreach ($route->getSortings() as $sorting) {
+            $documentation->addAvailableSortField($sorting->getField());
+        }
+
+        return $documentation;
+    }
+}

--- a/Documentation/Response/ResponseDocumentationFactory.php
+++ b/Documentation/Response/ResponseDocumentationFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Documentation\Response;
+
+use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use apivalk\apivalk\Resource\AbstractResource;
+
+final class ResponseDocumentationFactory
+{
+    /**
+     * Response documentation for a resource in a given mode, used by the OpenAPI generator.
+     */
+    public static function create(
+        AbstractResource $resource,
+        string $mode
+    ): ApivalkResponseDocumentation {
+        $documentation = new ApivalkResponseDocumentation();
+        $documentation->setDescription(\ucfirst($mode) . ' ' . $resource->getName() . ' response');
+
+        $excluded = $resource->excludeFromMode($mode);
+
+        $documentation->addProperty($resource->getIdentifierProperty());
+
+        foreach ($resource->getProperties() as $property) {
+            if (\in_array($property->getPropertyName(), $excluded, true)) {
+                continue;
+            }
+
+            $documentation->addProperty($property);
+        }
+
+        return $documentation;
+    }
+}

--- a/Http/Controller/Resource/AbstractCreateResourceController.php
+++ b/Http/Controller/Resource/AbstractCreateResourceController.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Controller\Resource;
+
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Request\Resource\ResourceRequest;
+use apivalk\apivalk\Http\Response\BadRequestApivalkResponse;
+use apivalk\apivalk\Http\Response\ForbiddenApivalkResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceCreatedResponse;
+use apivalk\apivalk\Resource\AbstractResource;
+
+/**
+ * @template TResource of AbstractResource
+ * @extends AbstractResourceController<TResource>
+ */
+abstract class AbstractCreateResourceController extends AbstractResourceController
+{
+    public static function getDescription(): string
+    {
+        return \sprintf('Create %s', self::getEmptyResource()->getName());
+    }
+
+    public static function getMode(): string
+    {
+        return AbstractResource::MODE_CREATE;
+    }
+
+    public static function getRequestClass(): string
+    {
+        return ResourceRequest::class;
+    }
+
+    public static function getResponseClasses(): array
+    {
+        return [
+            ResourceCreatedResponse::class,
+            BadRequestApivalkResponse::class,
+            ForbiddenApivalkResponse::class,
+        ];
+    }
+
+    /** @return TResource */
+    public function getResource(ApivalkRequestInterface $apivalkRequest): AbstractResource
+    {
+        /** @var class-string<AbstractResource> $resourceClass */
+        $resourceClass = static::getResourceClass();
+
+        return $resourceClass::byRequest($apivalkRequest);
+    }
+}

--- a/Http/Controller/Resource/AbstractDeleteResourceController.php
+++ b/Http/Controller/Resource/AbstractDeleteResourceController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Controller\Resource;
+
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Request\Resource\ResourceRequest;
+use apivalk\apivalk\Http\Response\BadRequestApivalkResponse;
+use apivalk\apivalk\Http\Response\DeletedApivalkResponse;
+use apivalk\apivalk\Http\Response\ForbiddenApivalkResponse;
+use apivalk\apivalk\Resource\AbstractResource;
+
+/**
+ * @template TResource of AbstractResource
+ * @extends AbstractResourceController<TResource>
+ */
+abstract class AbstractDeleteResourceController extends AbstractResourceController
+{
+    public static function getDescription(): string
+    {
+        return \sprintf('Delete %s', self::getEmptyResource()->getName());
+    }
+
+    public static function getMode(): string
+    {
+        return AbstractResource::MODE_DELETE;
+    }
+
+    public static function getRequestClass(): string
+    {
+        return ResourceRequest::class;
+    }
+
+    public function getResourceIdentifier(ApivalkRequestInterface $request): ?string
+    {
+        $identifierPropertyName = self::getEmptyResource()->getIdentifierProperty()->getPropertyName();
+        $identifierParameter = $request->path()->get($identifierPropertyName);
+
+        if ($identifierParameter === null) {
+            throw new \InvalidArgumentException(\sprintf('Missing path parameter "%s"', $identifierPropertyName));
+        }
+
+        return $identifierParameter->getValue();
+    }
+
+    public static function getResponseClasses(): array
+    {
+        return [
+            DeletedApivalkResponse::class,
+            BadRequestApivalkResponse::class,
+            ForbiddenApivalkResponse::class,
+        ];
+    }
+}

--- a/Http/Controller/Resource/AbstractListResourceController.php
+++ b/Http/Controller/Resource/AbstractListResourceController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Controller\Resource;
+
+use apivalk\apivalk\Http\Request\Resource\ResourceRequest;
+use apivalk\apivalk\Http\Response\BadRequestApivalkResponse;
+use apivalk\apivalk\Http\Response\ForbiddenApivalkResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceListResponse;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Router\Route\Pagination\Pagination;
+use apivalk\apivalk\Router\Route\Route;
+
+/**
+ * @template TResource of AbstractResource
+ * @extends AbstractResourceController<TResource>
+ */
+abstract class AbstractListResourceController extends AbstractResourceController
+{
+    public static function getDescription(): string
+    {
+        return \sprintf('List %s', self::getEmptyResource()->getPluralName());
+    }
+
+    public static function pagination(): ?Pagination
+    {
+        return null;
+    }
+
+    protected static function configureRoute(Route $route): void
+    {
+        $route->filtering(self::getEmptyResource()->availableFilters());
+        $route->sorting(self::getEmptyResource()->availableSortings());
+
+        $pagination = static::pagination();
+        if ($pagination !== null) {
+            $route->pagination($pagination);
+        }
+    }
+
+    public static function getMode(): string
+    {
+        return AbstractResource::MODE_LIST;
+    }
+
+    public static function getRequestClass(): string
+    {
+        return ResourceRequest::class;
+    }
+
+    public static function getResponseClasses(): array
+    {
+        return [
+            ResourceListResponse::class,
+            BadRequestApivalkResponse::class,
+            ForbiddenApivalkResponse::class,
+        ];
+    }
+}

--- a/Http/Controller/Resource/AbstractResourceController.php
+++ b/Http/Controller/Resource/AbstractResourceController.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Controller\Resource;
+
+use apivalk\apivalk\Http\Controller\AbstractApivalkController;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Router\RateLimit\RateLimitInterface;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Security\RouteAuthorization;
+
+/**
+ * @template TResource of AbstractResource
+ * @implements ResourceControllerInterface<TResource>
+ */
+abstract class AbstractResourceController extends AbstractApivalkController implements ResourceControllerInterface
+{
+    /**
+     * @return class-string<TResource>
+     */
+    abstract public static function getResourceClass(): string;
+
+    abstract public static function getDescription(): string;
+
+    /**
+     * @return TResource
+     */
+    public static function getEmptyResource(): AbstractResource
+    {
+        /** @var class-string<TResource> $resourceClass */
+        $resourceClass = static::getResourceClass();
+
+        return new $resourceClass();
+    }
+
+    public static function getRoute(): Route
+    {
+        $resource = self::getEmptyResource();
+        $route = Route::resource($resource, static::getMode());
+
+        $route->description(static::getDescription());
+        $route->tags(static::getEmptyResource()->tags());
+
+        $rateLimit = static::rateLimit();
+        if ($rateLimit !== null) {
+            $route->rateLimit($rateLimit);
+        }
+
+        $authorization = static::routeAuthorization();
+        if ($authorization !== null) {
+            $route->routeAuthorization($authorization);
+        }
+
+        static::configureRoute($route);
+
+        return $route;
+    }
+
+    /**
+     * Hook for mode-specific route configuration. Default is a no-op; modes that need extra
+     * wiring (e.g. list filters/sortings/pagination) override this.
+     */
+    protected static function configureRoute(Route $route): void
+    {
+    }
+
+    public static function rateLimit(): ?RateLimitInterface
+    {
+        return null;
+    }
+
+    public static function routeAuthorization(): ?RouteAuthorization
+    {
+        return null;
+    }
+}

--- a/Http/Controller/Resource/AbstractUpdateResourceController.php
+++ b/Http/Controller/Resource/AbstractUpdateResourceController.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Controller\Resource;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Request\Resource\ResourceRequest;
+use apivalk\apivalk\Http\Response\BadRequestApivalkResponse;
+use apivalk\apivalk\Http\Response\ForbiddenApivalkResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceUpdatedResponse;
+use apivalk\apivalk\Resource\AbstractResource;
+
+/**
+ * @template TResource of AbstractResource
+ * @extends AbstractResourceController<TResource>
+ */
+abstract class AbstractUpdateResourceController extends AbstractResourceController
+{
+    public static function getDescription(): string
+    {
+        return \sprintf('Update %s', self::getEmptyResource()->getName());
+    }
+
+    public static function getMode(): string
+    {
+        return AbstractResource::MODE_UPDATE;
+    }
+
+    public static function getRequestClass(): string
+    {
+        return ResourceRequest::class;
+    }
+
+    public static function getResponseClasses(): array
+    {
+        return [
+            ResourceUpdatedResponse::class,
+            BadRequestApivalkResponse::class,
+            ForbiddenApivalkResponse::class,
+        ];
+    }
+
+    public function getResourceIdentifier(ApivalkRequestInterface $request): ?string
+    {
+        $identifierPropertyName = self::getEmptyResource()->getIdentifierProperty()->getPropertyName();
+        $identifierParameter = $request->path()->get($identifierPropertyName);
+
+        if ($identifierParameter === null) {
+            throw new \InvalidArgumentException(\sprintf('Missing path parameter "%s"', $identifierPropertyName));
+        }
+
+        return $identifierParameter->getValue();
+    }
+
+    public function getResource(AbstractApivalkRequest $apivalkRequest): AbstractResource
+    {
+        /** @var class-string<AbstractResource> $resourceClass */
+        $resourceClass = static::getResourceClass();
+
+        return $resourceClass::byRequest($apivalkRequest);
+    }
+}

--- a/Http/Controller/Resource/AbstractViewResourceController.php
+++ b/Http/Controller/Resource/AbstractViewResourceController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Controller\Resource;
+
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Request\Resource\ResourceRequest;
+use apivalk\apivalk\Http\Response\BadRequestApivalkResponse;
+use apivalk\apivalk\Http\Response\ForbiddenApivalkResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceViewResponse;
+use apivalk\apivalk\Resource\AbstractResource;
+
+/**
+ * @template TResource of AbstractResource
+ * @extends AbstractResourceController<TResource>
+ */
+abstract class AbstractViewResourceController extends AbstractResourceController
+{
+    public static function getDescription(): string
+    {
+        return \sprintf('Get %s', self::getEmptyResource()->getName());
+    }
+
+    public static function getMode(): string
+    {
+        return AbstractResource::MODE_VIEW;
+    }
+
+    public static function getRequestClass(): string
+    {
+        return ResourceRequest::class;
+    }
+
+    public function getResourceIdentifier(ApivalkRequestInterface $request): ?string
+    {
+        $identifierPropertyName = self::getEmptyResource()->getIdentifierProperty()->getPropertyName();
+        $identifierParameter = $request->path()->get($identifierPropertyName);
+
+        if ($identifierParameter === null) {
+            throw new \InvalidArgumentException(\sprintf('Missing path parameter "%s"', $identifierPropertyName));
+        }
+
+        return $identifierParameter->getValue();
+    }
+
+    public static function getResponseClasses(): array
+    {
+        return [
+            ResourceViewResponse::class,
+            BadRequestApivalkResponse::class,
+            ForbiddenApivalkResponse::class,
+        ];
+    }
+}

--- a/Http/Controller/Resource/ResourceControllerInterface.php
+++ b/Http/Controller/Resource/ResourceControllerInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Controller\Resource;
+
+use apivalk\apivalk\Resource\AbstractResource;
+
+/**
+ * @template TResource of AbstractResource
+ */
+interface ResourceControllerInterface
+{
+    /** @return class-string<AbstractResource> */
+    public static function getResourceClass(): string;
+
+    public static function getMode(): string;
+}

--- a/Http/Request/AbstractApivalkRequest.php
+++ b/Http/Request/AbstractApivalkRequest.php
@@ -8,22 +8,18 @@ use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Http\i18n\Locale;
 use apivalk\apivalk\Http\Method\MethodInterface;
 use apivalk\apivalk\Http\Request\File\FileBag;
-use apivalk\apivalk\Http\Request\File\FileBagFactory;
 use apivalk\apivalk\Http\Request\Pagination\CursorPaginator;
 use apivalk\apivalk\Http\Request\Pagination\OffsetPaginator;
 use apivalk\apivalk\Http\Request\Pagination\PagePaginator;
-use apivalk\apivalk\Http\Request\Pagination\PaginatorFactory;
 use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
-use apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationStrategyCollection;
 use apivalk\apivalk\Router\RateLimit\RateLimitResult;
 use apivalk\apivalk\Router\Route\Filter\FilterBag;
-use apivalk\apivalk\Router\Route\Sort\Sort;
-use apivalk\apivalk\Router\Route\Sort\SortBag;
-use apivalk\apivalk\Router\Route\Pagination\Pagination;
 use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\Sort\SortBag;
 use apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity;
 use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
-use apivalk\apivalk\Util\IpResolver;
 
 abstract class AbstractApivalkRequest implements ApivalkRequestInterface
 {
@@ -53,101 +49,24 @@ abstract class AbstractApivalkRequest implements ApivalkRequestInterface
     private $filterBag;
     /** @var CursorPaginator|PagePaginator|OffsetPaginator|null */
     private $paginator;
+    /** @var ApivalkRequestDocumentation */
+    private $documentation;
 
-    abstract public static function getDocumentation(): ApivalkRequestDocumentation;
-
-    public function populate(Route $route): void
+    public function populate(Route $route, ApivalkRequestDocumentation $documentation): void
     {
-        $documentation = static::getDocumentation();
+        $this->documentation = $documentation;
 
-        // ToDo: Write Populator Logic/Strategy for this, it gets messy by now
+        $requestPopulationContext = new RequestPopulationContext($route, $documentation);
+        $requestPopulationStrategyCollection = new RequestPopulationStrategyCollection();
 
-        $this->method = $route->getMethod();
-        $this->headerBag = ParameterBagFactory::createHeaderBag();
-        $this->queryParameterBag = ParameterBagFactory::createQueryBag($route, $documentation);
-        $this->pathParameterBag = ParameterBagFactory::createPathBag($route, $documentation);
-        $this->bodyParameterBag = ParameterBagFactory::createBodyBag($documentation);
-        $this->fileBag = FileBagFactory::create();
-        $this->authIdentity = new GuestAuthIdentity([]);
-        $this->ip = IpResolver::getClientIp();
-        $this->sortBag = new SortBag();
-        $this->filterBag = new FilterBag();
-
-        $this->populateOrderBag($route);
-        $this->populateFilterBag($route);
-        $this->createPaginator($route);
-    }
-
-    private function populateOrderBag(Route $route): void
-    {
-        foreach ($route->getSortings() as $ordering) {
-            if (!$this->sortBag->has($ordering->getField())) {
-                $this->sortBag->set($ordering);
-            }
-        }
-
-        $orderBy = $this->queryParameterBag->get('order_by');
-
-        if ($orderBy === null) {
-            return;
-        }
-
-        foreach (explode(',', $orderBy->getRawValue()) as $curOrderByField) {
-            $curOrderByField = trim($curOrderByField);
-
-            if ($curOrderByField === '') {
-                continue;
-            }
-
-            if ($curOrderByField[0] !== '+' && $curOrderByField[0] !== '-') {
-                $direction = '+';
-                $field = $curOrderByField;
-            } else {
-                $direction = $curOrderByField[0];
-                $field = substr($curOrderByField, 1);
-            }
-
-            if ($field === '') {
-                continue;
-            }
-
-            $this->sortBag->set($direction === '-' ? Sort::desc($field) : Sort::asc($field));
+        foreach ($requestPopulationStrategyCollection->getAll() as $populationStrategy) {
+            $populationStrategy->populate($this, $requestPopulationContext);
         }
     }
 
-    private function populateFilterBag(Route $route): void
+    public function getRuntimeDocumentation(): ApivalkRequestDocumentation
     {
-        foreach ($route->getFilters() as $filter) {
-            $field = $filter->getField();
-            $queryParameter = $this->queryParameterBag->get($field);
-
-            $clonedFilter = clone $filter;
-            if ($queryParameter !== null) {
-                $clonedFilter->setValue(
-                    ParameterBagFactory::typeCastValueByProperty($queryParameter->getRawValue(), $filter->getProperty())
-                );
-            }
-            $this->filterBag->set($clonedFilter);
-        }
-    }
-
-    private function createPaginator(Route $route): void
-    {
-        $pagination = $route->getPagination();
-
-        if ($pagination !== null) {
-            switch ($pagination->getType()) {
-                case Pagination::TYPE_OFFSET:
-                    $this->paginator = PaginatorFactory::offset($this, $pagination->getMaxLimit());
-                    break;
-                case Pagination::TYPE_CURSOR:
-                    $this->paginator = PaginatorFactory::cursor($this, $pagination->getMaxLimit());
-                    break;
-                case Pagination::TYPE_PAGE:
-                    $this->paginator = PaginatorFactory::page($this, $pagination->getMaxLimit());
-                    break;
-            }
-        }
+        return $this->documentation;
     }
 
     public function getMethod(): MethodInterface
@@ -195,9 +114,6 @@ abstract class AbstractApivalkRequest implements ApivalkRequestInterface
         return $this->filterBag;
     }
 
-    /**
-     * @return mixed|null
-     */
     public function paginator()
     {
         return $this->paginator;
@@ -231,5 +147,58 @@ abstract class AbstractApivalkRequest implements ApivalkRequestInterface
     public function setLocale(Locale $locale): void
     {
         $this->locale = $locale;
+    }
+
+    public function setMethod(MethodInterface $method): void
+    {
+        $this->method = $method;
+    }
+
+    public function setHeaderBag(ParameterBag $headerBag): void
+    {
+        $this->headerBag = $headerBag;
+    }
+
+    public function setQueryParameterBag(ParameterBag $queryParameterBag): void
+    {
+        $this->queryParameterBag = $queryParameterBag;
+    }
+
+    public function setPathParameterBag(ParameterBag $pathParameterBag): void
+    {
+        $this->pathParameterBag = $pathParameterBag;
+    }
+
+    public function setBodyParameterBag(ParameterBag $bodyParameterBag): void
+    {
+        $this->bodyParameterBag = $bodyParameterBag;
+    }
+
+    public function setFileBag(FileBag $fileBag): void
+    {
+        $this->fileBag = $fileBag;
+    }
+
+    public function setIp(?string $ip): void
+    {
+        $this->ip = $ip;
+    }
+
+    public function setSortBag(SortBag $sortBag): void
+    {
+        $this->sortBag = $sortBag;
+    }
+
+    public function setFilterBag(FilterBag $filterBag): void
+    {
+        $this->filterBag = $filterBag;
+    }
+
+    /**
+     * @param CursorPaginator|OffsetPaginator|PagePaginator|null $paginator
+     */
+    public function setPaginator($paginator): void
+    {
+        $this->paginator = $paginator;
     }
 }

--- a/Http/Request/ApivalkRequestInterface.php
+++ b/Http/Request/ApivalkRequestInterface.php
@@ -11,15 +11,17 @@ use apivalk\apivalk\Http\Request\File\FileBag;
 use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
 use apivalk\apivalk\Router\RateLimit\RateLimitResult;
 use apivalk\apivalk\Router\Route\Filter\FilterBag;
-use apivalk\apivalk\Router\Route\Sort\SortBag;
 use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\Sort\SortBag;
 use apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity;
 
 interface ApivalkRequestInterface
 {
     public static function getDocumentation(): ApivalkRequestDocumentation;
 
-    public function populate(Route $route): void;
+    public function populate(Route $route, ApivalkRequestDocumentation $documentation): void;
+
+    public function getRuntimeDocumentation(): ApivalkRequestDocumentation;
 
     public function getMethod(): MethodInterface;
 

--- a/Http/Request/Parameter/ParameterBagFactory.php
+++ b/Http/Request/Parameter/ParameterBagFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Http\Request\Parameter;
 
-use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Documentation\Property\AbstractProperty;
 use apivalk\apivalk\Documentation\Property\ArrayProperty;
 use apivalk\apivalk\Router\Route\Route;
@@ -26,9 +25,11 @@ final class ParameterBagFactory
         return $headerBag;
     }
 
-    public static function createQueryBag(Route $route, ApivalkRequestDocumentation $documentation): ParameterBag
+    /**
+     * @param AbstractProperty[] $queryProperties
+     */
+    public static function createQueryBag(Route $route, array $queryProperties): ParameterBag
     {
-        $properties = $documentation->getQueryProperties();
         $queryBag = new ParameterBag();
 
         foreach ($_GET as $key => $value) {
@@ -36,11 +37,11 @@ final class ParameterBagFactory
                 continue;
             }
 
-            if (isset($properties[$key])) {
+            if (isset($queryProperties[$key])) {
                 $queryBag->set(
                     new Parameter(
                         $key,
-                        self::typeCastValueByProperty($value, $properties[$key]),
+                        self::typeCastValueByProperty($value, $queryProperties[$key]),
                         $value
                     )
                 );
@@ -63,22 +64,14 @@ final class ParameterBagFactory
             }
         }
 
-        if (isset($_GET['order_by']) && $_GET['order_by'] !== null) {
-            $queryBag->set(
-                new Parameter(
-                    'order_by',
-                    $_GET['order_by'],
-                    $_GET['order_by']
-                )
-            );
-        }
-
         return $queryBag;
     }
 
-    public static function createPathBag(Route $route, ApivalkRequestDocumentation $documentation): ParameterBag
+    /**
+     * @param AbstractProperty[] $pathProperties
+     */
+    public static function createPathBag(Route $route, array $pathProperties): ParameterBag
     {
-        $properties = $documentation->getPathProperties();
         $pathBag = new ParameterBag();
 
         preg_match_all('/\{([a-zA-Z0-9]+)\}/', $route->getUrl(), $keyMatches);
@@ -113,7 +106,7 @@ final class ParameterBagFactory
         }
 
         foreach ($result as $parameterName => $parameterValue) {
-            if (!isset($properties[$parameterName])) {
+            if (!isset($pathProperties[$parameterName])) {
                 continue;
             }
 
@@ -124,7 +117,7 @@ final class ParameterBagFactory
             $pathBag->set(
                 new Parameter(
                     $parameterName,
-                    self::typeCastValueByProperty($parameterValue, $properties[$parameterName]),
+                    self::typeCastValueByProperty($parameterValue, $pathProperties[$parameterName]),
                     $parameterValue
                 )
             );
@@ -133,7 +126,10 @@ final class ParameterBagFactory
         return $pathBag;
     }
 
-    public static function createBodyBag(ApivalkRequestDocumentation $documentation): ParameterBag
+    /**
+     * @param AbstractProperty[] $bodyProperties
+     */
+    public static function createBodyBag(array $bodyProperties): ParameterBag
     {
         $inputValues = [];
 
@@ -150,7 +146,7 @@ final class ParameterBagFactory
 
         $inputBag = new ParameterBag();
 
-        foreach ($documentation->getBodyProperties() as $inputProperty) {
+        foreach ($bodyProperties as $inputProperty) {
             $value = $inputValues[$inputProperty->getPropertyName()] ?? null;
 
             if ($value === null) {
@@ -170,6 +166,8 @@ final class ParameterBagFactory
     }
 
     /**
+     * ToDo: Refactor this, move this to a class. Something like PropertyTypeCaster or so
+     *
      * @return bool|float|int|object|array|string|null
      */
     public static function typeCastValueByProperty($value, AbstractProperty $property)

--- a/Http/Request/Population/RequestPopulationContext.php
+++ b/Http/Request/Population/RequestPopulationContext.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population;
+
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Router\Route\Route;
+
+class RequestPopulationContext
+{
+    /** @var Route */
+    private $route;
+    /** @var ApivalkRequestDocumentation */
+    private $documentation;
+
+    public function __construct(Route $route, ApivalkRequestDocumentation $documentation)
+    {
+        $this->route = $route;
+        $this->documentation = $documentation;
+    }
+
+    public function getRoute(): Route
+    {
+        return $this->route;
+    }
+
+    public function getDocumentation(): ApivalkRequestDocumentation
+    {
+        return $this->documentation;
+    }
+}

--- a/Http/Request/Population/RequestPopulationStrategyCollection.php
+++ b/Http/Request/Population/RequestPopulationStrategyCollection.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population;
+
+use apivalk\apivalk\Http\Request\Population\Strategy\AuthIdentityPopulationStrategy;
+use apivalk\apivalk\Http\Request\Population\Strategy\BodyParameterPopulationStrategy;
+use apivalk\apivalk\Http\Request\Population\Strategy\FilePopulationStrategy;
+use apivalk\apivalk\Http\Request\Population\Strategy\FilteringPopulationStrategy;
+use apivalk\apivalk\Http\Request\Population\Strategy\HeaderPopulationStrategy;
+use apivalk\apivalk\Http\Request\Population\Strategy\IpPopulationStrategy;
+use apivalk\apivalk\Http\Request\Population\Strategy\MethodPopulationStrategy;
+use apivalk\apivalk\Http\Request\Population\Strategy\PaginationPopulationStrategy;
+use apivalk\apivalk\Http\Request\Population\Strategy\PathParameterPopulationStrategy;
+use apivalk\apivalk\Http\Request\Population\Strategy\PopulationStrategyInterface;
+use apivalk\apivalk\Http\Request\Population\Strategy\QueryParameterPopulationStrategy;
+use apivalk\apivalk\Http\Request\Population\Strategy\SortingPopulationStrategy;
+
+class RequestPopulationStrategyCollection
+{
+    /** @var PopulationStrategyInterface[] */
+    private $strategies = [];
+
+    public function __construct()
+    {
+        $this->strategies[] = new MethodPopulationStrategy();
+        $this->strategies[] = new HeaderPopulationStrategy();
+        $this->strategies[] = new QueryParameterPopulationStrategy();
+        $this->strategies[] = new PathParameterPopulationStrategy();
+        $this->strategies[] = new BodyParameterPopulationStrategy();
+        $this->strategies[] = new FilePopulationStrategy();
+        $this->strategies[] = new AuthIdentityPopulationStrategy();
+        $this->strategies[] = new IpPopulationStrategy();
+        $this->strategies[] = new SortingPopulationStrategy();
+        $this->strategies[] = new FilteringPopulationStrategy();
+        $this->strategies[] = new PaginationPopulationStrategy();
+    }
+
+    /**
+     * @return PopulationStrategyInterface[]
+     */
+    public function getAll(): array
+    {
+        return $this->strategies;
+    }
+}

--- a/Http/Request/Population/Strategy/AuthIdentityPopulationStrategy.php
+++ b/Http/Request/Population/Strategy/AuthIdentityPopulationStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
+
+class AuthIdentityPopulationStrategy implements PopulationStrategyInterface
+{
+    public function populate(AbstractApivalkRequest $request, RequestPopulationContext $context): void
+    {
+        $request->setAuthIdentity(new GuestAuthIdentity([]));
+    }
+}

--- a/Http/Request/Population/Strategy/BodyParameterPopulationStrategy.php
+++ b/Http/Request/Population/Strategy/BodyParameterPopulationStrategy.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+
+class BodyParameterPopulationStrategy implements PopulationStrategyInterface
+{
+    public function populate(AbstractApivalkRequest $request, RequestPopulationContext $context): void
+    {
+        $request->setBodyParameterBag(
+            ParameterBagFactory::createBodyBag(
+                $context->getDocumentation()->getBodyProperties()
+            )
+        );
+    }
+}

--- a/Http/Request/Population/Strategy/FilePopulationStrategy.php
+++ b/Http/Request/Population/Strategy/FilePopulationStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\File\FileBagFactory;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+
+class FilePopulationStrategy implements PopulationStrategyInterface
+{
+    public function populate(AbstractApivalkRequest $request, RequestPopulationContext $context): void
+    {
+        $request->setFileBag(FileBagFactory::create());
+    }
+}

--- a/Http/Request/Population/Strategy/FilteringPopulationStrategy.php
+++ b/Http/Request/Population/Strategy/FilteringPopulationStrategy.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Router\Route\Filter\FilterBag;
+
+class FilteringPopulationStrategy implements PopulationStrategyInterface
+{
+    public function populate(AbstractApivalkRequest $request, RequestPopulationContext $context): void
+    {
+        $filterBag = new FilterBag();
+
+        foreach ($context->getRoute()->getFilters() as $filter) {
+            $queryParameter = $request->query()->get($filter->getField());
+
+            $clonedFilter = clone $filter;
+            if ($queryParameter !== null) {
+                $clonedFilter->setValue(
+                    ParameterBagFactory::typeCastValueByProperty(
+                        $queryParameter->getRawValue(),
+                        $filter->getProperty()
+                    )
+                );
+            }
+            $filterBag->set($clonedFilter);
+        }
+
+        $request->setFilterBag($filterBag);
+    }
+}

--- a/Http/Request/Population/Strategy/HeaderPopulationStrategy.php
+++ b/Http/Request/Population/Strategy/HeaderPopulationStrategy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+
+class HeaderPopulationStrategy implements PopulationStrategyInterface
+{
+    public function populate(
+        AbstractApivalkRequest $request,
+        RequestPopulationContext $context
+    ): void {
+        $request->setHeaderBag(ParameterBagFactory::createHeaderBag());
+    }
+}

--- a/Http/Request/Population/Strategy/IpPopulationStrategy.php
+++ b/Http/Request/Population/Strategy/IpPopulationStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Util\IpResolver;
+
+class IpPopulationStrategy implements PopulationStrategyInterface
+{
+    public function populate(AbstractApivalkRequest $request, RequestPopulationContext $context): void
+    {
+        $request->setIp(IpResolver::getClientIp());
+    }
+}

--- a/Http/Request/Population/Strategy/MethodPopulationStrategy.php
+++ b/Http/Request/Population/Strategy/MethodPopulationStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+
+class MethodPopulationStrategy implements PopulationStrategyInterface
+{
+    public function populate(AbstractApivalkRequest $request, RequestPopulationContext $context): void
+    {
+        $request->setMethod($context->getRoute()->getMethod());
+    }
+}

--- a/Http/Request/Population/Strategy/PaginationPopulationStrategy.php
+++ b/Http/Request/Population/Strategy/PaginationPopulationStrategy.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Pagination\PaginatorFactory;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Router\Route\Pagination\Pagination;
+
+class PaginationPopulationStrategy implements PopulationStrategyInterface
+{
+    public function populate(AbstractApivalkRequest $request, RequestPopulationContext $context): void
+    {
+        $pagination = $context->getRoute()->getPagination();
+
+        if ($pagination === null) {
+            return;
+        }
+
+        switch ($pagination->getType()) {
+            case Pagination::TYPE_OFFSET:
+                $request->setPaginator(PaginatorFactory::offset($request, $pagination->getMaxLimit()));
+                break;
+            case Pagination::TYPE_CURSOR:
+                $request->setPaginator(PaginatorFactory::cursor($request, $pagination->getMaxLimit()));
+                break;
+            case Pagination::TYPE_PAGE:
+                $request->setPaginator(PaginatorFactory::page($request, $pagination->getMaxLimit()));
+                break;
+        }
+    }
+}

--- a/Http/Request/Population/Strategy/PathParameterPopulationStrategy.php
+++ b/Http/Request/Population/Strategy/PathParameterPopulationStrategy.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+
+class PathParameterPopulationStrategy implements PopulationStrategyInterface
+{
+    public function populate(AbstractApivalkRequest $request, RequestPopulationContext $context): void
+    {
+        $request->setPathParameterBag(
+            ParameterBagFactory::createPathBag(
+                $context->getRoute(),
+                $context->getDocumentation()->getPathProperties()
+            )
+        );
+    }
+}

--- a/Http/Request/Population/Strategy/PopulationStrategyInterface.php
+++ b/Http/Request/Population/Strategy/PopulationStrategyInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+
+interface PopulationStrategyInterface
+{
+    public function populate(AbstractApivalkRequest $request, RequestPopulationContext $context): void;
+}

--- a/Http/Request/Population/Strategy/QueryParameterPopulationStrategy.php
+++ b/Http/Request/Population/Strategy/QueryParameterPopulationStrategy.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+
+class QueryParameterPopulationStrategy implements PopulationStrategyInterface
+{
+    public function populate(AbstractApivalkRequest $request, RequestPopulationContext $context): void
+    {
+        $request->setQueryParameterBag(
+            ParameterBagFactory::createQueryBag(
+                $context->getRoute(),
+                $context->getDocumentation()->getQueryProperties()
+            )
+        );
+    }
+}

--- a/Http/Request/Population/Strategy/SortingPopulationStrategy.php
+++ b/Http/Request/Population/Strategy/SortingPopulationStrategy.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Router\Route\Sort\Sort;
+use apivalk\apivalk\Router\Route\Sort\SortBag;
+
+class SortingPopulationStrategy implements PopulationStrategyInterface
+{
+    public function populate(AbstractApivalkRequest $request, RequestPopulationContext $context): void
+    {
+        $sortBag = new SortBag();
+
+        foreach ($context->getRoute()->getSortings() as $ordering) {
+            if (!$sortBag->has($ordering->getField())) {
+                $sortBag->set($ordering);
+            }
+        }
+
+        $rawOrderBy = isset($_GET['order_by']) ? (string)$_GET['order_by'] : null;
+
+        if ($rawOrderBy !== null && $rawOrderBy !== '') {
+            foreach (explode(',', $rawOrderBy) as $curOrderByField) {
+                $curOrderByField = trim($curOrderByField);
+                if ($curOrderByField === '') {
+                    continue;
+                }
+
+                if ($curOrderByField[0] !== '+' && $curOrderByField[0] !== '-') {
+                    $direction = '+';
+                    $field = $curOrderByField;
+                } else {
+                    $direction = $curOrderByField[0];
+                    $field = substr($curOrderByField, 1);
+                }
+
+                if ($field === '') {
+                    continue;
+                }
+
+                $sortBag->set($direction === '-' ? Sort::desc($field) : Sort::asc($field));
+            }
+        }
+
+        $request->setSortBag($sortBag);
+    }
+}

--- a/Http/Request/Resource/ResourceRequest.php
+++ b/Http/Request/Resource/ResourceRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Request\Resource;
+
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+
+class ResourceRequest extends AbstractApivalkRequest
+{
+    public static function getDocumentation(): ApivalkRequestDocumentation
+    {
+        return new ApivalkRequestDocumentation();
+    }
+}

--- a/Http/Response/Resource/ResourceCreatedResponse.php
+++ b/Http/Response/Resource/ResourceCreatedResponse.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Response\Resource;
+
+use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Resource\AbstractResource;
+
+class ResourceCreatedResponse extends AbstractApivalkResponse
+{
+    /** @var AbstractResource */
+    private $resource;
+
+    public function __construct(AbstractResource $resource)
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * Just a dummy method to satisfy the interface. The documentation will be generated from the resource.
+     */
+    public static function getDocumentation(): ApivalkResponseDocumentation
+    {
+        return new ApivalkResponseDocumentation();
+    }
+
+    public static function getStatusCode(): int
+    {
+        return self::HTTP_201_CREATED;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'data' => $this->resource->toArray(AbstractResource::MODE_CREATE)
+        ];
+    }
+}

--- a/Http/Response/Resource/ResourceDeletedResponse.php
+++ b/Http/Response/Resource/ResourceDeletedResponse.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Response\Resource;
+
+use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Resource\AbstractResource;
+
+class ResourceDeletedResponse extends AbstractApivalkResponse
+{
+    /** @var AbstractResource */
+    private $resource;
+
+    public function __construct(AbstractResource $resource)
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * Just a dummy method to satisfy the interface. The documentation will be generated from the resource.
+     */
+    public static function getDocumentation(): ApivalkResponseDocumentation
+    {
+        return new ApivalkResponseDocumentation();
+    }
+
+    public static function getStatusCode(): int
+    {
+        return self::HTTP_200_OK;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'data' => $this->resource->toArray(AbstractResource::MODE_DELETE),
+        ];
+    }
+}

--- a/Http/Response/Resource/ResourceListResponse.php
+++ b/Http/Response/Resource/ResourceListResponse.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Response\Resource;
+
+use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\Pagination\PaginationResponseInterface;
+use apivalk\apivalk\Resource\AbstractResource;
+
+class ResourceListResponse extends AbstractApivalkResponse
+{
+    /** @var AbstractResource[] */
+    private $resources;
+
+    /**
+     * @param AbstractResource[] $resources
+     */
+    public function __construct(array $resources, PaginationResponseInterface $paginationResponse)
+    {
+        $this->resources = $resources;
+
+        $this->setPaginationResponse($paginationResponse);
+    }
+
+    /**
+     * Just a dummy method to satisfy the interface. The documentation will be generated from the resource.
+     */
+    public static function getDocumentation(): ApivalkResponseDocumentation
+    {
+        return new ApivalkResponseDocumentation();
+    }
+
+    public static function getStatusCode(): int
+    {
+        return self::HTTP_200_OK;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        $items = [];
+
+        foreach ($this->resources as $resource) {
+            $items[] = $resource->toArray(AbstractResource::MODE_LIST);
+        }
+
+        return [
+            'data' => $items,
+        ];
+    }
+}

--- a/Http/Response/Resource/ResourceUpdatedResponse.php
+++ b/Http/Response/Resource/ResourceUpdatedResponse.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Response\Resource;
+
+use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Resource\AbstractResource;
+
+class ResourceUpdatedResponse extends AbstractApivalkResponse
+{
+    /** @var AbstractResource */
+    private $resource;
+
+    public function __construct(AbstractResource $resource)
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * Just a dummy method to satisfy the interface. The documentation will be generated from the resource.
+     */
+    public static function getDocumentation(): ApivalkResponseDocumentation
+    {
+        return new ApivalkResponseDocumentation();
+    }
+
+    public static function getStatusCode(): int
+    {
+        return self::HTTP_200_OK;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'data' => $this->resource->toArray(AbstractResource::MODE_UPDATE),
+        ];
+    }
+}

--- a/Http/Response/Resource/ResourceViewResponse.php
+++ b/Http/Response/Resource/ResourceViewResponse.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Http\Response\Resource;
+
+use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Resource\AbstractResource;
+
+class ResourceViewResponse extends AbstractApivalkResponse
+{
+    /** @var AbstractResource */
+    private $resource;
+
+    public function __construct(AbstractResource $resource)
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * Just a dummy method to satisfy the interface. The documentation will be generated from the resource.
+     */
+    public static function getDocumentation(): ApivalkResponseDocumentation
+    {
+        return new ApivalkResponseDocumentation();
+    }
+
+    public static function getStatusCode(): int
+    {
+        return self::HTTP_200_OK;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'data' => $this->resource->toArray(AbstractResource::MODE_VIEW),
+        ];
+    }
+}

--- a/Middleware/RequestValidationMiddleware.php
+++ b/Middleware/RequestValidationMiddleware.php
@@ -8,12 +8,14 @@ use apivalk\apivalk\Documentation\Property\AbstractProperty;
 use apivalk\apivalk\Documentation\Property\Validator\ValidatorResult;
 use apivalk\apivalk\Documentation\Response\ValidationErrorObject;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Request\Parameter\Parameter;
 use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
-use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\BadValidationApivalkResponse;
+use apivalk\apivalk\Router\Route\Filter\FilterBag;
 use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use apivalk\apivalk\Router\Route\Sort\SortBag;
 
 class RequestValidationMiddleware implements MiddlewareInterface
 {
@@ -27,24 +29,13 @@ class RequestValidationMiddleware implements MiddlewareInterface
     ): AbstractApivalkResponse {
         $this->errors = [];
 
-        $documentation = $request::getDocumentation();
+        $documentation = $request->getRuntimeDocumentation();
 
-        $this->validateProperties(
-            $documentation->getBodyProperties(),
-            $request->body()
-        );
-
-        $this->validateProperties(
-            $documentation->getQueryProperties(),
-            $request->query()
-        );
-
-        $this->validateProperties(
-            $documentation->getPathProperties(),
-            $request->path()
-        );
-
-        $this->validateFilters($request->filtering()->all());
+        $this->validateProperties($documentation->getBodyProperties(), $request->body());
+        $this->validateProperties($documentation->getQueryProperties(), $request->query());
+        $this->validateProperties($documentation->getPathProperties(), $request->path());
+        $this->validateFilters($request->filtering());
+        $this->validateSortings($request->sorting(), $documentation->getAvailableSortFields());
 
         if (\count($this->errors) > 0) {
             return new BadValidationApivalkResponse($this->errors);
@@ -54,11 +45,28 @@ class RequestValidationMiddleware implements MiddlewareInterface
     }
 
     /**
-     * @param FilterInterface[] $filters
+     * @param string[] $availableSortFields
      */
-    private function validateFilters(array $filters): void
+    private function validateSortings(SortBag $sortBag, array $availableSortFields): void
     {
-        foreach ($filters as $filter) {
+        if (empty($availableSortFields)) {
+            return;
+        }
+
+        foreach ($sortBag as $sort) {
+            if (!\in_array($sort->getField(), $availableSortFields, true)) {
+                $this->errors[] = ValidationErrorObject::createByValidatorResult(
+                    'order_by',
+                    new ValidatorResult(false, \sprintf('Invalid sort field "%s"', $sort->getField()))
+                );
+            }
+        }
+    }
+
+    private function validateFilters(FilterBag $filterBag): void
+    {
+        /** @var FilterInterface $filter */
+        foreach ($filterBag->getIterator() as $filter) {
             $value = $filter->getValue();
             $property = $filter->getProperty();
 
@@ -68,24 +76,18 @@ class RequestValidationMiddleware implements MiddlewareInterface
 
             if ($value === null && $property->isRequired()) {
                 $this->errors[] = ValidationErrorObject::createByValidatorResult(
-                    $property->getPropertyName(),
+                    $filter->getField(),
                     new ValidatorResult(false, ValidatorResult::FIELD_IS_REQUIRED)
                 );
-
                 continue;
             }
 
-            $parameter = new Parameter($property->getPropertyName(), $value, $value);
+            $parameter = new Parameter($filter->getField(), $value, (string)$value);
 
             foreach ($property->getValidators() as $validator) {
-                /** @var ValidatorResult $validatorResult */
-                $validatorResult = $validator->validate($parameter);
-
-                if (!$validatorResult->isSuccess()) {
-                    $this->errors[] = ValidationErrorObject::createByValidatorResult(
-                        $property->getPropertyName(),
-                        $validatorResult
-                    );
+                $result = $validator->validate($parameter);
+                if (!$result->isSuccess()) {
+                    $this->errors[] = ValidationErrorObject::createByValidatorResult($filter->getField(), $result);
                 }
             }
         }

--- a/Resource/AbstractResource.php
+++ b/Resource/AbstractResource.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Resource;
+
+use apivalk\apivalk\Documentation\OpenAPI\Object\TagObject;
+use apivalk\apivalk\Documentation\Property\AbstractProperty;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory;
+use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use apivalk\apivalk\Router\Route\Sort\Sort;
+
+abstract class AbstractResource
+{
+    /** @var string */
+    public const MODE_LIST = 'list';
+    /** @var string */
+    public const MODE_UPDATE = 'update';
+    /** @var string */
+    public const MODE_VIEW = 'view';
+    /** @var string */
+    public const MODE_CREATE = 'create';
+    /** @var string */
+    public const MODE_DELETE = 'delete';
+
+    /** @var array<string, mixed> */
+    private $data = [];
+    /** @var AbstractProperty[] */
+    private $properties = [];
+
+    /**
+     * Never overwrite __construct() in child classes.
+     */
+    final public function __construct()
+    {
+        $this->init();
+    }
+
+    abstract protected function init(): void;
+
+    abstract public function getIdentifierProperty(): AbstractProperty;
+
+    /** Returns base url for resource. Example: /api/v1 */
+    abstract public function getBaseUrl(): string;
+
+    abstract public function getName(): string;
+
+    public function getPluralName(): string
+    {
+        return $this->getName() . 's';
+    }
+
+    /**
+     * Filters this resource exposes for list endpoints. List controllers use this as the default
+     * catalog; each controller may expose a subset via its own filters() hook.
+     *
+     * @return FilterInterface[]
+     */
+    public function availableFilters(): array
+    {
+        return [];
+    }
+
+    /**
+     * Sortings this resource exposes for list endpoints. List controllers use this as the default
+     * catalog; each controller may expose a subset via its own sortings() hook.
+     *
+     * @return Sort[]
+     */
+    public function availableSortings(): array
+    {
+        return [];
+    }
+
+    /**
+     * OpenAPI tags that group operations for this resource. Controllers default to these; a
+     * controller may override via its tags() hook.
+     *
+     * @return TagObject[]
+     */
+    public function tags(): array
+    {
+        return [];
+    }
+
+    /**
+     * Return a property name array of properties that should be excluded from the given mode.
+     *
+     * Example:
+     *
+     * if ($mode === self::MODE_LIST) {
+     *   return ['password'];
+     * }
+     *
+     * In the list this property will not be returned or included in an array.
+     *
+     * @return string[]
+     */
+    abstract public function excludeFromMode(string $mode): array;
+
+    protected function addProperty(AbstractProperty $property): void
+    {
+        $this->properties[$property->getPropertyName()] = $property;
+    }
+
+    protected function hasProperty(string $propertyName): bool
+    {
+        return \array_key_exists($propertyName, $this->properties);
+    }
+
+    /**
+     * @return AbstractProperty[]
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function byArray(array $data): self
+    {
+        $resource = new static();
+        $identifierPropertyName = $resource->getIdentifierProperty()->getPropertyName();
+
+        foreach ($data as $propertyName => $value) {
+            if ($identifierPropertyName !== $propertyName
+                && !$resource->hasProperty($propertyName)
+            ) {
+                continue;
+            }
+
+            if ($identifierPropertyName === $propertyName) {
+                $resource->__set(
+                    $propertyName,
+                    ParameterBagFactory::typeCastValueByProperty($value, $resource->getIdentifierProperty())
+                );
+            } else {
+                $resource->__set(
+                    $propertyName,
+                    ParameterBagFactory::typeCastValueByProperty($value, $resource->getProperties()[$propertyName])
+                );
+            }
+        }
+
+        return $resource;
+    }
+
+    public static function byRequest(ApivalkRequestInterface $apivalkRequest): self
+    {
+        $resource = new static();
+
+        foreach ($apivalkRequest->body()->getIterator() as $bodyParameter) {
+            if (!$resource->hasProperty($bodyParameter->getName())) {
+                continue;
+            }
+
+            $resource->__set($bodyParameter->getName(), $bodyParameter->getValue());
+        }
+
+        $resourceIdentifierPropertyName = $resource->getIdentifierProperty()->getPropertyName();
+
+        $pathIdentifier = $apivalkRequest->path()->get($resourceIdentifierPropertyName);
+        if ($pathIdentifier !== null) {
+            $resource->__set($resourceIdentifierPropertyName, $pathIdentifier->getValue());
+        }
+
+        return $resource;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function __set(string $propertyName, $value): void
+    {
+        $this->data[$propertyName] = $value;
+    }
+
+    public function has(string $propertyName): bool
+    {
+        return isset($this->data[$propertyName]);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function __get(string $propertyName)
+    {
+        return $this->data[$propertyName] ?? null;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(string $mode): array
+    {
+        $excluded = $this->excludeFromMode($mode);
+        $data = [];
+
+        foreach ($this->data as $propertyName => $value) {
+            if (\in_array($propertyName, $excluded, true)) {
+                continue;
+            }
+
+            $data[$propertyName] = $value;
+        }
+
+        return $data;
+    }
+}

--- a/Router/Route/Route.php
+++ b/Router/Route/Route.php
@@ -11,10 +11,11 @@ use apivalk\apivalk\Http\Method\MethodInterface;
 use apivalk\apivalk\Http\Method\PatchMethod;
 use apivalk\apivalk\Http\Method\PostMethod;
 use apivalk\apivalk\Http\Method\PutMethod;
+use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\RateLimit\RateLimitInterface;
 use apivalk\apivalk\Router\Route\Filter\FilterInterface;
-use apivalk\apivalk\Router\Route\Sort\Sort;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
+use apivalk\apivalk\Router\Route\Sort\Sort;
 use apivalk\apivalk\Security\RouteAuthorization;
 
 class Route
@@ -99,6 +100,38 @@ class Route
     public static function put(string $url): self
     {
         return new self($url, new PutMethod());
+    }
+
+    public static function resource(AbstractResource $resource, string $mode): self
+    {
+        $route = null;
+        $url = \sprintf('%s/%s', $resource->getBaseUrl(), $resource->getPluralName());
+
+        if ($mode === AbstractResource::MODE_DELETE) {
+            $route = self::delete($url);
+        }
+
+        if ($mode === AbstractResource::MODE_LIST) {
+            $route = self::get($url);
+        }
+
+        if ($mode === AbstractResource::MODE_CREATE) {
+            $route = self::post($url);
+        }
+
+        if ($mode === AbstractResource::MODE_UPDATE) {
+            $route = self::patch(\sprintf('%s/{%s}', $url, $resource->getIdentifierProperty()->getPropertyName()));
+        }
+
+        if ($mode === AbstractResource::MODE_VIEW) {
+            $route = self::get(\sprintf('%s/{%s}', $url, $resource->getIdentifierProperty()->getPropertyName()));
+        }
+
+        if ($route === null) {
+            throw new \InvalidArgumentException(\sprintf('Resource Mode "%s" not supported', $mode));
+        }
+
+        return $route;
     }
 
     /**

--- a/Router/Router.php
+++ b/Router/Router.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Router;
 
 use apivalk\apivalk\Cache\CacheItem;
+use apivalk\apivalk\Documentation\Request\RequestDocumentationFactory;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Http\i18n\LocaleResolver;
 use apivalk\apivalk\Http\Method\MethodInterface;
@@ -47,12 +48,9 @@ class Router extends AbstractRouter
             return new MethodNotAllowedApivalkResponse();
         }
 
-        $request = $this->buildRequestByRoute(
-            $matchingRoutes[$requestMethod]['controllerClass'],
-            $matchingRoutes[$requestMethod]['route']
-        );
-
         $controller = $this->buildControllerByClass($matchingRoutes[$requestMethod]['controllerClass']);
+
+        $request = $this->buildRequestByRoute($controller, $matchingRoutes[$requestMethod]['route']);
 
         return $middlewareStack->handle($request, $controller);
     }
@@ -81,17 +79,16 @@ class Router extends AbstractRouter
         return $this->getControllerFactory()->create($controllerClass);
     }
 
-    /**
-     * @param class-string<AbstractApivalkController> $controllerClass
-     */
-    private function buildRequestByRoute(string $controllerClass, Route $route): ApivalkRequestInterface
+    private function buildRequestByRoute(AbstractApivalkController $controller, Route $route): ApivalkRequestInterface
     {
         /** @var class-string<ApivalkRequestInterface> $requestClass */
-        $requestClass = $controllerClass::getRequestClass();
+        $requestClass = $controller::getRequestClass();
+
+        $documentation = RequestDocumentationFactory::buildRuntimeDocumentation($route, \get_class($controller));
 
         $request = new $requestClass();
         $request->setLocale(LocaleResolver::resolve($this->getApivalk()->getLocalizationConfiguration()));
-        $request->populate($route);
+        $request->populate($route, $documentation);
 
         return $request;
     }

--- a/Tests/PhpUnit/Documentation/ApivalkRequestDocumentationTest.php
+++ b/Tests/PhpUnit/Documentation/ApivalkRequestDocumentationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Tests\PhpUnit\Documentation;
 
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
-use apivalk\apivalk\Documentation\Property\IntegerProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use PHPUnit\Framework\TestCase;
 
@@ -49,21 +48,5 @@ class ApivalkRequestDocumentationTest extends TestCase
         $this->assertCount(1, $pathProperties);
         $this->assertArrayHasKey('testPath', $pathProperties);
         $this->assertSame($property, $pathProperties['testPath']);
-    }
-
-    public function testAddPaginationQueryProperties(): void
-    {
-        $this->requestDocumentation->addPaginationQueryProperties();
-
-        $queryProperties = $this->requestDocumentation->getQueryProperties();
-        $this->assertCount(1, $queryProperties);
-        $this->assertArrayHasKey('page', $queryProperties);
-
-        /** @var IntegerProperty $pageProperty */
-        $pageProperty = $queryProperties['page'];
-        $this->assertInstanceOf(IntegerProperty::class, $pageProperty);
-        $this->assertSame('page', $pageProperty->getPropertyName());
-        $this->assertFalse($pageProperty->isRequired());
-        $this->assertSame(IntegerProperty::FORMAT_INT32, $pageProperty->getFormat());
     }
 }

--- a/Tests/PhpUnit/Documentation/ApivalkResponseDocumentationTest.php
+++ b/Tests/PhpUnit/Documentation/ApivalkResponseDocumentationTest.php
@@ -34,15 +34,4 @@ class ApivalkResponseDocumentationTest extends TestCase
 
         $this->assertSame($description, $this->responseDocumentation->getDescription());
     }
-
-    public function testSetAndGetResponsePagination(): void
-    {
-        $this->assertFalse($this->responseDocumentation->hasResponsePagination());
-
-        $this->responseDocumentation->setHasResponsePagination(true);
-        $this->assertTrue($this->responseDocumentation->hasResponsePagination());
-
-        $this->responseDocumentation->setHasResponsePagination(false);
-        $this->assertFalse($this->responseDocumentation->hasResponsePagination());
-    }
 }

--- a/Tests/PhpUnit/Documentation/DocBlock/DocBlockGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/DocBlock/DocBlockGeneratorTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Documentation\DocBlock;
 
-use PHPUnit\Framework\TestCase;
 use apivalk\apivalk\Documentation\DocBlock\DocBlockGenerator;
-use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
-use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use PHPUnit\Framework\TestCase;
 
 class DocBlockGeneratorTest extends TestCase
 {
@@ -113,5 +111,194 @@ PHP;
         $this->expectException(\RuntimeException::class);
         $generator = new DocBlockGenerator();
         $generator->run('/invalid/path', 'Namespace');
+    }
+
+    public function testRunGeneratesResourcePropertyDocBlocks(): void
+    {
+        $resourceDir = $this->tempDir . '/Resource';
+        mkdir($resourceDir);
+
+        $resourceClassName = 'TestResource_' . str_replace('.', '_', uniqid('', true));
+        $resourceFile = $resourceDir . '/' . $resourceClassName . '.php';
+        $resourceContent = <<<PHP
+<?php
+
+namespace TestNamespace\\Resource;
+
+use apivalk\\apivalk\\Documentation\\Property\\AbstractProperty;
+use apivalk\\apivalk\\Documentation\\Property\\FloatProperty;
+use apivalk\\apivalk\\Documentation\\Property\\StringProperty;
+use apivalk\\apivalk\\Resource\\AbstractResource;
+
+class {$resourceClassName} extends AbstractResource
+{
+    public function getIdentifierProperty(): AbstractProperty
+    {
+        return new StringProperty('thing_uuid', 'Identifier of the thing');
+    }
+
+    public function getBaseUrl(): string { return '/api/v1'; }
+    public function getName(): string { return 'thing'; }
+    public function excludeFromMode(string \$mode): array { return []; }
+
+    protected function init(): void
+    {
+        \$this->addProperty(new StringProperty('name', 'Name of the thing'));
+        \$this->addProperty((new FloatProperty('weight'))->setIsRequired(false));
+    }
+}
+PHP;
+        file_put_contents($resourceFile, $resourceContent);
+        require_once $resourceFile;
+
+        $controllerClassName = 'TestResourceController_' . str_replace('.', '_', uniqid('', true));
+        $controllerFile = $this->tempDir . '/' . $controllerClassName . '.php';
+        $controllerContent = <<<PHP
+<?php
+
+namespace TestNamespace;
+
+use apivalk\\apivalk\\Http\\Controller\\Resource\\AbstractListResourceController;
+use apivalk\\apivalk\\Http\\Request\\ApivalkRequestInterface;
+use apivalk\\apivalk\\Http\\Response\\AbstractApivalkResponse;
+use apivalk\\apivalk\\Http\\Response\\Resource\\ResourceListResponse;
+use apivalk\\apivalk\\Http\\Response\\Pagination\\PagePaginationPaginationResponse;
+use TestNamespace\\Resource\\{$resourceClassName};
+
+class {$controllerClassName} extends AbstractListResourceController
+{
+    public static function getResourceClass(): string
+    {
+        return {$resourceClassName}::class;
+    }
+
+    public function __invoke(ApivalkRequestInterface \$request): AbstractApivalkResponse
+    {
+        return new ResourceListResponse([], new PagePaginationPaginationResponse(1, 25, false, 0));
+    }
+}
+PHP;
+        file_put_contents($controllerFile, $controllerContent);
+        require_once $controllerFile;
+
+        $generator = new DocBlockGenerator();
+
+        ob_start();
+        $generator->run($this->tempDir, 'TestNamespace');
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Resource @property docblocks generated', $output);
+        $this->assertStringContainsString($resourceClassName, $output);
+
+        $updatedResource = file_get_contents($resourceFile);
+        $this->assertStringContainsString('@property string $thing_uuid', $updatedResource);
+        $this->assertStringContainsString('@property string $name', $updatedResource);
+        $this->assertStringContainsString('@property float|null $weight', $updatedResource);
+    }
+
+    public function testRunOnlyProcessesEachResourceClassOnce(): void
+    {
+        $resourceDir = $this->tempDir . '/Resource';
+        mkdir($resourceDir);
+
+        $resourceClassName = 'SharedResource_' . str_replace('.', '_', uniqid('', true));
+        $resourceFile = $resourceDir . '/' . $resourceClassName . '.php';
+        $resourceContent = <<<PHP
+<?php
+
+namespace TestNamespace\\Resource;
+
+use apivalk\\apivalk\\Documentation\\Property\\AbstractProperty;
+use apivalk\\apivalk\\Documentation\\Property\\StringProperty;
+use apivalk\\apivalk\\Resource\\AbstractResource;
+
+class {$resourceClassName} extends AbstractResource
+{
+    public function getIdentifierProperty(): AbstractProperty
+    {
+        return new StringProperty('shared_uuid');
+    }
+
+    public function getBaseUrl(): string { return '/api/v1'; }
+    public function getName(): string { return 'shared'; }
+    public function excludeFromMode(string \$mode): array { return []; }
+
+    protected function init(): void
+    {
+        \$this->addProperty(new StringProperty('name'));
+    }
+}
+PHP;
+        file_put_contents($resourceFile, $resourceContent);
+        require_once $resourceFile;
+
+        $listClassName = 'SharedListController_' . str_replace('.', '_', uniqid('', true));
+        $viewClassName = 'SharedViewController_' . str_replace('.', '_', uniqid('', true));
+
+        $listFile = $this->tempDir . '/' . $listClassName . '.php';
+        $viewFile = $this->tempDir . '/' . $viewClassName . '.php';
+
+        $listContent = <<<PHP
+<?php
+
+namespace TestNamespace;
+
+use apivalk\\apivalk\\Http\\Controller\\Resource\\AbstractListResourceController;
+use apivalk\\apivalk\\Http\\Request\\ApivalkRequestInterface;
+use apivalk\\apivalk\\Http\\Response\\AbstractApivalkResponse;
+use apivalk\\apivalk\\Http\\Response\\Resource\\ResourceListResponse;
+use apivalk\\apivalk\\Http\\Response\\Pagination\\PagePaginationPaginationResponse;
+use TestNamespace\\Resource\\{$resourceClassName};
+
+class {$listClassName} extends AbstractListResourceController
+{
+    public static function getResourceClass(): string { return {$resourceClassName}::class; }
+    public function __invoke(ApivalkRequestInterface \$request): AbstractApivalkResponse
+    {
+        return new ResourceListResponse([], new PagePaginationPaginationResponse(1, 25, false, 0));
+    }
+}
+PHP;
+
+        $viewContent = <<<PHP
+<?php
+
+namespace TestNamespace;
+
+use apivalk\\apivalk\\Http\\Controller\\Resource\\AbstractViewResourceController;
+use apivalk\\apivalk\\Http\\Request\\ApivalkRequestInterface;
+use apivalk\\apivalk\\Http\\Response\\AbstractApivalkResponse;
+use apivalk\\apivalk\\Http\\Response\\Resource\\ResourceViewResponse;
+use TestNamespace\\Resource\\{$resourceClassName};
+
+class {$viewClassName} extends AbstractViewResourceController
+{
+    public static function getResourceClass(): string { return {$resourceClassName}::class; }
+    public function __invoke(ApivalkRequestInterface \$request): AbstractApivalkResponse
+    {
+        return new ResourceViewResponse(new {$resourceClassName}());
+    }
+}
+PHP;
+
+        file_put_contents($listFile, $listContent);
+        file_put_contents($viewFile, $viewContent);
+        require_once $listFile;
+        require_once $viewFile;
+
+        $generator = new DocBlockGenerator();
+
+        ob_start();
+        $generator->run($this->tempDir, 'TestNamespace');
+        $output = ob_get_clean();
+
+        // Match line-by-line so "generated for X (from Y)" is counted once per resource class
+        $resourceLines = preg_grep('/Resource @property docblocks generated for /', explode("\n", $output));
+
+        $this->assertCount(
+            1,
+            $resourceLines,
+            'Resource shared by multiple controllers must only be processed once.'
+        );
     }
 }

--- a/Tests/PhpUnit/Documentation/DocBlock/DocBlockResourceGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/DocBlock/DocBlockResourceGeneratorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Documentation\DocBlock;
+
+use apivalk\apivalk\Documentation\DocBlock\DocBlockResource;
+use apivalk\apivalk\Documentation\DocBlock\DocBlockResourceGenerator;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class DocBlockResourceGeneratorTest extends TestCase
+{
+    public function testGenerateProducesDocBlockWithIdentifierAndAllProperties(): void
+    {
+        $generator = new DocBlockResourceGenerator();
+
+        $docBlock = $generator->generate(new AnimalResource());
+
+        self::assertInstanceOf(DocBlockResource::class, $docBlock);
+
+        $properties = $docBlock->getProperties();
+
+        self::assertArrayHasKey('animal_uuid', $properties);
+        self::assertArrayHasKey('name', $properties);
+        self::assertArrayHasKey('type', $properties);
+        self::assertArrayHasKey('weight', $properties);
+    }
+
+    public function testGeneratedDocBlockRendersExpectedAnnotations(): void
+    {
+        $generator = new DocBlockResourceGenerator();
+
+        $docBlock = $generator->generate(new AnimalResource());
+        $rendered = $docBlock->getResourceDocBlock();
+
+        self::assertStringStartsWith("/**\n", $rendered);
+        self::assertStringEndsWith("\n */", $rendered);
+
+        self::assertContains('@property string $animal_uuid', $rendered);
+        self::assertContains('@property string $name', $rendered);
+        self::assertContains('@property string $type', $rendered);
+        self::assertContains('@property float|null $weight', $rendered);
+    }
+
+    public function testEmptyResourceProducesPlaceholder(): void
+    {
+        $docBlock = new DocBlockResource();
+
+        $rendered = $docBlock->getResourceDocBlock();
+
+        self::assertContains('(no properties)', $rendered);
+    }
+
+    public function testPropertyDescriptionIsAppendedToAnnotation(): void
+    {
+        $generator = new DocBlockResourceGenerator();
+
+        $docBlock = $generator->generate(new AnimalResource());
+        $rendered = $docBlock->getResourceDocBlock();
+
+        self::assertContains('Unique identifier of the animal', $rendered);
+        self::assertContains('Name of the animal', $rendered);
+    }
+}

--- a/Tests/PhpUnit/Documentation/DocBlock/DocBlockResourceRequestTest.php
+++ b/Tests/PhpUnit/Documentation/DocBlock/DocBlockResourceRequestTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Documentation\DocBlock;
+
+use apivalk\apivalk\Documentation\DocBlock\DocBlockResourceRequest;
+use apivalk\apivalk\Documentation\DocBlock\DocBlockShape;
+use apivalk\apivalk\Http\Request\Pagination\PagePaginator;
+use apivalk\apivalk\Http\Request\Resource\ResourceRequest;
+use apivalk\apivalk\Router\Route\Filter\FilterBag;
+use apivalk\apivalk\Router\Route\Sort\SortBag;
+use PHPUnit\Framework\TestCase;
+
+class DocBlockResourceRequestTest extends TestCase
+{
+    public function testGetDocBlockOnlyContainsSortingAndFiltering(): void
+    {
+        $sortShape = new DocBlockShape('AnimalList', 'Sorting');
+        $filterShape = new DocBlockShape('AnimalList', 'Filtering');
+
+        $docBlock = new DocBlockResourceRequest($sortShape, $filterShape, null, ResourceRequest::class);
+        $rendered = $docBlock->getDocBlockOnly('My\\Namespace\\Shape');
+
+        self::assertStringContainsString('sorting()', $rendered);
+        self::assertStringContainsString('filtering()', $rendered);
+        self::assertStringNotContainsString('paginator()', $rendered);
+    }
+
+    public function testGetDocBlockOnlyContainsPaginatorWhenSet(): void
+    {
+        $sortShape = new DocBlockShape('AnimalList', 'Sorting');
+        $filterShape = new DocBlockShape('AnimalList', 'Filtering');
+
+        $docBlock = new DocBlockResourceRequest($sortShape, $filterShape, PagePaginator::class, ResourceRequest::class);
+        $rendered = $docBlock->getDocBlockOnly('My\\Namespace\\Shape');
+
+        self::assertStringContainsString('paginator()', $rendered);
+        self::assertStringContainsString(PagePaginator::class, $rendered);
+    }
+
+    public function testGetDocBlockUsesClassConstantsNotHardcodedStrings(): void
+    {
+        $sortShape = new DocBlockShape('AnimalList', 'Sorting');
+        $filterShape = new DocBlockShape('AnimalList', 'Filtering');
+
+        $docBlock = new DocBlockResourceRequest($sortShape, $filterShape, null, ResourceRequest::class);
+        $rendered = $docBlock->getDocBlockOnly('My\\Namespace\\Shape');
+
+        self::assertStringContainsString(SortBag::class, $rendered);
+        self::assertStringContainsString(FilterBag::class, $rendered);
+    }
+
+    public function testShapeNamespace(): void
+    {
+        $sortShape = new DocBlockShape('AnimalList', 'Sorting');
+        $filterShape = new DocBlockShape('AnimalList', 'Filtering');
+
+        $docBlock = new DocBlockResourceRequest($sortShape, $filterShape, null, ResourceRequest::class);
+
+        self::assertSame('My\\NS\\Shape', $docBlock->getShapeNamespace('My\\NS'));
+    }
+
+    public function testGetShapeFilenames(): void
+    {
+        $sortShape = new DocBlockShape('AnimalList', 'Sorting');
+        $filterShape = new DocBlockShape('AnimalList', 'Filtering');
+
+        $docBlock = new DocBlockResourceRequest($sortShape, $filterShape, null, ResourceRequest::class);
+        $filenames = $docBlock->getShapeFilenames('/var/app/Request');
+
+        self::assertArrayHasKey('sorting', $filenames);
+        self::assertArrayHasKey('filtering', $filenames);
+        self::assertStringContainsString('AnimalListSortingShape', $filenames['sorting']);
+        self::assertStringContainsString('AnimalListFilteringShape', $filenames['filtering']);
+    }
+}

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/OperationGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/OperationGeneratorTest.php
@@ -12,8 +12,8 @@ use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Router\RateLimit\RateLimitInterface;
 use apivalk\apivalk\Router\Route\Filter\StringFilter;
-use apivalk\apivalk\Router\Route\Sort\Sort;
 use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\Sort\Sort;
 use PHPUnit\Framework\TestCase;
 
 class TestResponse extends AbstractApivalkResponse
@@ -110,7 +110,7 @@ class OperationGeneratorTest extends TestCase
         );
         $this->assertFalse($orderByParameter->isRequired());
         $this->assertEquals(
-            '^([+-](id|price))(,([+-](id|price)))*$',
+            '/^([+-](id|price))(,([+-](id|price)))*$/',
             $orderByParameter->toArray()['schema']['pattern']
         );
     }
@@ -313,5 +313,90 @@ class OperationGeneratorTest extends TestCase
         foreach ($operation->getResponses() as $response) {
             $this->assertArrayHasKey('Content-Language', $response->getHeaders());
         }
+    }
+
+    public function testGenerateFromDocumentationProducesEquivalentOperation(): void
+    {
+        $generator = new OperationGenerator();
+        $route = $this->createRouteMock();
+
+        $documentations = [[
+            'statusCode' => TestResponse::getStatusCode(),
+            'documentation' => TestResponse::getDocumentation(),
+        ]];
+
+        $operation = $generator->generateFromDocumentation(
+            $route,
+            $this->createRequestDocMock(),
+            $documentations
+        );
+
+        $this->assertEquals('Route desc', $operation->getDescription());
+        $this->assertCount(6, $operation->getResponses()); // 1 custom + 5 default
+    }
+
+    public function testGenerateFromDocumentationSupportsMultipleResponseDocumentations(): void
+    {
+        $generator = new OperationGenerator();
+        $route = $this->createRouteMock();
+
+        $createDoc = new ApivalkResponseDocumentation();
+        $createDoc->setDescription('Created');
+
+        $viewDoc = new ApivalkResponseDocumentation();
+        $viewDoc->setDescription('Viewed');
+
+        $documentations = [
+            ['statusCode' => 201, 'documentation' => $createDoc],
+            ['statusCode' => 200, 'documentation' => $viewDoc],
+        ];
+
+        $operation = $generator->generateFromDocumentation(
+            $route,
+            $this->createRequestDocMock(),
+            $documentations
+        );
+
+        $statusCodes = [];
+        foreach ($operation->getResponses() as $response) {
+            $statusCodes[] = $response->getStatusCode();
+        }
+
+        $this->assertContains(200, $statusCodes);
+        $this->assertContains(201, $statusCodes);
+    }
+
+    public function testGenerateFromDocumentationStillEmitsAcceptLanguageParameter(): void
+    {
+        $generator = new OperationGenerator();
+        $route = $this->createRouteMock();
+
+        $operation = $generator->generateFromDocumentation(
+            $route,
+            $this->createRequestDocMock(),
+            []
+        );
+
+        $names = [];
+        foreach ($operation->getParameters() as $parameter) {
+            $names[] = $parameter->getName();
+        }
+
+        $this->assertContains('Accept-Language', $names);
+    }
+
+    public function testGenerateFromDocumentationWithoutCustomResponsesStillIncludesDefaults(): void
+    {
+        $generator = new OperationGenerator();
+        $route = $this->createRouteMock();
+
+        $operation = $generator->generateFromDocumentation(
+            $route,
+            $this->createRequestDocMock(),
+            []
+        );
+
+        // 0 custom + 5 default
+        $this->assertCount(5, $operation->getResponses());
     }
 }

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/PathItemGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/PathItemGeneratorTest.php
@@ -11,10 +11,15 @@ use apivalk\apivalk\Http\i18n\Locale;
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Router\RateLimit\RateLimitResult;
-use apivalk\apivalk\Router\Route\Sort\SortBag;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
 use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\Sort\SortBag;
 use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\CreateAnimalController;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\DeleteAnimalController;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\ListAnimalsController;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\UpdateAnimalController;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\ViewAnimalController;
 use PHPUnit\Framework\TestCase;
 
 class PathItemTestController extends AbstractApivalkController
@@ -62,8 +67,13 @@ class PathItemTestRequest implements ApivalkRequestInterface
         return new ApivalkRequestDocumentation();
     }
 
-    public function populate(Route $route): void
+    public function populate(Route $route, ApivalkRequestDocumentation $documentation): void
     {
+    }
+
+    public function getRuntimeDocumentation(): ApivalkRequestDocumentation
+    {
+        return self::getDocumentation();
     }
 
     public function getMethod(): \apivalk\apivalk\Http\Method\MethodInterface
@@ -78,19 +88,24 @@ class PathItemTestRequest implements ApivalkRequestInterface
 
     public function query(): \apivalk\apivalk\Http\Request\Parameter\ParameterBag
     {
-        return \apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory::createQueryBag(self::getDocumentation());
+        return \apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory::createQueryBag(
+            new Route('', new GetMethod()),
+            self::getDocumentation()->getQueryProperties()
+        );
     }
 
     public function body(): \apivalk\apivalk\Http\Request\Parameter\ParameterBag
     {
-        return \apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory::createBodyBag(self::getDocumentation());
+        return \apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory::createBodyBag(
+            self::getDocumentation()->getBodyProperties()
+        );
     }
 
     public function path(): \apivalk\apivalk\Http\Request\Parameter\ParameterBag
     {
         return \apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory::createPathBag(
             new Route('', new GetMethod()),
-            self::getDocumentation()
+            self::getDocumentation()->getPathProperties()
         );
     }
 
@@ -170,5 +185,123 @@ class PathItemGeneratorTest extends TestCase
 
         $pathItem = $generator->generate($routes);
         $this->assertNotNull($pathItem->getGet());
+    }
+
+    public function testListResourceControllerProducesGetOperation(): void
+    {
+        $generator = new PathItemGenerator();
+
+        $route = ListAnimalsController::getRoute();
+
+        $pathItem = $generator->generate([
+            ['route' => $route, 'controllerClass' => ListAnimalsController::class],
+        ]);
+
+        $this->assertNotNull($pathItem->getGet());
+        $this->assertNull($pathItem->getPost());
+        $this->assertNull($pathItem->getPatch());
+        $this->assertNull($pathItem->getDelete());
+    }
+
+    public function testCreateResourceControllerProducesPostOperationWithBody(): void
+    {
+        $generator = new PathItemGenerator();
+
+        $route = CreateAnimalController::getRoute();
+
+        $pathItem = $generator->generate([
+            ['route' => $route, 'controllerClass' => CreateAnimalController::class],
+        ]);
+
+        $this->assertNotNull($pathItem->getPost());
+
+        $requestBody = $pathItem->getPost()->getRequestBody();
+        $this->assertNotNull($requestBody, 'Create operation must include request body documentation.');
+    }
+
+    public function testViewResourceControllerProducesGetOperationWithIdentifierPathParameter(): void
+    {
+        $generator = new PathItemGenerator();
+
+        $route = ViewAnimalController::getRoute();
+
+        $pathItem = $generator->generate([
+            ['route' => $route, 'controllerClass' => ViewAnimalController::class],
+        ]);
+
+        $this->assertNotNull($pathItem->getGet());
+
+        $hasIdentifierPathParam = false;
+        foreach ($pathItem->getGet()->getParameters() as $parameter) {
+            if ($parameter->getName() === 'animal_uuid' && $parameter->getIn() === 'path') {
+                $hasIdentifierPathParam = true;
+            }
+        }
+
+        $this->assertTrue($hasIdentifierPathParam, 'View operation must expose the identifier as a path parameter.');
+    }
+
+    public function testUpdateResourceControllerProducesPatchOperationWithBodyAndIdentifier(): void
+    {
+        $generator = new PathItemGenerator();
+
+        $route = UpdateAnimalController::getRoute();
+
+        $pathItem = $generator->generate([
+            ['route' => $route, 'controllerClass' => UpdateAnimalController::class],
+        ]);
+
+        $this->assertNotNull($pathItem->getPatch());
+        $this->assertNotNull($pathItem->getPatch()->getRequestBody());
+
+        $hasIdentifierPathParam = false;
+        foreach ($pathItem->getPatch()->getParameters() as $parameter) {
+            if ($parameter->getName() === 'animal_uuid' && $parameter->getIn() === 'path') {
+                $hasIdentifierPathParam = true;
+            }
+        }
+
+        $this->assertTrue($hasIdentifierPathParam);
+    }
+
+    public function testDeleteResourceControllerProducesDeleteOperationWith204Response(): void
+    {
+        $generator = new PathItemGenerator();
+
+        $route = DeleteAnimalController::getRoute();
+
+        $pathItem = $generator->generate([
+            ['route' => $route, 'controllerClass' => DeleteAnimalController::class],
+        ]);
+
+        $this->assertNotNull($pathItem->getDelete());
+
+        $statusCodes = [];
+        foreach ($pathItem->getDelete()->getResponses() as $response) {
+            $statusCodes[] = $response->getStatusCode();
+        }
+
+        $this->assertContains(204, $statusCodes, 'Delete operation must declare a 204 (DeletedApivalkResponse) status.');
+    }
+
+    public function testListResourceControllerExposesPaginationQueryParameters(): void
+    {
+        $generator = new PathItemGenerator();
+
+        $route = ListAnimalsController::getRoute();
+
+        $pathItem = $generator->generate([
+            ['route' => $route, 'controllerClass' => ListAnimalsController::class],
+        ]);
+
+        $names = [];
+        foreach ($pathItem->getGet()->getParameters() as $parameter) {
+            if ($parameter->getIn() === 'query') {
+                $names[] = $parameter->getName();
+            }
+        }
+
+        $this->assertContains('limit', $names);
+        $this->assertContains('page', $names);
     }
 }

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/PathsGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/PathsGeneratorTest.php
@@ -11,9 +11,9 @@ use apivalk\apivalk\Http\i18n\Locale;
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Router\RateLimit\RateLimitResult;
-use apivalk\apivalk\Router\Route\Sort\SortBag;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
 use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\Sort\SortBag;
 use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
 use PHPUnit\Framework\TestCase;
 
@@ -62,8 +62,13 @@ class PathsTestRequest implements ApivalkRequestInterface
         return new ApivalkRequestDocumentation();
     }
 
-    public function populate(Route $route): void
+    public function populate(Route $route, ApivalkRequestDocumentation $documentation): void
     {
+    }
+
+    public function getRuntimeDocumentation(): ApivalkRequestDocumentation
+    {
+        return self::getDocumentation();
     }
 
     public function getMethod(): \apivalk\apivalk\Http\Method\MethodInterface
@@ -78,19 +83,24 @@ class PathsTestRequest implements ApivalkRequestInterface
 
     public function query(): \apivalk\apivalk\Http\Request\Parameter\ParameterBag
     {
-        return \apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory::createQueryBag(self::getDocumentation());
+        return \apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory::createQueryBag(
+            new Route('', new GetMethod()),
+            self::getDocumentation()->getQueryProperties()
+        );
     }
 
     public function body(): \apivalk\apivalk\Http\Request\Parameter\ParameterBag
     {
-        return \apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory::createBodyBag(self::getDocumentation());
+        return \apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory::createBodyBag(
+            self::getDocumentation()->getBodyProperties()
+        );
     }
 
     public function path(): \apivalk\apivalk\Http\Request\Parameter\ParameterBag
     {
         return \apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory::createPathBag(
             new Route('', new GetMethod()),
-            self::getDocumentation()
+            self::getDocumentation()->getPathProperties()
         );
     }
 

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/ResponseGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/ResponseGeneratorTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Documentation\OpenAPI\Generator;
 
-use PHPUnit\Framework\TestCase;
+use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
 use apivalk\apivalk\Documentation\OpenAPI\Generator\ResponseGenerator;
 use apivalk\apivalk\Documentation\OpenAPI\Object\HeaderObject;
-use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use PHPUnit\Framework\TestCase;
 
 class ResponseGeneratorTest extends TestCase
 {
@@ -17,7 +17,6 @@ class ResponseGeneratorTest extends TestCase
         $doc = $this->createMock(ApivalkResponseDocumentation::class);
         $doc->method('getDescription')->willReturn('Response desc');
         $doc->method('getProperties')->willReturn([]);
-        $doc->method('hasResponsePagination')->willReturn(false);
 
         $response = $generator->generate(200, $doc);
 
@@ -32,7 +31,6 @@ class ResponseGeneratorTest extends TestCase
         $doc = $this->createMock(ApivalkResponseDocumentation::class);
         $doc->method('getDescription')->willReturn('Response with headers');
         $doc->method('getProperties')->willReturn([]);
-        $doc->method('hasResponsePagination')->willReturn(false);
 
         $headers = [
             'Content-Language' => new HeaderObject('The locale of the response content.'),

--- a/Tests/PhpUnit/Documentation/Response/ResponseDocumentationFactoryTest.php
+++ b/Tests/PhpUnit/Documentation/Response/ResponseDocumentationFactoryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Documentation\Response;
+
+use apivalk\apivalk\Documentation\Response\ResponseDocumentationFactory;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class ResponseDocumentationFactoryTest extends TestCase
+{
+    public function testViewModeIncludesAllProperties(): void
+    {
+        $doc = ResponseDocumentationFactory::create(new AnimalResource(), AbstractResource::MODE_VIEW);
+
+        $names = array_map(static function ($p) {
+            return $p->getPropertyName();
+        }, $doc->getProperties());
+
+        self::assertContains('animal_uuid', $names);
+        self::assertContains('name', $names);
+        self::assertContains('type', $names);
+        self::assertContains('weight', $names);
+    }
+
+    public function testListModeExcludesWeightForAnimalResource(): void
+    {
+        $doc = ResponseDocumentationFactory::create(new AnimalResource(), AbstractResource::MODE_LIST);
+
+        $names = array_map(static function ($p) {
+            return $p->getPropertyName();
+        }, $doc->getProperties());
+
+        self::assertContains('animal_uuid', $names);
+        self::assertContains('name', $names);
+        self::assertNotContains('weight', $names);
+    }
+
+    public function testDescriptionIsSet(): void
+    {
+        $doc = ResponseDocumentationFactory::create(new AnimalResource(), AbstractResource::MODE_VIEW);
+
+        self::assertSame('View animal response', $doc->getDescription());
+    }
+
+    public function testIdentifierIsAlwaysIncluded(): void
+    {
+        foreach ([
+            AbstractResource::MODE_CREATE,
+            AbstractResource::MODE_UPDATE,
+            AbstractResource::MODE_LIST,
+            AbstractResource::MODE_VIEW,
+            AbstractResource::MODE_DELETE,
+        ] as $mode) {
+            $doc = ResponseDocumentationFactory::create(new AnimalResource(), $mode);
+
+            $names = array_map(static function ($p) {
+                return $p->getPropertyName();
+            }, $doc->getProperties());
+
+            self::assertContains('animal_uuid', $names, "Identifier missing for mode: $mode");
+        }
+    }
+}

--- a/Tests/PhpUnit/Http/Request/AbstractApivalkRequestTest.php
+++ b/Tests/PhpUnit/Http/Request/AbstractApivalkRequestTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Tests\PhpUnit\Http\Request;
 
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Documentation\Property\IntegerProperty;
 use apivalk\apivalk\Http\Method\MethodInterface;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
-use apivalk\apivalk\Router\Route\Sort\SortBag;
-use apivalk\apivalk\Router\Route\Route;
-use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
 use apivalk\apivalk\Router\Route\Filter\IntegerFilter;
-use apivalk\apivalk\Documentation\Property\IntegerProperty;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\Sort\SortBag;
+use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
 use PHPUnit\Framework\TestCase;
 
 class AbstractApivalkRequestTest extends TestCase
@@ -31,7 +31,7 @@ class AbstractApivalkRequestTest extends TestCase
         $route = Route::get('/test')
             ->filtering([$filter]);
 
-        $request->populate($route);
+        $request->populate($route, new ApivalkRequestDocumentation());
 
         $this->assertEquals(123, $request->filtering()->id->getValue());
         $this->assertInstanceOf(IntegerFilter::class, $request->filtering()->get('id'));
@@ -66,7 +66,7 @@ class AbstractApivalkRequestTest extends TestCase
         $route->method('getMethod')->willReturn($method);
 
         // Mock global factories is hard, but we can check if they are called and set bags
-        $request->populate($route);
+        $request->populate($route, new ApivalkRequestDocumentation());
 
         $this->assertSame($method, $request->getMethod());
         $this->assertInstanceOf(\apivalk\apivalk\Http\Request\Parameter\ParameterBag::class, $request->header());

--- a/Tests/PhpUnit/Http/Request/Parameter/ParameterBagFactoryTest.php
+++ b/Tests/PhpUnit/Http/Request/Parameter/ParameterBagFactoryTest.php
@@ -56,7 +56,7 @@ class ParameterBagFactoryTest extends TestCase
 
         $route = $this->createMock(Route::class);
 
-        $bag = ParameterBagFactory::createQueryBag($route, $doc);
+        $bag = ParameterBagFactory::createQueryBag($route, $doc->getQueryProperties());
         $this->assertEquals('John', $bag->name);
         $this->assertNull($bag->age);
     }
@@ -71,7 +71,7 @@ class ParameterBagFactoryTest extends TestCase
 
         $_SERVER['REQUEST_URI'] = '/users/123';
 
-        $bag = ParameterBagFactory::createPathBag($route, $doc);
+        $bag = ParameterBagFactory::createPathBag($route, $doc->getPathProperties());
         $this->assertEquals(123, $bag->id);
         $this->assertIsInt($bag->id);
     }
@@ -85,7 +85,7 @@ class ParameterBagFactoryTest extends TestCase
         $_POST['name'] = 'Jane';
         $_POST['age'] = '30';
 
-        $bag = ParameterBagFactory::createBodyBag($doc);
+        $bag = ParameterBagFactory::createBodyBag($doc->getBodyProperties());
         $this->assertEquals('Jane', $bag->name);
         $this->assertEquals(30, $bag->age);
         $this->assertIsInt($bag->age);

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/AuthIdentityPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/AuthIdentityPopulationStrategyTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Http\Request\Population\Strategy\AuthIdentityPopulationStrategy;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity;
+use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class AuthIdentityPopulationStrategyTest extends TestCase
+{
+    public function testSetsGuestAuthIdentityByDefault(): void
+    {
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+
+        $request = $this->makeRequest();
+        $strategy = new AuthIdentityPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertInstanceOf(GuestAuthIdentity::class, $request->getAuthIdentity());
+    }
+
+    private function makeRequest(): AbstractApivalkRequest
+    {
+        return new class extends AbstractApivalkRequest {
+            /** @var AbstractAuthIdentity|null */
+            private $identity;
+
+            public static function getDocumentation(): ApivalkRequestDocumentation
+            {
+                return new ApivalkRequestDocumentation();
+            }
+
+            public function setAuthIdentity(AbstractAuthIdentity $authIdentity): void
+            {
+                $this->identity = $authIdentity;
+            }
+
+            public function getAuthIdentity(): AbstractAuthIdentity
+            {
+                return $this->identity;
+            }
+        };
+    }
+}

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/FilteringPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/FilteringPopulationStrategyTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Documentation\Property\StringProperty;
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Parameter\Parameter;
+use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Http\Request\Population\Strategy\FilteringPopulationStrategy;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Router\Route\Filter\FilterBag;
+use apivalk\apivalk\Router\Route\Filter\StringFilter;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class FilteringPopulationStrategyTest extends TestCase
+{
+    public function testFiltersWithNoQueryParamsHaveNullValues(): void
+    {
+        $property = new StringProperty('status');
+        $filter = StringFilter::equals($property);
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route->filtering([$filter]);
+
+        $queryBag = new ParameterBag();
+        $request = $this->makeRequest($queryBag);
+
+        $strategy = new FilteringPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        $filterBag = $request->filtering();
+        self::assertTrue($filterBag->has('status'));
+        self::assertNull($filterBag->get('status')->getValue());
+    }
+
+    public function testFiltersPickUpValueFromQueryBag(): void
+    {
+        $property = new StringProperty('status');
+        $filter = StringFilter::equals($property);
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route->filtering([$filter]);
+
+        $queryBag = new ParameterBag();
+        $queryBag->set(new Parameter('status', 'active', 'active'));
+        $request = $this->makeRequest($queryBag);
+
+        $strategy = new FilteringPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        $filterBag = $request->filtering();
+        self::assertSame('active', $filterBag->get('status')->getValue());
+    }
+
+    public function testFilterCloneDoesNotMutateOriginalRoute(): void
+    {
+        $property = new StringProperty('status');
+        $filter = StringFilter::equals($property);
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route->filtering([$filter]);
+
+        $queryBag = new ParameterBag();
+        $queryBag->set(new Parameter('status', 'active', 'active'));
+        $request = $this->makeRequest($queryBag);
+
+        $strategy = new FilteringPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertNull($route->getFilters()[0]->getValue());
+    }
+
+    public function testEmptyRouteFiltersProducesEmptyFilterBag(): void
+    {
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+
+        $request = $this->makeRequest(new ParameterBag());
+
+        $strategy = new FilteringPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertCount(0, $request->filtering());
+    }
+
+    private function makeRequest(ParameterBag $queryBag): AbstractApivalkRequest
+    {
+        return new class($queryBag) extends AbstractApivalkRequest {
+            /** @var ParameterBag */
+            private $queryBag;
+            /** @var FilterBag */
+            private $filterBag;
+
+            public function __construct(ParameterBag $queryBag)
+            {
+                $this->queryBag = $queryBag;
+                $this->filterBag = new FilterBag();
+            }
+
+            public static function getDocumentation(): ApivalkRequestDocumentation
+            {
+                return new ApivalkRequestDocumentation();
+            }
+
+            public function query(): ParameterBag
+            {
+                return $this->queryBag;
+            }
+
+            public function setFilterBag(FilterBag $bag): void
+            {
+                $this->filterBag = $bag;
+            }
+
+            public function filtering(): FilterBag
+            {
+                return $this->filterBag;
+            }
+        };
+    }
+}

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/IpPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/IpPopulationStrategyTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Http\Request\Population\Strategy\IpPopulationStrategy;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class IpPopulationStrategyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['REMOTE_ADDR']);
+    }
+
+    public function testSetsIpFromServer(): void
+    {
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+
+        $request = $this->makeRequest();
+        $strategy = new IpPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertSame('1.2.3.4', $request->getIp());
+    }
+
+    private function makeRequest(): AbstractApivalkRequest
+    {
+        return new class extends AbstractApivalkRequest {
+            /** @var string */
+            private $ip = '';
+
+            public static function getDocumentation(): ApivalkRequestDocumentation
+            {
+                return new ApivalkRequestDocumentation();
+            }
+
+            public function setIp(?string $ip): void
+            {
+                $this->ip = $ip ?? '';
+            }
+
+            public function getIp(): string
+            {
+                return $this->ip;
+            }
+        };
+    }
+}

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/MethodPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/MethodPopulationStrategyTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Http\Method\MethodInterface;
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Http\Request\Population\Strategy\MethodPopulationStrategy;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class MethodPopulationStrategyTest extends TestCase
+{
+    public function testSetsMethodFromRoute(): void
+    {
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+
+        $request = $this->makeRequest();
+        $strategy = new MethodPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertInstanceOf(MethodInterface::class, $request->getMethod());
+        self::assertSame(\get_class($route->getMethod()), \get_class($request->getMethod()));
+    }
+
+    private function makeRequest(): AbstractApivalkRequest
+    {
+        return new class extends AbstractApivalkRequest {
+            /** @var MethodInterface|null */
+            private $method;
+
+            public static function getDocumentation(): ApivalkRequestDocumentation
+            {
+                return new ApivalkRequestDocumentation();
+            }
+
+            public function setMethod(MethodInterface $method): void
+            {
+                $this->method = $method;
+            }
+
+            public function getMethod(): MethodInterface
+            {
+                return $this->method;
+            }
+        };
+    }
+}

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/PaginationPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/PaginationPopulationStrategyTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Pagination\OffsetPaginator;
+use apivalk\apivalk\Http\Request\Pagination\PagePaginator;
+use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Http\Request\Population\Strategy\PaginationPopulationStrategy;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Router\Route\Pagination\Pagination;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class PaginationPopulationStrategyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        unset($_GET['page'], $_GET['per_page'], $_GET['limit'], $_GET['offset']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_GET['page'], $_GET['per_page'], $_GET['limit'], $_GET['offset']);
+    }
+
+    public function testNoPaginationOnRouteLeavesPaginatorNull(): void
+    {
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+
+        $request = $this->makeRequest();
+        $strategy = new PaginationPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertNull($request->paginator());
+    }
+
+    public function testPagePaginatorIsCreatedForPageType(): void
+    {
+        $_GET['page'] = '2';
+        $_GET['per_page'] = '10';
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route->pagination(new Pagination(Pagination::TYPE_PAGE, 100));
+
+        $request = $this->makeRequest();
+        $strategy = new PaginationPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertInstanceOf(PagePaginator::class, $request->paginator());
+    }
+
+    public function testOffsetPaginatorIsCreatedForOffsetType(): void
+    {
+        $_GET['limit'] = '20';
+        $_GET['offset'] = '40';
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route->pagination(new Pagination(Pagination::TYPE_OFFSET, 100));
+
+        $request = $this->makeRequest();
+        $strategy = new PaginationPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertInstanceOf(OffsetPaginator::class, $request->paginator());
+    }
+
+    private function makeRequest(): AbstractApivalkRequest
+    {
+        return new class extends AbstractApivalkRequest {
+            /** @var mixed */
+            private $paginator;
+
+            public static function getDocumentation(): ApivalkRequestDocumentation
+            {
+                return new ApivalkRequestDocumentation();
+            }
+
+            public function query(): ParameterBag
+            {
+                return new ParameterBag();
+            }
+
+            public function setPaginator($paginator): void
+            {
+                $this->paginator = $paginator;
+            }
+
+            public function paginator()
+            {
+                return $this->paginator;
+            }
+        };
+    }
+}

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/QueryParameterPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/QueryParameterPopulationStrategyTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Documentation\Property\StringProperty;
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Http\Request\Population\Strategy\QueryParameterPopulationStrategy;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class QueryParameterPopulationStrategyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_GET = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = [];
+    }
+
+    public function testKnownQueryPropertyIsPopulated(): void
+    {
+        $_GET['search'] = 'cat';
+
+        $doc = new ApivalkRequestDocumentation();
+        $doc->addQueryProperty(new StringProperty('search'));
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+
+        $request = $this->makeRequest();
+        $strategy = new QueryParameterPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, $doc));
+
+        self::assertNotNull($request->query()->get('search'));
+        self::assertSame('cat', $request->query()->get('search')->getValue());
+    }
+
+    public function testUnknownQueryParameterIsIgnored(): void
+    {
+        $_GET['unknown'] = 'foo';
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+
+        $request = $this->makeRequest();
+        $strategy = new QueryParameterPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertNull($request->query()->get('unknown'));
+    }
+
+    public function testOrderByIsNoLongerHandledByQueryBag(): void
+    {
+        $_GET['order_by'] = 'name';
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+
+        $request = $this->makeRequest();
+        $strategy = new QueryParameterPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertNull($request->query()->get('order_by'));
+    }
+
+    private function makeRequest(): AbstractApivalkRequest
+    {
+        return new class extends AbstractApivalkRequest {
+            /** @var ParameterBag */
+            private $queryBag;
+
+            public function __construct()
+            {
+                $this->queryBag = new ParameterBag();
+            }
+
+            public static function getDocumentation(): ApivalkRequestDocumentation
+            {
+                return new ApivalkRequestDocumentation();
+            }
+
+            public function setQueryParameterBag(ParameterBag $bag): void
+            {
+                $this->queryBag = $bag;
+            }
+
+            public function query(): ParameterBag
+            {
+                return $this->queryBag;
+            }
+        };
+    }
+}

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/SortingPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/SortingPopulationStrategyTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Http\Request\Population\Strategy;
+
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
+use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
+use apivalk\apivalk\Http\Request\Population\Strategy\SortingPopulationStrategy;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\Sort\Sort;
+use apivalk\apivalk\Router\Route\Sort\SortBag;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class SortingPopulationStrategyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        unset($_GET['order_by']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_GET['order_by']);
+    }
+
+    public function testPopulatesDefaultSortingsFromRoute(): void
+    {
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route->sorting([Sort::asc('name'), Sort::desc('weight')]);
+
+        $request = $this->makeRequest();
+        $strategy = new SortingPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        $bag = $request->sorting();
+        self::assertTrue($bag->has('name'));
+        self::assertTrue($bag->has('weight'));
+        self::assertTrue($bag->get('name')->isAsc());
+        self::assertTrue($bag->get('weight')->isDesc());
+    }
+
+    public function testOrderByQueryParamOverridesDirection(): void
+    {
+        $_GET['order_by'] = '-name';
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route->sorting([Sort::asc('name')]);
+
+        $request = $this->makeRequest();
+        $strategy = new SortingPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        $bag = $request->sorting();
+        self::assertTrue($bag->has('name'));
+        self::assertTrue($bag->get('name')->isDesc());
+    }
+
+    public function testOrderByQueryParamWithPlusPrefix(): void
+    {
+        $_GET['order_by'] = '+name';
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+
+        $request = $this->makeRequest();
+        $strategy = new SortingPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        $bag = $request->sorting();
+        self::assertTrue($bag->has('name'));
+        self::assertTrue($bag->get('name')->isAsc());
+    }
+
+    public function testOrderByQueryParamWithoutPrefix(): void
+    {
+        $_GET['order_by'] = 'name';
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+
+        $request = $this->makeRequest();
+        $strategy = new SortingPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        $bag = $request->sorting();
+        self::assertTrue($bag->has('name'));
+        self::assertTrue($bag->get('name')->isAsc());
+    }
+
+    public function testMultipleFieldsInOrderBy(): void
+    {
+        $_GET['order_by'] = '+name,-weight';
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+
+        $request = $this->makeRequest();
+        $strategy = new SortingPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        $bag = $request->sorting();
+        self::assertTrue($bag->has('name'));
+        self::assertTrue($bag->has('weight'));
+        self::assertTrue($bag->get('name')->isAsc());
+        self::assertTrue($bag->get('weight')->isDesc());
+    }
+
+    public function testEmptyOrderByIsIgnored(): void
+    {
+        $_GET['order_by'] = '';
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+
+        $request = $this->makeRequest();
+        $strategy = new SortingPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertCount(0, $request->sorting());
+    }
+
+    public function testNoOrderByLeavesRouteDefaults(): void
+    {
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route->sorting([Sort::asc('name')]);
+
+        $request = $this->makeRequest();
+        $strategy = new SortingPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertCount(1, $request->sorting());
+    }
+
+    private function makeRequest(): AbstractApivalkRequest
+    {
+        return new class extends AbstractApivalkRequest {
+            /** @var SortBag */
+            private $sortBag;
+
+            public function __construct()
+            {
+                $this->sortBag = new SortBag();
+            }
+
+            public static function getDocumentation(): ApivalkRequestDocumentation
+            {
+                return new ApivalkRequestDocumentation();
+            }
+
+            public function setSortBag(SortBag $bag): void
+            {
+                $this->sortBag = $bag;
+            }
+
+            public function sorting(): SortBag
+            {
+                return $this->sortBag;
+            }
+        };
+    }
+}

--- a/Tests/PhpUnit/Http/Response/Resource/ResourceCreatedResponseTest.php
+++ b/Tests/PhpUnit/Http/Response/Resource/ResourceCreatedResponseTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Http\Response\Resource;
+
+use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use apivalk\apivalk\Http\Response\Resource\ResourceCreatedResponse;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class ResourceCreatedResponseTest extends TestCase
+{
+    public function testStatusCodeIs201(): void
+    {
+        $resource = $this->makeResource();
+        $response = new ResourceCreatedResponse($resource);
+
+        self::assertSame(201, $response::getStatusCode());
+    }
+
+    public function testToArrayWrapsDataUnderKey(): void
+    {
+        $resource = $this->makeResource();
+        $response = new ResourceCreatedResponse($resource);
+
+        $array = $response->toArray();
+
+        self::assertArrayHasKey('data', $array);
+    }
+
+    public function testGetDocumentationReturnsEmptyDocumentation(): void
+    {
+        $doc = ResourceCreatedResponse::getDocumentation();
+
+        self::assertInstanceOf(ApivalkResponseDocumentation::class, $doc);
+    }
+
+    private function makeResource(): AbstractResource
+    {
+        $resource = new AnimalResource();
+        $resource->animal_uuid = 'abc-123';
+        $resource->name = 'Leo';
+        $resource->type = 'lion';
+
+        return $resource;
+    }
+}

--- a/Tests/PhpUnit/Http/Response/Resource/ResourceDeletedResponseTest.php
+++ b/Tests/PhpUnit/Http/Response/Resource/ResourceDeletedResponseTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Http\Response\Resource;
+
+use apivalk\apivalk\Http\Response\Resource\ResourceDeletedResponse;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class ResourceDeletedResponseTest extends TestCase
+{
+    public function testStatusCodeIs200(): void
+    {
+        self::assertSame(200, ResourceDeletedResponse::getStatusCode());
+    }
+
+    public function testToArrayWrapsDataUnderKey(): void
+    {
+        $resource = new AnimalResource();
+        $resource->name = 'Leo';
+
+        $response = new ResourceDeletedResponse($resource);
+
+        self::assertArrayHasKey('data', $response->toArray());
+    }
+}

--- a/Tests/PhpUnit/Http/Response/Resource/ResourceListResponseTest.php
+++ b/Tests/PhpUnit/Http/Response/Resource/ResourceListResponseTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Http\Response\Resource;
+
+use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceListResponse;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class ResourceListResponseTest extends TestCase
+{
+    public function testStatusCodeIs200(): void
+    {
+        self::assertSame(200, ResourceListResponse::getStatusCode());
+    }
+
+    public function testToArrayContainsDataKey(): void
+    {
+        $resource = new AnimalResource();
+        $resource->name = 'Leo';
+        $resource->type = 'lion';
+
+        $pagination = new PagePaginationPaginationResponse(1, 10, false);
+        $response = new ResourceListResponse([$resource], $pagination);
+
+        $array = $response->toArray();
+        self::assertArrayHasKey('data', $array);
+        self::assertIsArray($array['data']);
+        self::assertCount(1, $array['data']);
+    }
+
+    public function testGetDocumentationReturnsEmptyDocumentation(): void
+    {
+        self::assertInstanceOf(ApivalkResponseDocumentation::class, ResourceListResponse::getDocumentation());
+    }
+}

--- a/Tests/PhpUnit/Http/Response/Resource/ResourceUpdatedResponseTest.php
+++ b/Tests/PhpUnit/Http/Response/Resource/ResourceUpdatedResponseTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Http\Response\Resource;
+
+use apivalk\apivalk\Http\Response\Resource\ResourceUpdatedResponse;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class ResourceUpdatedResponseTest extends TestCase
+{
+    public function testStatusCodeIs200(): void
+    {
+        self::assertSame(200, ResourceUpdatedResponse::getStatusCode());
+    }
+
+    public function testToArrayWrapsDataUnderKey(): void
+    {
+        $resource = new AnimalResource();
+        $resource->name = 'Leo';
+
+        $response = new ResourceUpdatedResponse($resource);
+
+        self::assertArrayHasKey('data', $response->toArray());
+    }
+}

--- a/Tests/PhpUnit/Http/Response/Resource/ResourceViewResponseTest.php
+++ b/Tests/PhpUnit/Http/Response/Resource/ResourceViewResponseTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Http\Response\Resource;
+
+use apivalk\apivalk\Http\Response\Resource\ResourceViewResponse;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class ResourceViewResponseTest extends TestCase
+{
+    public function testStatusCodeIs200(): void
+    {
+        self::assertSame(200, ResourceViewResponse::getStatusCode());
+    }
+
+    public function testToArrayWrapsDataUnderKey(): void
+    {
+        $resource = new AnimalResource();
+        $resource->name = 'Leo';
+        $resource->type = 'lion';
+
+        $response = new ResourceViewResponse($resource);
+
+        $array = $response->toArray();
+        self::assertArrayHasKey('data', $array);
+        self::assertIsArray($array['data']);
+    }
+}

--- a/Tests/PhpUnit/Middleware/RequestValidationMiddlewareTest.php
+++ b/Tests/PhpUnit/Middleware/RequestValidationMiddlewareTest.php
@@ -6,6 +6,7 @@ namespace apivalk\apivalk\Tests\PhpUnit\Middleware;
 
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Documentation\Property\AbstractProperty;
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Documentation\Property\Validator\AbstractValidator;
 use apivalk\apivalk\Documentation\Property\Validator\ValidatorResult;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
@@ -17,11 +18,10 @@ use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\BadValidationApivalkResponse;
 use apivalk\apivalk\Middleware\RequestValidationMiddleware;
 use apivalk\apivalk\Router\RateLimit\RateLimitResult;
-use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Router\Route\Filter\FilterBag;
 use apivalk\apivalk\Router\Route\Filter\StringFilter;
-use apivalk\apivalk\Router\Route\Sort\SortBag;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
+use apivalk\apivalk\Router\Route\Sort\SortBag;
 use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
 use PHPUnit\Framework\TestCase;
 
@@ -65,8 +65,13 @@ class RequestValidationMiddlewareTest extends TestCase
                 return self::$d;
             }
 
-            public function populate(\apivalk\apivalk\Router\Route\Route $route): void
+            public function populate(\apivalk\apivalk\Router\Route\Route $route, ApivalkRequestDocumentation $documentation): void
             {
+            }
+
+            public function getRuntimeDocumentation(): ApivalkRequestDocumentation
+            {
+                return self::$d;
             }
 
             public function getMethod(): \apivalk\apivalk\Http\Method\MethodInterface
@@ -199,8 +204,13 @@ class RequestValidationMiddlewareTest extends TestCase
                 return self::$d;
             }
 
-            public function populate(\apivalk\apivalk\Router\Route\Route $route): void
+            public function populate(\apivalk\apivalk\Router\Route\Route $route, ApivalkRequestDocumentation $documentation): void
             {
+            }
+
+            public function getRuntimeDocumentation(): ApivalkRequestDocumentation
+            {
+                return self::$d;
             }
 
             public function getMethod(): \apivalk\apivalk\Http\Method\MethodInterface
@@ -243,7 +253,6 @@ class RequestValidationMiddlewareTest extends TestCase
             public function setAuthIdentity(\apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity $authIdentity
             ): void {
             }
-
 
             public function getIp(): string
             {
@@ -417,8 +426,13 @@ class RequestValidationMiddlewareTest extends TestCase
                 return self::$d;
             }
 
-            public function populate(\apivalk\apivalk\Router\Route\Route $route): void
+            public function populate(\apivalk\apivalk\Router\Route\Route $route, ApivalkRequestDocumentation $documentation): void
             {
+            }
+
+            public function getRuntimeDocumentation(): ApivalkRequestDocumentation
+            {
+                return self::$d;
             }
 
             public function getMethod(): \apivalk\apivalk\Http\Method\MethodInterface

--- a/Tests/PhpUnit/Middleware/SortingValidationTest.php
+++ b/Tests/PhpUnit/Middleware/SortingValidationTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Middleware;
+
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Http\Controller\AbstractApivalkController;
+use apivalk\apivalk\Http\i18n\Locale;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\BadValidationApivalkResponse;
+use apivalk\apivalk\Middleware\RequestValidationMiddleware;
+use apivalk\apivalk\Router\RateLimit\RateLimitResult;
+use apivalk\apivalk\Router\Route\Filter\FilterBag;
+use apivalk\apivalk\Router\Route\Sort\Sort;
+use apivalk\apivalk\Router\Route\Sort\SortBag;
+use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
+use PHPUnit\Framework\TestCase;
+
+class SortingValidationTest extends TestCase
+{
+    public function testValidSortFieldPassesValidation(): void
+    {
+        $doc = new ApivalkRequestDocumentation();
+        $doc->addAvailableSortField('name');
+
+        $sortBag = new SortBag();
+        $sortBag->set(Sort::asc('name'));
+
+        $request = $this->makeRequest($doc, $sortBag);
+        $middleware = new RequestValidationMiddleware();
+        $next = function () {
+            return $this->createMock(AbstractApivalkResponse::class);
+        };
+
+        $response = $middleware->process($request, $this->createMock(AbstractApivalkController::class), $next);
+
+        self::assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    public function testInvalidSortFieldFailsValidation(): void
+    {
+        $doc = new ApivalkRequestDocumentation();
+        $doc->addAvailableSortField('name');
+
+        $sortBag = new SortBag();
+        $sortBag->set(Sort::asc('hacked_field'));
+
+        $request = $this->makeRequest($doc, $sortBag);
+        $middleware = new RequestValidationMiddleware();
+        $next = function () {
+            return $this->createMock(AbstractApivalkResponse::class);
+        };
+
+        $response = $middleware->process($request, $this->createMock(AbstractApivalkController::class), $next);
+
+        self::assertInstanceOf(BadValidationApivalkResponse::class, $response);
+        /** @var BadValidationApivalkResponse $response */
+        self::assertCount(1, $response->getErrors());
+    }
+
+    public function testNoAvailableSortFieldsSkipsValidation(): void
+    {
+        $doc = new ApivalkRequestDocumentation();
+
+        $sortBag = new SortBag();
+        $sortBag->set(Sort::asc('anything'));
+
+        $request = $this->makeRequest($doc, $sortBag);
+        $middleware = new RequestValidationMiddleware();
+        $next = function () {
+            return $this->createMock(AbstractApivalkResponse::class);
+        };
+
+        $response = $middleware->process($request, $this->createMock(AbstractApivalkController::class), $next);
+
+        self::assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    public function testMultipleInvalidSortFieldsProduceMultipleErrors(): void
+    {
+        $doc = new ApivalkRequestDocumentation();
+        $doc->addAvailableSortField('name');
+
+        $sortBag = new SortBag();
+        $sortBag->set(Sort::asc('bad1'));
+        $sortBag->set(Sort::asc('bad2'));
+
+        $request = $this->makeRequest($doc, $sortBag);
+        $middleware = new RequestValidationMiddleware();
+        $next = function () {
+            return $this->createMock(AbstractApivalkResponse::class);
+        };
+
+        $response = $middleware->process($request, $this->createMock(AbstractApivalkController::class), $next);
+
+        self::assertInstanceOf(BadValidationApivalkResponse::class, $response);
+        /** @var BadValidationApivalkResponse $response */
+        self::assertCount(2, $response->getErrors());
+    }
+
+    private function makeRequest(ApivalkRequestDocumentation $doc, SortBag $sortBag): ApivalkRequestInterface
+    {
+        return new class($doc, $sortBag) implements ApivalkRequestInterface {
+            private static $d;
+            private static $sb;
+
+            public function __construct($d, $sb)
+            {
+                self::$d = $d;
+                self::$sb = $sb;
+            }
+
+            public static function getDocumentation(): ApivalkRequestDocumentation
+            {
+                return self::$d;
+            }
+
+            public function populate(\apivalk\apivalk\Router\Route\Route $route, ApivalkRequestDocumentation $doc): void
+            {
+            }
+
+            public function getRuntimeDocumentation(): ApivalkRequestDocumentation
+            {
+                return self::$d;
+            }
+
+            public function getMethod(): \apivalk\apivalk\Http\Method\MethodInterface
+            {
+                return new class implements \apivalk\apivalk\Http\Method\MethodInterface {
+                    public function getMethod(): string
+                    {
+                        return 'GET';
+                    }
+                };
+            }
+
+            public function header(): ParameterBag { return new ParameterBag(); }
+            public function query(): ParameterBag { return new ParameterBag(); }
+            public function body(): ParameterBag { return new ParameterBag(); }
+            public function path(): ParameterBag { return new ParameterBag(); }
+
+            public function file(): \apivalk\apivalk\Http\Request\File\FileBag
+            {
+                return new \apivalk\apivalk\Http\Request\File\FileBag();
+            }
+
+            public function getAuthIdentity(): \apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity
+            {
+                return new GuestAuthIdentity([]);
+            }
+
+            public function setAuthIdentity(\apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity $i): void {}
+
+            public function getIp(): string { return '127.0.0.1'; }
+
+            public function getRateLimitResult(): ?RateLimitResult { return null; }
+            public function setRateLimitResult(RateLimitResult $r): void {}
+
+            public function getLocale(): Locale { return Locale::en(); }
+            public function setLocale(Locale $l): void {}
+
+            public function sorting(): SortBag { return self::$sb; }
+            public function filtering(): FilterBag { return new FilterBag(); }
+            public function paginator() { return null; }
+        };
+    }
+}

--- a/Tests/PhpUnit/Resource/Stub/AnimalResource.php
+++ b/Tests/PhpUnit/Resource/Stub/AnimalResource.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Resource\Stub;
+
+use apivalk\apivalk\Documentation\Property\AbstractProperty;
+use apivalk\apivalk\Documentation\Property\FloatProperty;
+use apivalk\apivalk\Documentation\Property\StringProperty;
+use apivalk\apivalk\Resource\AbstractResource;
+
+class AnimalResource extends AbstractResource
+{
+    public function getIdentifierProperty(): AbstractProperty
+    {
+        return new StringProperty('animal_uuid', 'Unique identifier of the animal');
+    }
+
+    public function getBaseUrl(): string
+    {
+        return '/api/v1';
+    }
+
+    public function getName(): string
+    {
+        return 'animal';
+    }
+
+    public function excludeFromMode(string $mode): array
+    {
+        if ($mode === self::MODE_LIST) {
+            return ['weight'];
+        }
+
+        return [];
+    }
+
+    protected function init(): void
+    {
+        $this->addProperty(new StringProperty('name', 'Name of the animal'));
+        $this->addProperty(new StringProperty('type', 'Type of the animal'));
+        $this->addProperty((new FloatProperty('weight', 'Weight of the animal in kg'))->setIsRequired(false));
+    }
+}

--- a/Tests/PhpUnit/Resource/Stub/CreateAnimalController.php
+++ b/Tests/PhpUnit/Resource/Stub/CreateAnimalController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Resource\Stub;
+
+use apivalk\apivalk\Http\Controller\Resource\AbstractCreateResourceController;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceCreatedResponse;
+
+class CreateAnimalController extends AbstractCreateResourceController
+{
+    public static function getResourceClass(): string
+    {
+        return AnimalResource::class;
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        return new ResourceCreatedResponse($this->getResource($request));
+    }
+}

--- a/Tests/PhpUnit/Resource/Stub/DeleteAnimalController.php
+++ b/Tests/PhpUnit/Resource/Stub/DeleteAnimalController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Resource\Stub;
+
+use apivalk\apivalk\Http\Controller\Resource\AbstractDeleteResourceController;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\DeletedApivalkResponse;
+
+class DeleteAnimalController extends AbstractDeleteResourceController
+{
+    public static function getResourceClass(): string
+    {
+        return AnimalResource::class;
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        return new DeletedApivalkResponse();
+    }
+}

--- a/Tests/PhpUnit/Resource/Stub/ListAnimalsController.php
+++ b/Tests/PhpUnit/Resource/Stub/ListAnimalsController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Resource\Stub;
+
+use apivalk\apivalk\Http\Controller\Resource\AbstractListResourceController;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceListResponse;
+use apivalk\apivalk\Router\Route\Pagination\Pagination;
+
+class ListAnimalsController extends AbstractListResourceController
+{
+    public static function getResourceClass(): string
+    {
+        return AnimalResource::class;
+    }
+
+    public static function pagination(): ?Pagination
+    {
+        return Pagination::page()->setMaxLimit(25);
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        return new ResourceListResponse([], new PagePaginationPaginationResponse(1, 25, false, 0));
+    }
+}

--- a/Tests/PhpUnit/Resource/Stub/UpdateAnimalController.php
+++ b/Tests/PhpUnit/Resource/Stub/UpdateAnimalController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Resource\Stub;
+
+use apivalk\apivalk\Http\Controller\Resource\AbstractUpdateResourceController;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceUpdatedResponse;
+
+class UpdateAnimalController extends AbstractUpdateResourceController
+{
+    public static function getResourceClass(): string
+    {
+        return AnimalResource::class;
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        $animal = $this->getResource($request);
+
+        return new ResourceUpdatedResponse($animal);
+    }
+}

--- a/Tests/PhpUnit/Resource/Stub/ViewAnimalController.php
+++ b/Tests/PhpUnit/Resource/Stub/ViewAnimalController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Resource\Stub;
+
+use apivalk\apivalk\Http\Controller\Resource\AbstractViewResourceController;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceViewResponse;
+
+class ViewAnimalController extends AbstractViewResourceController
+{
+    public static function getResourceClass(): string
+    {
+        return AnimalResource::class;
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        $animal = AnimalResource::byRequest($request);
+
+        return new ResourceViewResponse($animal);
+    }
+}

--- a/Tests/PhpUnit/Resource/old/Documentation/ResourceDocumentationFactoryTest.php
+++ b/Tests/PhpUnit/Resource/old/Documentation/ResourceDocumentationFactoryTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Resource\Documentation;
+
+use apivalk\apivalk\Documentation\Request\RequestDocumentationFactory;
+use apivalk\apivalk\Documentation\Response\ResponseDocumentationFactory;
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
+use PHPUnit\Framework\TestCase;
+
+class RequestDocumentationFactoryTest extends TestCase
+{
+    public function testCreateResponseDocumentationViewMode(): void
+    {
+        $resource = new AnimalResource();
+        $doc = ResponseDocumentationFactory::create(
+            $resource,
+            AbstractResource::MODE_VIEW
+        );
+
+        $propertyNames = array_map(function ($p) {
+            return $p->getPropertyName();
+        }, $doc->getProperties());
+
+        // identifier + view properties (name, type, weight)
+        $this->assertContains('animal_uuid', $propertyNames);
+        $this->assertContains('name', $propertyNames);
+        $this->assertContains('type', $propertyNames);
+        $this->assertContains('weight', $propertyNames);
+    }
+
+    public function testCreateResponseDocumentationListMode(): void
+    {
+        $resource = new AnimalResource();
+        $doc = ResponseDocumentationFactory::create(
+            $resource,
+            AbstractResource::MODE_LIST
+        );
+
+        $propertyNames = array_map(function ($p) {
+            return $p->getPropertyName();
+        }, $doc->getProperties());
+
+        // weight is excluded from list mode
+        $this->assertContains('animal_uuid', $propertyNames);
+        $this->assertContains('name', $propertyNames);
+        $this->assertContains('type', $propertyNames);
+        $this->assertNotContains('weight', $propertyNames);
+    }
+
+    public function testCreateRequestDocumentationCreateMode(): void
+    {
+        $resource = new AnimalResource();
+        $doc = RequestDocumentationFactory::createRequestDocumentation(
+            $resource,
+            AbstractResource::MODE_CREATE
+        );
+
+        $bodyPropertyNames = array_keys($doc->getBodyProperties());
+        $pathPropertyNames = array_keys($doc->getPathProperties());
+
+        $this->assertContains('name', $bodyPropertyNames);
+        $this->assertContains('type', $bodyPropertyNames);
+        $this->assertContains('weight', $bodyPropertyNames);
+        $this->assertEmpty($pathPropertyNames);
+    }
+
+    public function testCreateRequestDocumentationUpdateMode(): void
+    {
+        $resource = new AnimalResource();
+        $doc = RequestDocumentationFactory::createRequestDocumentation(
+            $resource,
+            AbstractResource::MODE_UPDATE
+        );
+
+        $bodyPropertyNames = array_keys($doc->getBodyProperties());
+        $pathPropertyNames = array_keys($doc->getPathProperties());
+
+        // All body properties present but not required
+        $this->assertContains('name', $bodyPropertyNames);
+        $this->assertContains('type', $bodyPropertyNames);
+        $this->assertContains('weight', $bodyPropertyNames);
+
+        foreach ($doc->getBodyProperties() as $property) {
+            $this->assertFalse(
+                $property->isRequired(),
+                sprintf('Body property "%s" should be optional in update mode', $property->getPropertyName())
+            );
+        }
+
+        // Identifier as path property
+        $this->assertContains('animal_uuid', $pathPropertyNames);
+    }
+
+    public function testCreateRequestDocumentationViewMode(): void
+    {
+        $resource = new AnimalResource();
+        $doc = RequestDocumentationFactory::createRequestDocumentation(
+            $resource,
+            AbstractResource::MODE_VIEW
+        );
+
+        $bodyPropertyNames = array_keys($doc->getBodyProperties());
+        $pathPropertyNames = array_keys($doc->getPathProperties());
+
+        $this->assertEmpty($bodyPropertyNames);
+        $this->assertContains('animal_uuid', $pathPropertyNames);
+    }
+
+    public function testCreateRequestDocumentationDeleteMode(): void
+    {
+        $resource = new AnimalResource();
+        $doc = RequestDocumentationFactory::createRequestDocumentation(
+            $resource,
+            AbstractResource::MODE_DELETE
+        );
+
+        $bodyPropertyNames = array_keys($doc->getBodyProperties());
+        $pathPropertyNames = array_keys($doc->getPathProperties());
+
+        $this->assertEmpty($bodyPropertyNames);
+        $this->assertContains('animal_uuid', $pathPropertyNames);
+    }
+
+    public function testCreateRequestDocumentationListMode(): void
+    {
+        $resource = new AnimalResource();
+        $doc = RequestDocumentationFactory::createRequestDocumentation(
+            $resource,
+            AbstractResource::MODE_LIST
+        );
+
+        $this->assertEmpty($doc->getBodyProperties());
+        $this->assertEmpty($doc->getPathProperties());
+    }
+
+    public function testResponseDocumentationDescription(): void
+    {
+        $resource = new AnimalResource();
+        $doc = ResponseDocumentationFactory::create(
+            $resource,
+            AbstractResource::MODE_VIEW
+        );
+
+        $this->assertSame('View animal response', $doc->getDescription());
+    }
+}

--- a/docs/concepts/request-lifecycle.mdx
+++ b/docs/concepts/request-lifecycle.mdx
@@ -56,13 +56,23 @@ Once a route is matched:
 
 ### 5. Request Population
 
-The `Request` object's `populate()` method is called. It uses `ParameterBagFactory` and `FileBagFactory` to extract data from PHP superglobals:
+Before dispatch, the router builds a fully merged `ApivalkRequestDocumentation` for the route via `RequestDocumentationFactory::buildRuntimeDocumentation()`. This combines the request class's base documentation with route-derived properties (pagination query params, filter fields, `order_by`, available sort fields).
 
-- **Headers**: Extracted from `$_SERVER`.
-- **Query Parameters**: Extracted from `$_GET`.
-- **Path Parameters**: Parsed from the URI based on the route pattern.
-- **Body Parameters**: Extracted from `$_POST` or `php://input` (JSON).
-- **Files**: Extracted from `$_FILES`.
+The `Request` object's `populate()` method then runs a pipeline of small, single-purpose strategies implementing `PopulationStrategyInterface`. The `RequestPopulationStrategyCollection` wires up the default set:
+
+- `HeaderPopulationStrategy` — extracts headers from `$_SERVER`.
+- `QueryParameterPopulationStrategy` — extracts declared query params and filter fields from `$_GET`.
+- `PathParameterPopulationStrategy` — parses the URI against the route's path pattern.
+- `BodyParameterPopulationStrategy` — decodes `php://input` (JSON) and `$_POST`.
+- `FilePopulationStrategy` — builds the file bag from `$_FILES`.
+- `SortingPopulationStrategy` — applies route default sortings, then parses `order_by` from `$_GET`.
+- `FilteringPopulationStrategy` — clones the route's declared filters and binds values from the query bag.
+- `PaginationPopulationStrategy` — builds the correct paginator (page / offset / cursor) when the route declares pagination.
+- `AuthIdentityPopulationStrategy` — sets a default `GuestAuthIdentity` (middleware replaces it if auth succeeds).
+- `IpPopulationStrategy` — resolves the client IP.
+- `MethodPopulationStrategy` — attaches the HTTP method from the route.
+
+Each strategy is independent, easy to test in isolation, and receives a `RequestPopulationContext` carrying the `Route` and the runtime documentation.
 
 ### 6. Middleware Pipeline
 

--- a/docs/concepts/structure.mdx
+++ b/docs/concepts/structure.mdx
@@ -60,10 +60,15 @@ The heart of the framework. It contains the Property and Validator system.
 The standard web layer.
 
 - `Request/`: Abstractions for HTTP requests, divided into "Bags" (Header, Query, Path, Body, File).
+- `Request/Population/`: The strategy pipeline that populates the request object (11 strategies + a collection that wires the defaults).
 - `Response/`: A suite of pre-defined response types (200, 400, 404, 500, etc.) ensuring consistent API output.
-- `Controller/`: Base classes for your business logic.
+- `Controller/`: Base classes for your business logic. Includes `Controller/Resource/` — abstract CRUD controllers that pair with `AbstractResource` to eliminate boilerplate.
 - `Method/`: Typed representations of HTTP verbs.
 - `Renderer/`: Handles the final conversion of Response objects to the output stream (defaulting to JSON).
+
+#### `Resource/`
+
+`AbstractResource` is a declarative resource definition: identifier property, data properties, available filters, available sortings, per-mode property exclusion, and OpenAPI tags. A resource is paired with one of the five abstract resource controllers (`AbstractCreate/View/Update/Delete/ListResourceController`) to produce a full CRUD surface with zero boilerplate. See the [Resources](/resources/index) section.
 
 #### `Router/`
 
@@ -117,5 +122,5 @@ This system ensures that when you access `$request->body()->get('email')`, you a
 Apivalk is designed for developer productivity through automation:
 
 1. **Route Discovery**: `RouteCacheFactory` uses `ClassLocator` to find all classes extending `AbstractApivalkController`. It calls `getRoute()` on each to build the routing table.
-2. **Request Population**: `AbstractApivalkRequest` automatically populates itself using metadata from `getDocumentation()`.
-3. **Request Validation**: `RequestValidationMiddleware` automatically validates the populated request against the same documentation before the controller is invoked.
+2. **Request Population**: `AbstractApivalkRequest::populate()` runs a pipeline of single-purpose strategies (`RequestPopulationStrategyCollection`) against the fully merged runtime documentation for the route. See the [Request Lifecycle](/concepts/request-lifecycle#5-request-population).
+3. **Request Validation**: `RequestValidationMiddleware` automatically validates the populated request against its runtime documentation (body, query, path, filters, and sort fields) before the controller is invoked.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,6 +58,15 @@
             ]
           },
           {
+            "group": "Resources",
+            "pages": [
+              "resources/index",
+              "resources/resource",
+              "resources/controllers",
+              "resources/responses"
+            ]
+          },
+          {
             "group": "Routing",
             "pages": [
               "routing/index",

--- a/docs/documentation/docblock-generator.mdx
+++ b/docs/documentation/docblock-generator.mdx
@@ -64,3 +64,14 @@ $generator->run(
 * `DocBlockRequestGenerator`: Converts an `AbstractApivalkRequest` into a `DocBlockRequest` data object.
 * `DocBlockRequest`: Holds the metadata for the shapes (Body, Query, Path, Sorting, Filtering).
 * `DocBlockShape`: Generates the PHP code for the Shape classes.
+* `DocBlockResourceGenerator` / `DocBlockResource`: Generates `@property` annotations for `AbstractResource` subclasses so you get IDE autocompletion on `$resource->name`, `$resource->status`, etc.
+* `DocBlockResourceRequestGenerator` / `DocBlockResourceRequest`: For each `AbstractListResourceController`, generates a typed per-resource list request (e.g. `AnimalListRequest`) with `@method` annotations for `sorting()`, `filtering()`, and `paginator()` wired to shape interfaces derived from the resource's `availableSortings()` / `availableFilters()`.
+
+## Resource DocBlock Generation
+
+When `DocBlockGenerator` encounters an `AbstractResourceController` subclass, it produces two extra artifacts:
+
+1. **Resource `@property` docblock** — written once per resource class so that `$animal->name`, `$animal->type`, etc. autocomplete in your IDE.
+2. **Per-resource list request** — for each `AbstractListResourceController`, a typed request class (e.g. `Api/v1/Animal/Request/AnimalListRequest.php`) with `@method` annotations pointing at generated sorting/filtering shape interfaces. If the file already exists, **only the docblock is updated** — your class body is preserved.
+
+This gives you full IDE autocompletion on `$request->sorting()->status`, `$request->filtering()->createdAt`, and `$request->paginator()` without writing the boilerplate yourself.

--- a/docs/documentation/request.mdx
+++ b/docs/documentation/request.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Request"
-description: "The `ApivalkRequestDocumentation` class is the primary container for defining the input contract of an API endpoint. It is used within your controller's `getRequestDocumentation()` method."
+description: "The `ApivalkRequestDocumentation` class is the primary container for defining the input contract of an API endpoint. It is returned by the static `getDocumentation()` method on your request class."
 ---
 
 ## Purpose
@@ -10,6 +10,15 @@ It allows you to specify exactly what data your endpoint expects, where it shoul
 1. **Automatic Validation**: via `RequestValidationMiddleware`.
 2. **IDE Autocompletion**: via `DocBlockGenerator`.
 3. **OpenAPI Export**: via `OpenAPIGenerator`.
+
+## Base vs. Runtime Documentation
+
+Apivalk distinguishes between two forms of request documentation:
+
+- **Base documentation** — returned by the static `AbstractApivalkRequest::getDocumentation()`. Describes the request's own body/query/path properties as declared by the developer.
+- **Runtime documentation** — available on the request instance via `$request->getRuntimeDocumentation()`. This is the base documentation merged with route-derived metadata (pagination query parameters, filter fields, `order_by`, available sort fields). The `RequestValidationMiddleware` validates against this merged documentation.
+
+You normally only define the **base** documentation. The framework builds the runtime view for you via `RequestDocumentationFactory::buildRuntimeDocumentation()`.
 
 ## Structure
 
@@ -39,32 +48,21 @@ Used for data embedded in the URL path (e.g., `/users/{id}`).
 $doc->addPathProperty(new IntegerProperty('id', 'The unique identifier of the resource'));
 ```
 
-## Helper Methods
+## Route-Derived Properties
 
-### `addPaginationQueryProperties()`
-
-A convenience method that adds a non-required, integer `page` query parameter to the documentation. This is commonly used in combination with the `Paginator` utility.
-
-```php
-public static function getRequestDocumentation(): ApivalkRequestDocumentation
-{
-    $doc = new ApivalkRequestDocumentation();
-    $doc->addPaginationQueryProperties();
-    return $doc;
-}
-```
+You do **not** need to manually add pagination, sorting, or filter query parameters. When a route declares `pagination()`, `sorting()`, or `filtering()`, the framework automatically injects the corresponding properties into the runtime documentation — and they are automatically exposed in your OpenAPI spec.
 
 ## Full Example
 
 ```php
-public static function getRequestDocumentation(): ApivalkRequestDocumentation
+public static function getDocumentation(): ApivalkRequestDocumentation
 {
     $doc = new ApivalkRequestDocumentation();
-    
+
     $doc->addPathProperty(new StringProperty('slug', 'Post slug'));
     $doc->addQueryProperty(new BooleanProperty('include_comments', 'Whether to include comments'));
     $doc->addBodyProperty(new StringProperty('title', 'Updated title'));
-    
+
     return $doc;
 }
 ```

--- a/docs/documentation/response.mdx
+++ b/docs/documentation/response.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Response"
-description: "The `ApivalkResponseDocumentation` class defines the structure of the data returned by an API endpoint. It is used within your controller's `getResponseDocumentation()` method."
+description: "The `ApivalkResponseDocumentation` class defines the structure of the data returned by an API endpoint. It is returned by the static `getDocumentation()` method on your response class."
 ---
 
 ## Purpose
@@ -26,32 +26,28 @@ You can set a human-readable description for the response, which will appear in 
 $doc->setDescription('Returns the profile of the authenticated user');
 ```
 
-### Pagination Support
+### Pagination Envelopes
 
-If your endpoint returns a list of items and uses the Apivalk pagination system, you can enable the pagination envelope.
+Response pagination envelopes are produced automatically when your controller attaches a `PaginationResponseInterface` via `$response->setPaginationResponse(...)`. The `JsonRenderer` emits the `pagination` key and the OpenAPI generator adds the corresponding envelope schema — no flag needs to be set on the documentation.
 
-```php
-$doc->setHasResponsePagination(true);
-```
-
-When this is set to `true`, the `OpenAPIGenerator` will wrap your defined properties in a standard `data` array and include metadata fields like `total`, `page`, `limit`, and `pages`.
+See [Pagination](/http/pagination) for the concrete response objects.
 
 ## Full Example
 
 ```php
-public static function getResponseDocumentation(): ApivalkResponseDocumentation
+public static function getDocumentation(): ApivalkResponseDocumentation
 {
     $doc = new ApivalkResponseDocumentation();
     $doc->setDescription('Successfully retrieved the list of posts');
-    
-    // Add properties that will be inside each item of the 'data' array 
-    // if pagination is enabled, or in the root object if not.
+
     $doc->addProperty(new StringProperty('title', 'The post title'));
     $doc->addProperty(new StringProperty('content', 'The post body'));
     $doc->addProperty(new StringProperty('created_at', 'ISO 8601 date'));
-    
-    $doc->setHasResponsePagination(true);
-    
+
     return $doc;
 }
 ```
+
+## Tip: Use Resource Responses for CRUD
+
+If your endpoint follows the standard CRUD shape, use the pre-built `Resource*Response` classes instead of authoring response documentation yourself — they wire the `data` envelope, pagination, and OpenAPI schema from the resource definition. See [Resource Responses](/resources/responses).

--- a/docs/http/controller.mdx
+++ b/docs/http/controller.mdx
@@ -93,3 +93,32 @@ Apivalk uses `ClassLocator` to scan your controller directory. You don't need to
 ## Pagination
 
 For endpoints returning lists of data, see the [Pagination](/http/pagination) guide.
+
+## Resource Controllers (CRUD)
+
+If your endpoint follows a standard RESTful CRUD pattern against a single entity, you don't need to author a controller class like the one above by hand. Apivalk ships five abstract base controllers — `AbstractCreateResourceController`, `AbstractViewResourceController`, `AbstractUpdateResourceController`, `AbstractDeleteResourceController`, `AbstractListResourceController` — that derive their route, request class, response classes, and OpenAPI documentation from an `AbstractResource` declaration.
+
+A minimal list controller looks like this:
+
+```php
+use apivalk\apivalk\Http\Controller\Resource\AbstractListResourceController;
+use App\Resource\AnimalResource;
+
+/**
+ * @extends AbstractListResourceController<AnimalResource>
+ */
+final class ListAnimalController extends AbstractListResourceController
+{
+    public static function getResourceClass(): string
+    {
+        return AnimalResource::class;
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        // fetch, paginate, return ResourceListResponse
+    }
+}
+```
+
+See the full [Resources](/resources/index) section for how to declare a resource and wire up all five CRUD endpoints.

--- a/docs/http/request.mdx
+++ b/docs/http/request.mdx
@@ -82,6 +82,15 @@ $name = $request->body()->name;
 $userId = $request->path()->id;
 ```
 
+## Base vs. Runtime Documentation
+
+Every request class exposes **two** documentation views:
+
+- **Static** — `RequestClass::getDocumentation()`. Returns the base `ApivalkRequestDocumentation` as declared by the developer. Stable and independent of the route.
+- **Instance** — `$request->getRuntimeDocumentation()`. Returns the base documentation merged with route-derived metadata (pagination query params, filter fields, `order_by`, available sort fields). This is what the `RequestValidationMiddleware` validates against and what the population strategies consume.
+
+You normally only define the base via `getDocumentation()`. The framework builds the runtime view for you in `RequestDocumentationFactory::buildRuntimeDocumentation()`.
+
 ## Automatic Request Documentation
 
 When a route has [sorting defined](/routing/route#sorting) or [pagination enabled](/http/pagination), the framework automatically documents the corresponding query parameters (`order_by`, `page`, `limit`, `offset`, or `cursor`) in your OpenAPI specification.
@@ -98,6 +107,10 @@ Additionally:
 ## Validation
 
 Validation happens automatically if you use the `RequestValidationMiddleware`. If the incoming data does not match your `getDocumentation()` definition, the framework will immediately return a `422 Unprocessable Entity` response with detailed error messages.
+
+## Resource Requests
+
+For endpoints backed by a resource CRUD controller you typically don't author a request class at all — the framework uses a single shared `ResourceRequest`, and the runtime documentation is derived from your `AbstractResource` definition. See [Resources](/resources/index).
 
 ## Authentication Identity
 

--- a/docs/http/response.mdx
+++ b/docs/http/response.mdx
@@ -52,6 +52,22 @@ class GetPetResponse extends AbstractApivalkResponse
 }
 ```
 
+## Resource Responses (CRUD)
+
+When a controller extends one of the `Abstract*ResourceController` bases, pair it with the matching pre-built response from `Http/Response/Resource/`:
+
+| Response class | Status | Used by |
+|---|---|---|
+| `ResourceCreatedResponse` | 201 | `AbstractCreateResourceController` |
+| `ResourceViewResponse` | 200 | `AbstractViewResourceController` |
+| `ResourceListResponse` | 200 | `AbstractListResourceController` |
+| `ResourceUpdatedResponse` | 200 | `AbstractUpdateResourceController` |
+| `ResourceDeletedResponse` | 200 | `AbstractDeleteResourceController` |
+
+Each wraps the resource's `toArray($mode)` output under a `data` key. `ResourceListResponse` additionally takes a `PaginationResponseInterface` and emits the standard `pagination` envelope. The OpenAPI schema for these responses is generated from the `AbstractResource` declaration — you do **not** author response documentation by hand.
+
+See [Resource Responses](/resources/responses).
+
 ## Built-in Error Responses
 
 Apivalk provides several pre-defined error responses for common scenarios:

--- a/docs/http/sorting.mdx
+++ b/docs/http/sorting.mdx
@@ -34,20 +34,20 @@ When a route has sorting enabled, you can access the resolved sortings from the 
 public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
 {
     $sorting = $request->sorting();
-    
+
     // Check if a specific field was sorted by the client
     if ($sorting->has('name')) {
         $nameSort = $sorting->name; // returns Sort|null
         $direction = $nameSort->isAsc() ? 'ASC' : 'DESC';
         // apply to your query...
     }
-    
-    // Iterate over all provided sortings
+
+    // Iterate over all provided sortings (SortBag implements IteratorAggregate)
     foreach ($sorting as $field => $sort) {
         $direction = $sort->isAsc() ? 'ASC' : 'DESC';
         // ...
     }
-    
+
     // ...
 }
 ```
@@ -60,6 +60,10 @@ Apivalk supports sorting using the `order_by` query parameter. Clients can speci
 
 **Example: sort by name ascending and then by id descending**
 `GET /pets?order_by=name,-id`
+
+## Validation
+
+`RequestValidationMiddleware` rejects any sort field that isn't declared in the route's `sorting([...])` list. A request like `GET /pets?order_by=hacked_field` returns `422 Unprocessable Entity` with a validation error on the `order_by` parameter. Routes without any declared sortings skip this check entirely.
 
 ---
 

--- a/docs/middleware/request-validation.mdx
+++ b/docs/middleware/request-validation.mdx
@@ -7,11 +7,12 @@ description: "The `RequestValidationMiddleware` is a core component of Apivalk's
 
 The middleware intercepts the request before it reaches the controller and performs the following steps:
 
-1. **Extract Documentation**: It retrieves the property definitions for Body, Query, and Path parameters from the Request object.
-2. **Iterative Validation**: It iterates through each defined property and checks the corresponding value in the `ParameterBag`.
-3. **Required Field Check**: If a property is marked as `required` but missing from the request, a validation error is recorded.
-4. **Validator Execution**: If the value is present, it runs all validators attached to that property (e.g., `StringValidator`, `IntegerValidator`, `FloatValidator`, `EnumValidator`, `DateValidator`).
-5. **Error Collection**: If any validation fails, the middleware collects the errors into an array of `ValidationErrorObject` instances.
+1. **Extract Runtime Documentation**: It retrieves the **merged** documentation from `$request->getRuntimeDocumentation()` — the developer-declared properties plus route-derived metadata (filters, pagination params, available sort fields).
+2. **Property Validation**: It iterates Body, Query, and Path properties and checks each corresponding value in the `ParameterBag` — running all validators attached to the property (`StringValidator`, `IntegerValidator`, `EnumValidator`, ...).
+3. **Required Field Check**: If a property is marked `required` but missing, a validation error is recorded.
+4. **Filter Validation**: Each filter in `$request->filtering()` is validated against its underlying property (required / type / custom validators).
+5. **Sort Field Validation**: Each `Sort` in `$request->sorting()` must correspond to a field declared on the route via `Route::sorting([...])`. Unknown fields sent via `?order_by=...` produce a validation error (key `order_by`, message `Invalid sort field "X"`). Routes without declared sortings skip this check.
+6. **Error Collection**: All errors are collected into `ValidationErrorObject[]`.
 
 ## Automatic Response
 

--- a/docs/open-api-best-practices/02-rest-design-and-naming.mdx
+++ b/docs/open-api-best-practices/02-rest-design-and-naming.mdx
@@ -115,3 +115,14 @@ GET /users?page_size=50&client_id=123
   "first_name": "Max"
 }
 ```
+
+## How Apivalk Enforces These Standards
+
+Most of the rules on this page are enforced automatically when you use [resource controllers](/resources/index):
+
+- **HTTP methods per mode** — `Route::resource()` picks `POST` for create, `GET` for view/list, `PATCH` for update, `DELETE` for delete. You can't accidentally use the wrong verb for a CRUD mode.
+- **Plural URLs** — paths are derived from `$resource->getPluralName()`.
+- **Explicit path-parameter naming** — the identifier property name (e.g. `{animal_uuid}`) is used literally in the URL. There's no generic `{id}`.
+- **snake_case fields** — property names on `AbstractProperty` instances are used verbatim as JSON keys; keep them in snake_case and the API stays consistent.
+
+UUID identifiers are still a developer choice — declare your identifier as a `StringProperty` holding a UUID rather than an `IntegerProperty`.

--- a/docs/open-api-best-practices/04-pagination-filtering-sorting.mdx
+++ b/docs/open-api-best-practices/04-pagination-filtering-sorting.mdx
@@ -78,7 +78,7 @@ Use '+' (ASC) or '-' (DESC) as a prefix for each field. If not specified, defaul
 GET /users?order_by=+id,-price
 ```
 
-In Apivalk, this `order_by` parameter automatically populates the `sorting()` bag on the request object, based on the fields allowed in the `Route` definition.
+In Apivalk, this `order_by` parameter automatically populates the `sorting()` bag on the request object, based on the fields allowed in the `Route` definition. Any field not declared via `Route::sorting([...])` (or `AbstractResource::availableSortings()`) is rejected by the validation middleware with a `422`.
 
 ### Filtering
 

--- a/docs/open-api-best-practices/05-responses-errors-status-codes.mdx
+++ b/docs/open-api-best-practices/05-responses-errors-status-codes.mdx
@@ -36,6 +36,8 @@ description: Standard response envelopes, error objects, validation errors, and 
 }
 ```
 
+> The pre-built [resource responses](/resources/responses) (`ResourceListResponse`, `ResourceViewResponse`, ...) emit exactly this shape — the `data` envelope and pagination wrapper come from the framework, not your controller code.
+
 Empty response must be an empty array:
 
 ```json

--- a/docs/resources/controllers.mdx
+++ b/docs/resources/controllers.mdx
@@ -1,0 +1,221 @@
+---
+title: "Resource Controllers"
+description: "Five abstract controllers — Create, View, Update, Delete, List — turn an `AbstractResource` into a full CRUD surface."
+---
+
+## The Five Controllers
+
+| Base class | HTTP | Path | Response (default) |
+|---|---|---|---|
+| `AbstractCreateResourceController` | `POST` | `/{base}/{plural}` | `ResourceCreatedResponse` (201) |
+| `AbstractViewResourceController` | `GET` | `/{base}/{plural}/{id}` | `ResourceViewResponse` (200) |
+| `AbstractUpdateResourceController` | `PATCH` | `/{base}/{plural}/{id}` | `ResourceUpdatedResponse` (200) |
+| `AbstractDeleteResourceController` | `DELETE` | `/{base}/{plural}/{id}` | `ResourceDeletedResponse` (200) |
+| `AbstractListResourceController` | `GET` | `/{base}/{plural}` | `ResourceListResponse` (200) |
+
+`{base}` comes from `$resource->getBaseUrl()`, `{plural}` from `$resource->getPluralName()`, `{id}` from `$resource->getIdentifierProperty()->getPropertyName()`.
+
+All five are generic over the resource type: `@template TResource of AbstractResource`. When you subclass, declare your concrete resource so static analysis propagates the type through.
+
+## What You Write
+
+A resource controller is **one small class** — a `getResourceClass()` method plus your business logic. The `@extends Abstract...<YourResource>` annotation is what gives you IDE autocompletion and static analysis on the typed helpers the base class exposes.
+
+### Example: Create
+
+`AbstractCreateResourceController` provides `$this->getResource($request)` which builds a typed resource instance from the validated request body (and path, for `Update`). Because of the `@template TResource`, `$customer` below is known to be a `CustomerResource` — your IDE and PHPStan both know it.
+
+```php
+namespace App\Http\Controller\Customer;
+
+use apivalk\apivalk\Http\Controller\Resource\AbstractCreateResourceController;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceCreatedResponse;
+use App\Resource\CustomerResource;
+
+/**
+ * @extends AbstractCreateResourceController<CustomerResource>
+ */
+final class CreateCustomerController extends AbstractCreateResourceController
+{
+    public static function getResourceClass(): string
+    {
+        return CustomerResource::class;
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        // CustomerResource (typed via the template parameter), built from
+        // the validated body + identifier path param. No manual property copying.
+        $customer = $this->getResource($request);
+
+        // ... persist $customer via your repository here ...
+
+        return new ResourceCreatedResponse($customer);
+    }
+}
+```
+
+That's the full controller. `AbstractUpdateResourceController` has the same `getResource($request)` helper; `AbstractView/Delete/ListResourceController` don't need it since they don't hydrate from a body.
+
+### Example: Update
+
+`AbstractUpdateResourceController` gives you **both** helpers: `$this->getResource($request)` hydrates a typed resource from the validated body **and** the identifier in the path, and `$this->getResourceIdentifier($request)` returns the raw identifier on its own (useful if you need to look up the existing row first, merge, and persist).
+
+```php
+namespace App\Http\Controller\Customer;
+
+use apivalk\apivalk\Http\Controller\Resource\AbstractUpdateResourceController;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceUpdatedResponse;
+use App\Resource\CustomerResource;
+
+/**
+ * @extends AbstractUpdateResourceController<CustomerResource>
+ */
+final class UpdateCustomerController extends AbstractUpdateResourceController
+{
+    public static function getResourceClass(): string
+    {
+        return CustomerResource::class;
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        // CustomerResource with path id + body fields already merged in.
+        $customer = $this->getResource($request);
+
+        // ... persist updates via your repository here ...
+
+        return new ResourceUpdatedResponse($customer);
+    }
+}
+```
+
+### Example: View
+
+`AbstractView/Delete/UpdateResourceController` expose `$this->getResourceIdentifier($request)` — a typed convenience for pulling the identifier path parameter (defined by `$resource->getIdentifierProperty()`) out of the request. It throws `InvalidArgumentException` if the parameter is missing, so the validation middleware has already ensured it's present by the time you reach `__invoke()`.
+
+```php
+namespace App\Http\Controller\Customer;
+
+use apivalk\apivalk\Http\Controller\Resource\AbstractViewResourceController;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceViewResponse;
+use App\Resource\CustomerResource;
+
+/**
+ * @extends AbstractViewResourceController<CustomerResource>
+ */
+final class ViewCustomerController extends AbstractViewResourceController
+{
+    public static function getResourceClass(): string
+    {
+        return CustomerResource::class;
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        $customerUuid = $this->getResourceIdentifier($request);
+
+        // ... fetch the row from your repository here ...
+        $customer = CustomerResource::byArray([
+            'uuid'       => $customerUuid,
+            'first_name' => 'John',
+            'last_name'  => 'Doe',
+            'status'     => 'active',
+        ]);
+
+        return new ResourceViewResponse($customer);
+    }
+}
+```
+
+`AbstractDeleteResourceController` follows the same pattern — call `$this->getResourceIdentifier($request)`, delete the row, return a `ResourceDeletedResponse`.
+
+### Example: List
+
+```php
+namespace App\Http\Controller\Animal;
+
+use apivalk\apivalk\Http\Controller\Resource\AbstractListResourceController;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceListResponse;
+use apivalk\apivalk\Router\Route\Pagination\Pagination;
+use App\Resource\AnimalResource;
+
+/**
+ * @extends AbstractListResourceController<AnimalResource>
+ */
+final class ListAnimalController extends AbstractListResourceController
+{
+    public static function getResourceClass(): string
+    {
+        return AnimalResource::class;
+    }
+
+    public static function pagination(): ?Pagination
+    {
+        return new Pagination(Pagination::TYPE_PAGE, 100);
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        $paginator = $request->paginator();
+
+        // $request->filtering()->status, $request->sorting() etc. are already typed
+        $animals = $this->repository->findAll(
+            $request->filtering(),
+            $request->sorting(),
+            $paginator->getLimit(),
+            ($paginator->getPage() - 1) * $paginator->getLimit()
+        );
+
+        return new ResourceListResponse(
+            $animals,
+            new PagePaginationPaginationResponse(
+                $paginator->getPage(),
+                $paginator->getLimit(),
+                /* hasMore */ true
+            )
+        );
+    }
+}
+```
+
+The five things the base class handles for you:
+
+1. `getRoute()` — built via `Route::resource($this->getEmptyResource(), static::getMode())`, wired with the resource's filters / sortings / pagination hook.
+2. `getRequestClass()` — returns `ResourceRequest::class` (a shared, empty request class).
+3. `getResponseClasses()` — the mode-specific response + standard error responses.
+4. `getMode()` — the constant for Create / View / Update / Delete / List.
+5. `getDescription()` — e.g. `"Create animal"`, `"List animals"`.
+
+## What You Can Override
+
+- `pagination(): ?Pagination` — on `AbstractListResourceController`. Default `null` (no pagination).
+- `routeAuthorization(): ?RouteAuthorization` — declare required scopes/permissions.
+- `rateLimit(): ?RateLimitInterface` — per-endpoint rate limit.
+- `getDescription(): string` — override the auto-generated description if needed.
+- `configureRoute(Route $route): void` — for exotic tweaks. `AbstractListResourceController` uses this internally to wire filters/sortings/pagination; if you override it on `List`, call back into the parent or re-wire manually.
+
+## The Shared `ResourceRequest`
+
+All resource controllers return `ResourceRequest::class` from `getRequestClass()`. This is intentional: the runtime documentation (body fields for create/update, path id for view/update/delete, filters/sortings/pagination for list) is built from the **resource declaration**, not from per-mode request classes. You never need to author a resource request class yourself.
+
+The [docblock generator](/documentation/docblock-generator#resource-docblock-generation) can emit an optional per-resource `AnimalListRequest` subclass purely for IDE autocompletion — that file only carries `@method` annotations, no runtime behavior.
+
+## Registering Controllers
+
+Resource controllers are ordinary controllers — the `ClassLocator` finds them automatically during route cache building. No manual registration.
+
+## Related
+
+- [Defining a Resource](/resources/resource)
+- [Resource Responses](/resources/responses)
+- [Route::resource()](/routing/route#resource-routes)

--- a/docs/resources/index.mdx
+++ b/docs/resources/index.mdx
@@ -1,0 +1,63 @@
+---
+title: "Resources"
+description: "Resources are Apivalk's declarative model for CRUD endpoints. You describe a resource once and get type-safe, validated, OpenAPI-documented Create / Read / Update / Delete / List endpoints with no per-endpoint boilerplate."
+---
+
+## What Is a Resource?
+
+In Apivalk, a **resource** is a concrete subclass of `AbstractResource` that describes one domain entity:
+
+- its **identifier property** (e.g. `animal_uuid`);
+- its **data properties** (name, type, weight, ...);
+- which properties are **excluded from a given mode** (e.g. hide `password` from list responses);
+- the **filters** and **sortings** list endpoints expose;
+- the OpenAPI **tags** for grouping.
+
+One resource declaration powers five controllers — Create, View, Update, Delete, List — and the matching response envelopes. The framework derives URLs, request validation, response shapes, and OpenAPI documentation from that single source of truth.
+
+## Why Use Resources?
+
+Without resources, building a full CRUD surface for one entity means authoring ~15 classes: five controllers, five request classes with property documentation, and five response classes. Resources collapse that to one resource class plus five thin controller subclasses.
+
+Benefits:
+
+- **Zero duplicate documentation**: identifier, properties, filters, and sortings are declared once.
+- **Consistent URLs and methods**: `Route::resource()` picks the correct URL template and HTTP verb per mode.
+- **Built-in validation**: `RequestValidationMiddleware` validates body, path, filters, and sort fields — all derived from the resource.
+- **Built-in OpenAPI**: request and response schemas are emitted for all five modes automatically.
+- **Shared response envelopes**: `ResourceCreated/View/Updated/Deleted/ListResponse` wrap the `data` key and pagination envelope for you.
+
+## Big Picture
+
+```text
+AbstractResource (your declaration)
+   ├─ getIdentifierProperty()  ── path param on view/update/delete
+   ├─ init() + addProperty()   ── body fields on create/update, response fields on all modes
+   ├─ excludeFromMode($mode)   ── per-mode field visibility
+   ├─ availableFilters()       ── list endpoint query params
+   ├─ availableSortings()      ── order_by fields
+   └─ tags()                   ── OpenAPI grouping
+
+    ▲
+    │ paired with one of
+    │
+Abstract{Create,View,Update,Delete,List}ResourceController
+   ├─ getRoute()         ── built by Route::resource($resource, $mode)
+   ├─ getRequestClass()  ── always ResourceRequest
+   ├─ getResponseClasses ── mode-specific Resource*Response
+   └─ __invoke()         ── your business logic (only thing you implement)
+```
+
+## Learn More
+
+<CardGroup cols={3}>
+  <Card title="Defining a Resource" href="/resources/resource">
+    How to subclass `AbstractResource`: identifier, properties, filters, sortings, per-mode exclusions.
+  </Card>
+  <Card title="Resource Controllers" href="/resources/controllers">
+    The five CRUD controller bases, how they wire up, and what you override.
+  </Card>
+  <Card title="Resource Responses" href="/resources/responses">
+    The five pre-built response envelopes and how to attach pagination.
+  </Card>
+</CardGroup>

--- a/docs/resources/resource.mdx
+++ b/docs/resources/resource.mdx
@@ -1,0 +1,161 @@
+---
+title: "Defining a Resource"
+description: "Every CRUD surface starts with a single class extending `AbstractResource`. This page walks through each hook."
+---
+
+## Minimal Resource
+
+```php
+namespace App\Resource;
+
+use apivalk\apivalk\Documentation\Property\AbstractProperty;
+use apivalk\apivalk\Documentation\Property\FloatProperty;
+use apivalk\apivalk\Documentation\Property\StringProperty;
+use apivalk\apivalk\Resource\AbstractResource;
+
+class AnimalResource extends AbstractResource
+{
+    public function getIdentifierProperty(): AbstractProperty
+    {
+        return new StringProperty('animal_uuid', 'Unique identifier of the animal');
+    }
+
+    public function getBaseUrl(): string
+    {
+        return '/api/v1';
+    }
+
+    public function getName(): string
+    {
+        return 'animal';
+    }
+
+    public function excludeFromMode(string $mode): array
+    {
+        if ($mode === self::MODE_LIST) {
+            return ['weight'];
+        }
+
+        return [];
+    }
+
+    protected function init(): void
+    {
+        $this->addProperty(new StringProperty('name', 'Name of the animal'));
+        $this->addProperty(new StringProperty('type', 'Type of the animal'));
+        $this->addProperty(
+            (new FloatProperty('weight', 'Weight of the animal in kg'))->setIsRequired(false)
+        );
+    }
+}
+```
+
+That's it — five CRUD endpoints' worth of documentation.
+
+## Hook Reference
+
+### `init(): void` (required)
+
+Declare data properties with `$this->addProperty(...)`. The constructor is `final` — all setup happens here.
+
+### `getIdentifierProperty(): AbstractProperty` (required)
+
+The property used for view / update / delete path parameters (`/animals/{animal_uuid}`) and the resource's identity in response bodies.
+
+Use UUID-typed identifiers (`StringProperty`) rather than integer IDs to comply with the framework's [REST naming standards](/open-api-best-practices/02-rest-design-and-naming#resource-identifiers-ids-vs-uuids).
+
+### `getBaseUrl(): string` (required)
+
+The URL prefix used by `Route::resource()` when building paths. Example: `/api/v1` produces `/api/v1/animals`, `/api/v1/animals/{animal_uuid}`.
+
+### `getName(): string` (required)
+
+Singular resource name. Used in descriptions ("Create animal"), OpenAPI response names, generated request class names (e.g. `AnimalListRequest`), and plural URL derivation.
+
+### `getPluralName(): string` (optional)
+
+Defaults to `getName() . 's'`. Override for irregular plurals:
+
+```php
+public function getPluralName(): string
+{
+    return 'children';
+}
+```
+
+### `excludeFromMode(string $mode): array` (required)
+
+Return an array of property names to exclude from a given mode. Typical uses:
+
+- Hide `password` from **every** response.
+- Hide `weight` from **list** responses only.
+- Exclude `created_at` / `updated_at` from **create** bodies because the server sets them.
+
+Modes are constants on `AbstractResource`: `MODE_CREATE`, `MODE_VIEW`, `MODE_UPDATE`, `MODE_DELETE`, `MODE_LIST`.
+
+### `availableFilters(): FilterInterface[]`
+
+Declare filters exposed on the list endpoint. Use the typed filter builders from `Router\Route\Filter\`:
+
+```php
+public function availableFilters(): array
+{
+    return [
+        EnumFilter::equals(new EnumProperty('status', 'Status', ['active', 'archived'])),
+        StringFilter::contains(new StringProperty('name', 'Name contains')),
+    ];
+}
+```
+
+Each filter becomes a typed query parameter with full OpenAPI documentation and is accessible in the controller as `$request->filtering()->status`.
+
+### `availableSortings(): Sort[]`
+
+Declare sortable fields for the list endpoint:
+
+```php
+public function availableSortings(): array
+{
+    return [
+        Sort::asc('name'),
+        Sort::desc('created_at'),
+    ];
+}
+```
+
+Any sort field sent via `?order_by=...` that isn't in this list is rejected by the validation middleware with a 422.
+
+### `tags(): TagObject[]`
+
+OpenAPI tags for grouping operations. All five CRUD endpoints for one resource inherit these.
+
+```php
+public function tags(): array
+{
+    return [new TagObject('Animals', 'Animal management')];
+}
+```
+
+## Working with Instances
+
+Controllers build resource instances from requests and arrays:
+
+```php
+$resource = AnimalResource::byRequest($request);   // from path + body
+$resource = AnimalResource::byArray($row);         // from a database row
+```
+
+And serialize them per mode:
+
+```php
+$resource->toArray(AbstractResource::MODE_LIST);   // respects excludeFromMode()
+```
+
+Fields are accessed as dynamic properties:
+
+```php
+$resource->name = 'Leo';
+echo $resource->name;
+```
+
+With the [docblock generator](/documentation/docblock-generator#resource-docblock-generation) run, these also autocomplete in your IDE.

--- a/docs/resources/responses.mdx
+++ b/docs/resources/responses.mdx
@@ -1,0 +1,74 @@
+---
+title: "Resource Responses"
+description: "Five response classes in `Http/Response/Resource/` mirror the five CRUD modes. They wrap `$resource->toArray($mode)` in the standard `data` envelope and emit matching OpenAPI schemas."
+---
+
+## The Five Responses
+
+| Class | Status | Payload | Typical controller |
+|---|---|---|---|
+| `ResourceCreatedResponse` | 201 | `{"data": {...}}` | `AbstractCreateResourceController` |
+| `ResourceViewResponse` | 200 | `{"data": {...}}` | `AbstractViewResourceController` |
+| `ResourceUpdatedResponse` | 200 | `{"data": {...}}` | `AbstractUpdateResourceController` |
+| `ResourceDeletedResponse` | 200 | `{"data": {...}}` | `AbstractDeleteResourceController` |
+| `ResourceListResponse` | 200 | `{"data": [...], "pagination": {...}}` | `AbstractListResourceController` |
+
+Each single-resource response takes the resource instance in its constructor. `ResourceListResponse` additionally requires a `PaginationResponseInterface`.
+
+## Usage
+
+### Create / View / Update / Delete
+
+```php
+return new ResourceCreatedResponse($animal);
+return new ResourceViewResponse($animal);
+return new ResourceUpdatedResponse($animal);
+return new ResourceDeletedResponse($animal);
+```
+
+Internally, each calls `$animal->toArray($mode)` with the matching mode constant, so per-mode field exclusions from `$resource->excludeFromMode($mode)` are applied automatically.
+
+### List
+
+```php
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+
+return new ResourceListResponse(
+    $animals,
+    new PagePaginationPaginationResponse($page, $pageSize, $hasMore, $totalPages)
+);
+```
+
+Or with offset / cursor pagination: swap in `OffsetPaginationPaginationResponse` / `CursorPaginationPaginationResponse`. The `JsonRenderer` adds the `pagination` key to the output automatically.
+
+Output shape:
+
+```json
+{
+  "data": [
+    { "animal_uuid": "...", "name": "Leo", "type": "lion" }
+  ],
+  "pagination": {
+    "page": 1,
+    "page_size": 20,
+    "has_more": true,
+    "total_pages": 5
+  }
+}
+```
+
+## OpenAPI Schema
+
+You do **not** call `addProperty(...)` or `setDescription(...)` on these response classes. Their `getDocumentation()` returns an empty `ApivalkResponseDocumentation` as a placeholder; the actual schema for OpenAPI is built by `ResponseDocumentationFactory::create($resource, $mode)` during spec generation, using the resource's properties and per-mode exclusions as the source of truth.
+
+This means a documentation change on the resource (adding a field, excluding one from list, etc.) updates every relevant CRUD response schema at once.
+
+## Writing a Custom Response
+
+If you need a response shape that doesn't fit these five envelopes (e.g. a bulk-import result), just return any subclass of `AbstractApivalkResponse` as normal — see the [Response](/http/response) page. You're not forced into the resource responses.
+
+## Related
+
+- [Resource Controllers](/resources/controllers)
+- [Defining a Resource](/resources/resource)
+- [Pagination](/http/pagination)

--- a/docs/routing/route.mdx
+++ b/docs/routing/route.mdx
@@ -147,6 +147,23 @@ public static function getRoute(): Route
 
 When pagination is enabled, the framework automatically handles the `page`, `limit`, `offset`, or `cursor` query parameters and includes them in the OpenAPI documentation. See the [Pagination](/http/pagination) guide for more details.
 
+## Resource Routes
+
+For CRUD endpoints against an `AbstractResource`, use `Route::resource()` to build a route pre-configured for one of the five resource modes. It derives the URL, HTTP method, and default configuration from the resource:
+
+```php
+use apivalk\apivalk\Resource\AbstractResource;
+use apivalk\apivalk\Router\Route\Route;
+use App\Resource\AnimalResource;
+
+public static function getRoute(): Route
+{
+    return Route::resource(new AnimalResource(), AbstractResource::MODE_LIST);
+}
+```
+
+In practice you won't call `Route::resource()` yourself — `AbstractResourceController::getRoute()` does it for you. See [Resources](/resources/index).
+
 ## Filtering
 
 You can define which fields are allowed for filtering by using the `filtering()` method. This takes an array of `FilterInterface` instances:


### PR DESCRIPTION
Introduce AbstractResource with CRUD controller hierarchy (Create, View, List, Update, Delete), resource-specific response types, and matching OpenAPI/DocBlock generators. Refactor request population into a strategy collection and add resource docs.