### PR TITLE
fix: skip abstract controllers, tighten paginator type, rename pagina…

### DIFF
--- a/Documentation/DocBlock/DocBlockRequest.php
+++ b/Documentation/DocBlock/DocBlockRequest.php
@@ -88,7 +88,7 @@ PHP;
                 $shapeNamespace . '\\' . $this->bodyShape->getClassName(),
                 $shapeNamespace . '\\' . $this->sortingShape->getClassName(),
                 $shapeNamespace . '\\' . $this->filteringShape->getClassName(),
-                $this->paginatorClass !== null ? $this->paginatorClass . '|null' : 'null',
+                $this->paginatorClass !== null ? $this->paginatorClass : 'null',
             ],
             $string
         );

--- a/Documentation/DocBlock/DocBlockResourceRequest.php
+++ b/Documentation/DocBlock/DocBlockResourceRequest.php
@@ -67,7 +67,7 @@ class DocBlockResourceRequest
         ];
 
         if ($this->paginatorClass !== null) {
-            $lines[] = ' * @method \\' . $this->paginatorClass . '|null paginator()';
+            $lines[] = ' * @method \\' . $this->paginatorClass . ' paginator()';
         }
 
         return "/**\n" . implode("\n", $lines) . "\n */";

--- a/Documentation/OpenAPI/Object/SchemaObject.php
+++ b/Documentation/OpenAPI/Object/SchemaObject.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Documentation\OpenAPI\Object;
 
 use apivalk\apivalk\Documentation\Property\AbstractProperty;
-use apivalk\apivalk\Http\Response\Pagination\CursorPaginationPaginationResponse;
-use apivalk\apivalk\Http\Response\Pagination\OffsetPaginationPaginationResponse;
-use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\CursorPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\OffsetPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationResponse;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
 
 /**
@@ -77,13 +77,13 @@ class SchemaObject implements ObjectInterface
 
             switch ($this->pagination->getType()) {
                 case Pagination::TYPE_PAGE:
-                    $paginationProperties = PagePaginationPaginationResponse::getResponseDocumentationProperties();
+                    $paginationProperties = PagePaginationResponse::getResponseDocumentationProperties();
                     break;
                 case Pagination::TYPE_OFFSET:
-                    $paginationProperties = OffsetPaginationPaginationResponse::getResponseDocumentationProperties();
+                    $paginationProperties = OffsetPaginationResponse::getResponseDocumentationProperties();
                     break;
                 case Pagination::TYPE_CURSOR:
-                    $paginationProperties = CursorPaginationPaginationResponse::getResponseDocumentationProperties();
+                    $paginationProperties = CursorPaginationResponse::getResponseDocumentationProperties();
                     break;
             }
 

--- a/Http/Response/Pagination/CursorPaginationResponse.php
+++ b/Http/Response/Pagination/CursorPaginationResponse.php
@@ -8,7 +8,7 @@ use apivalk\apivalk\Documentation\Property\BooleanProperty;
 use apivalk\apivalk\Documentation\Property\IntegerProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 
-class CursorPaginationPaginationResponse implements PaginationResponseInterface
+class CursorPaginationResponse implements PaginationResponseInterface
 {
     /** @var int */
     private $limit;

--- a/Http/Response/Pagination/OffsetPaginationResponse.php
+++ b/Http/Response/Pagination/OffsetPaginationResponse.php
@@ -7,7 +7,7 @@ namespace apivalk\apivalk\Http\Response\Pagination;
 use apivalk\apivalk\Documentation\Property\BooleanProperty;
 use apivalk\apivalk\Documentation\Property\IntegerProperty;
 
-class OffsetPaginationPaginationResponse implements PaginationResponseInterface
+class OffsetPaginationResponse implements PaginationResponseInterface
 {
     /** @var int */
     private $limit;

--- a/Http/Response/Pagination/PagePaginationResponse.php
+++ b/Http/Response/Pagination/PagePaginationResponse.php
@@ -8,7 +8,7 @@ use apivalk\apivalk\Documentation\Property\AbstractProperty;
 use apivalk\apivalk\Documentation\Property\BooleanProperty;
 use apivalk\apivalk\Documentation\Property\IntegerProperty;
 
-class PagePaginationPaginationResponse implements PaginationResponseInterface
+class PagePaginationResponse implements PaginationResponseInterface
 {
     /** @var int */
     private $page;

--- a/Router/Route/RouteCacheFactory.php
+++ b/Router/Route/RouteCacheFactory.php
@@ -41,6 +41,10 @@ class RouteCacheFactory
                 continue;
             }
 
+            if ((new \ReflectionClass($className))->isAbstract()) {
+                continue;
+            }
+
             $route = $className::getRoute();
 
             $routeCacheKey = $this->getRouteCacheKey($route);

--- a/Tests/PhpUnit/Documentation/DocBlock/DocBlockGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/DocBlock/DocBlockGeneratorTest.php
@@ -162,7 +162,7 @@ use apivalk\\apivalk\\Http\\Controller\\Resource\\AbstractListResourceController
 use apivalk\\apivalk\\Http\\Request\\ApivalkRequestInterface;
 use apivalk\\apivalk\\Http\\Response\\AbstractApivalkResponse;
 use apivalk\\apivalk\\Http\\Response\\Resource\\ResourceListResponse;
-use apivalk\\apivalk\\Http\\Response\\Pagination\\PagePaginationPaginationResponse;
+use apivalk\\apivalk\\Http\\Response\\Pagination\\PagePaginationResponse;
 use TestNamespace\\Resource\\{$resourceClassName};
 
 class {$controllerClassName} extends AbstractListResourceController
@@ -174,7 +174,7 @@ class {$controllerClassName} extends AbstractListResourceController
 
     public function __invoke(ApivalkRequestInterface \$request): AbstractApivalkResponse
     {
-        return new ResourceListResponse([], new PagePaginationPaginationResponse(1, 25, false, 0));
+        return new ResourceListResponse([], new PagePaginationResponse(1, 25, false, 0));
     }
 }
 PHP;
@@ -247,7 +247,7 @@ use apivalk\\apivalk\\Http\\Controller\\Resource\\AbstractListResourceController
 use apivalk\\apivalk\\Http\\Request\\ApivalkRequestInterface;
 use apivalk\\apivalk\\Http\\Response\\AbstractApivalkResponse;
 use apivalk\\apivalk\\Http\\Response\\Resource\\ResourceListResponse;
-use apivalk\\apivalk\\Http\\Response\\Pagination\\PagePaginationPaginationResponse;
+use apivalk\\apivalk\\Http\\Response\\Pagination\\PagePaginationResponse;
 use TestNamespace\\Resource\\{$resourceClassName};
 
 class {$listClassName} extends AbstractListResourceController
@@ -255,7 +255,7 @@ class {$listClassName} extends AbstractListResourceController
     public static function getResourceClass(): string { return {$resourceClassName}::class; }
     public function __invoke(ApivalkRequestInterface \$request): AbstractApivalkResponse
     {
-        return new ResourceListResponse([], new PagePaginationPaginationResponse(1, 25, false, 0));
+        return new ResourceListResponse([], new PagePaginationResponse(1, 25, false, 0));
     }
 }
 PHP;

--- a/Tests/PhpUnit/Http/Response/Pagination/CursorPaginationResponseTest.php
+++ b/Tests/PhpUnit/Http/Response/Pagination/CursorPaginationResponseTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Tests\PhpUnit\Http\Response\Pagination;
 
 use PHPUnit\Framework\TestCase;
-use apivalk\apivalk\Http\Response\Pagination\CursorPaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\CursorPaginationResponse;
 
-class CursorPaginationPaginationResponseTest extends TestCase
+class CursorPaginationResponseTest extends TestCase
 {
     public function testToArray(): void
     {
-        $response = new CursorPaginationPaginationResponse(15, 'cur', 'nxt', true);
+        $response = new CursorPaginationResponse(15, 'cur', 'nxt', true);
         $expected = [
             'limit' => 15,
             'current_cursor' => 'cur',
@@ -24,7 +24,7 @@ class CursorPaginationPaginationResponseTest extends TestCase
     public function testToArrayFiltersEmptyStrings(): void
     {
         // currentCursor is required in constructor, but if we pass empty string it might be filtered
-        $response = new CursorPaginationPaginationResponse(15, '', '', false);
+        $response = new CursorPaginationResponse(15, '', '', false);
         $result = $response->toArray();
         
         $this->assertEquals(15, $result['limit']);
@@ -35,7 +35,7 @@ class CursorPaginationPaginationResponseTest extends TestCase
 
     public function testGetResponseDocumentationProperties(): void
     {
-        $properties = CursorPaginationPaginationResponse::getResponseDocumentationProperties();
+        $properties = CursorPaginationResponse::getResponseDocumentationProperties();
         $this->assertCount(3, $properties);
         $this->assertEquals('limit', $properties[0]->getPropertyName());
         $this->assertEquals('next_cursor', $properties[1]->getPropertyName());

--- a/Tests/PhpUnit/Http/Response/Pagination/OffsetPaginationResponseTest.php
+++ b/Tests/PhpUnit/Http/Response/Pagination/OffsetPaginationResponseTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Tests\PhpUnit\Http\Response\Pagination;
 
 use PHPUnit\Framework\TestCase;
-use apivalk\apivalk\Http\Response\Pagination\OffsetPaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\OffsetPaginationResponse;
 
-class OffsetPaginationPaginationResponseTest extends TestCase
+class OffsetPaginationResponseTest extends TestCase
 {
     public function testToArray(): void
     {
-        $response = new OffsetPaginationPaginationResponse(20, 40, true, 100);
+        $response = new OffsetPaginationResponse(20, 40, true, 100);
         $expected = [
             'limit' => 20,
             'offset' => 40,
@@ -23,7 +23,7 @@ class OffsetPaginationPaginationResponseTest extends TestCase
 
     public function testToArrayFiltersNull(): void
     {
-        $response = new OffsetPaginationPaginationResponse(20, 0, false, null);
+        $response = new OffsetPaginationResponse(20, 0, false, null);
         $result = $response->toArray();
         
         $this->assertEquals(20, $result['limit']);
@@ -35,7 +35,7 @@ class OffsetPaginationPaginationResponseTest extends TestCase
 
     public function testGetResponseDocumentationProperties(): void
     {
-        $properties = OffsetPaginationPaginationResponse::getResponseDocumentationProperties();
+        $properties = OffsetPaginationResponse::getResponseDocumentationProperties();
         $this->assertCount(4, $properties);
         $this->assertEquals('limit', $properties[0]->getPropertyName());
         $this->assertEquals('offset', $properties[1]->getPropertyName());

--- a/Tests/PhpUnit/Http/Response/Pagination/PagePaginationResponseTest.php
+++ b/Tests/PhpUnit/Http/Response/Pagination/PagePaginationResponseTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Tests\PhpUnit\Http\Response\Pagination;
 
 use PHPUnit\Framework\TestCase;
-use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationResponse;
 
-class PagePaginationPaginationResponseTest extends TestCase
+class PagePaginationResponseTest extends TestCase
 {
     public function testToArray(): void
     {
-        $response = new PagePaginationPaginationResponse(1, 10, true, 5);
+        $response = new PagePaginationResponse(1, 10, true, 5);
         $expected = [
             'page' => 1,
             'total_pages' => 5,
@@ -23,15 +23,15 @@ class PagePaginationPaginationResponseTest extends TestCase
 
     public function testToArrayFiltersNull(): void
     {
-        $response = new PagePaginationPaginationResponse(1, 10, false, null);
+        $response = new PagePaginationResponse(1, 10, false, null);
         $expected = [
             'page' => 1,
             'page_size' => 10,
             // has_more is false, array_filter might remove it if not careful, 
             // but in PHP false is filtered out by array_filter without callback.
-            // Wait, let's check PagePaginationPaginationResponse::toArray()
+            // Wait, let's check PagePaginationResponse::toArray()
         ];
-        // In PagePaginationPaginationResponse.php:
+        // In PagePaginationResponse.php:
         // return array_filter([
         //     'page' => $this->page,
         //     'total_pages' => $this->totalPages,
@@ -47,7 +47,7 @@ class PagePaginationPaginationResponseTest extends TestCase
 
     public function testGetResponseDocumentationProperties(): void
     {
-        $properties = PagePaginationPaginationResponse::getResponseDocumentationProperties();
+        $properties = PagePaginationResponse::getResponseDocumentationProperties();
         $this->assertCount(4, $properties);
         $this->assertEquals('page', $properties[0]->getPropertyName());
         $this->assertEquals('total_pages', $properties[1]->getPropertyName());

--- a/Tests/PhpUnit/Http/Response/Resource/ResourceListResponseTest.php
+++ b/Tests/PhpUnit/Http/Response/Resource/ResourceListResponseTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Tests\PhpUnit\Http\Response\Resource;
 
 use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
-use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceListResponse;
 use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
 use PHPUnit\Framework\TestCase;
@@ -23,7 +23,7 @@ class ResourceListResponseTest extends TestCase
         $resource->name = 'Leo';
         $resource->type = 'lion';
 
-        $pagination = new PagePaginationPaginationResponse(1, 10, false);
+        $pagination = new PagePaginationResponse(1, 10, false);
         $response = new ResourceListResponse([$resource], $pagination);
 
         $array = $response->toArray();

--- a/Tests/PhpUnit/Resource/Stub/ListAnimalsController.php
+++ b/Tests/PhpUnit/Resource/Stub/ListAnimalsController.php
@@ -7,7 +7,7 @@ namespace apivalk\apivalk\Tests\PhpUnit\Resource\Stub;
 use apivalk\apivalk\Http\Controller\Resource\AbstractListResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
-use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceListResponse;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
 
@@ -25,6 +25,6 @@ class ListAnimalsController extends AbstractListResourceController
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
-        return new ResourceListResponse([], new PagePaginationPaginationResponse(1, 25, false, 0));
+        return new ResourceListResponse([], new PagePaginationResponse(1, 25, false, 0));
     }
 }

--- a/Tests/PhpUnit/Router/RouteCacheFactoryTest.php
+++ b/Tests/PhpUnit/Router/RouteCacheFactoryTest.php
@@ -16,6 +16,10 @@ use apivalk\apivalk\Router\Route\RouteCacheFactory;
 use apivalk\apivalk\Util\ClassLocator;
 use PHPUnit\Framework\TestCase;
 
+abstract class AbstractIntermediateStubController extends AbstractApivalkController
+{
+}
+
 class RouteCacheFactoryTest extends TestCase
 {
     public function testBuildCache(): void
@@ -49,6 +53,31 @@ class RouteCacheFactoryTest extends TestCase
         // Expect cache sets
         $cache->expects($this->atLeastOnce())->method('set');
         $cache->expects($this->once())->method('clear');
+
+        $factory = new RouteCacheFactory($router);
+        $factory->build();
+    }
+
+    public function testBuildCacheSkipsAbstractControllerSubclasses(): void
+    {
+        $cache = $this->createMock(CacheInterface::class);
+        $classLocator = $this->createMock(ClassLocator::class);
+
+        $cache->method('get')->with(AbstractRouter::CACHE_INDEX_KEY)->willReturn(null);
+
+        $classLocator->method('find')->willReturn([
+            ['className' => AbstractIntermediateStubController::class, 'path' => 'path/to/abstract.php'],
+        ]);
+
+        $router = $this->getMockBuilder(AbstractRouter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $router->method('getCache')->willReturn($cache);
+        $router->method('getClassLocator')->willReturn($classLocator);
+
+        $cache->expects($this->once())->method('clear');
+        // Only the index entry is written; no per-route cache entry for the abstract class.
+        $cache->expects($this->once())->method('set');
 
         $factory = new RouteCacheFactory($router);
         $factory->build();

--- a/docs/deprecating-upgrade.mdx
+++ b/docs/deprecating-upgrade.mdx
@@ -15,7 +15,6 @@ This section lists major changes and steps required to upgrade from Apivalk v1 t
 - **Renamed `MODE_EDIT` to `MODE_UPDATE`**: All occurrences of `MODE_EDIT` in `AbstractPropertyCollection` and related security permissions (e.g., `asset:edit` to `asset:update`) have been renamed.
 - **Renamed "Ordering" to "Sorting"**: The terminology and related classes/methods have been updated from "Ordering" to "Sorting" (e.g., `Order` is now `Sort`).
 - **Property System Refactor**: `NumberProperty` has been split into `IntegerProperty` and `FloatProperty`. `StringProperty` now has specialized variants like `EnumProperty`, `DateProperty`, `DateTimeProperty`, `ByteProperty`, and `BinaryProperty`.
-- **Pagination Refactor**: `ResponsePagination` was replaced by dedicated response interfaces (`CursorPaginationPaginationResponse`, `OffsetPaginationPaginationResponse`, `PagePaginationPaginationResponse`).
 
 #### New Features
 

--- a/docs/how-to/pagination.mdx
+++ b/docs/how-to/pagination.mdx
@@ -54,7 +54,7 @@ public function __invoke(ApivalkRequestInterface $request): AbstractApivalkRespo
 
     $response = new ListAnimalsResponse($rows);
     $response->setPaginationResponse(
-        new PagePaginationPaginationResponse(
+        new PagePaginationResponse(
             $page,
             $limit,
             $page < $totalPages,
@@ -74,7 +74,7 @@ $rows = $this->animals->findRange($paginator->getOffset(), $paginator->getLimit(
 $total = $this->animals->count();
 
 $response->setPaginationResponse(
-    new OffsetPaginationPaginationResponse(
+    new OffsetPaginationResponse(
         $paginator->getLimit(),
         $paginator->getOffset(),
         $paginator->getOffset() + $paginator->getLimit() < $total,
@@ -92,7 +92,7 @@ $rows = $this->animals->findAfter($paginator->getCursor(), $paginator->getLimit(
 $nextCursor = \end($rows) !== false ? \end($rows)['id'] : null;
 
 $response->setPaginationResponse(
-    new CursorPaginationPaginationResponse(
+    new CursorPaginationResponse(
         $paginator->getLimit(),
         $paginator->getCursor(),
         $nextCursor,

--- a/docs/how-to/resource-crud.mdx
+++ b/docs/how-to/resource-crud.mdx
@@ -314,7 +314,7 @@ namespace App\Http\Controller\Animal;
 use apivalk\apivalk\Http\Controller\Resource\AbstractListResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
-use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceListResponse;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
 use apivalk\apivalk\Security\RouteAuthorization;
@@ -367,7 +367,7 @@ final class ListAnimalController extends AbstractListResourceController
 
         return new ResourceListResponse(
             $resources,
-            new PagePaginationPaginationResponse(
+            new PagePaginationResponse(
                 $paginator->getPage(),
                 $paginator->getLimit(),
                 $paginator->getPage() < $totalPages,

--- a/docs/http/pagination.mdx
+++ b/docs/http/pagination.mdx
@@ -59,7 +59,7 @@ public function __invoke(ApivalkRequestInterface $request): AbstractApivalkRespo
 After fetching your data, you must create a `PaginationResponse` object and attach it to your response. This ensures the pagination metadata (like `total_pages` or `has_more`) is included in the JSON output.
 
 ```php
-use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationResponse;
 
 // Inside Controller:
 $totalEntries = $this->petRepository->count();
@@ -68,7 +68,7 @@ $hasMore = $paginator->getPage() < $totalPages;
 
 $response = new GetPetsResponse($pets);
 $response->setPaginationResponse(
-    new PagePaginationPaginationResponse(
+    new PagePaginationResponse(
         $paginator->getPage(),
         $paginator->getLimit(),
         $hasMore,

--- a/docs/http/response.mdx
+++ b/docs/http/response.mdx
@@ -110,10 +110,10 @@ If the rate limit is exceeded (429 Too Many Requests), the `Retry-After` header 
 If a route has [pagination enabled](/http/pagination), you can attach a pagination response object to your response. This will automatically inject the `pagination` metadata into the JSON output and the OpenAPI documentation.
 
 ```php
-use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationResponse;
 
 $response->setPaginationResponse(
-    new PagePaginationPaginationResponse($page, $limit, $hasMore, $totalPages)
+    new PagePaginationResponse($page, $limit, $hasMore, $totalPages)
 );
 ```
 

--- a/docs/resources/controllers.mdx
+++ b/docs/resources/controllers.mdx
@@ -144,7 +144,7 @@ namespace App\Http\Controller\Animal;
 use apivalk\apivalk\Http\Controller\Resource\AbstractListResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
-use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceListResponse;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
 use App\Resource\AnimalResource;
@@ -178,7 +178,7 @@ final class ListAnimalController extends AbstractListResourceController
 
         return new ResourceListResponse(
             $animals,
-            new PagePaginationPaginationResponse(
+            new PagePaginationResponse(
                 $paginator->getPage(),
                 $paginator->getLimit(),
                 /* hasMore */ true

--- a/docs/resources/responses.mdx
+++ b/docs/resources/responses.mdx
@@ -31,15 +31,15 @@ Internally, each calls `$animal->toArray($mode)` with the matching mode constant
 ### List
 
 ```php
-use apivalk\apivalk\Http\Response\Pagination\PagePaginationPaginationResponse;
+use apivalk\apivalk\Http\Response\Pagination\PagePaginationResponse;
 
 return new ResourceListResponse(
     $animals,
-    new PagePaginationPaginationResponse($page, $pageSize, $hasMore, $totalPages)
+    new PagePaginationResponse($page, $pageSize, $hasMore, $totalPages)
 );
 ```
 
-Or with offset / cursor pagination: swap in `OffsetPaginationPaginationResponse` / `CursorPaginationPaginationResponse`. The `JsonRenderer` adds the `pagination` key to the output automatically.
+Or with offset / cursor pagination: swap in `OffsetPaginationResponse` / `CursorPaginationResponse`. The `JsonRenderer` adds the `pagination` key to the output automatically.
 
 Output shape:
 


### PR DESCRIPTION
…tion responses

- RouteCacheFactory now skips abstract AbstractApivalkController subclasses so intermediate base controllers no longer fatal on ::getRoute().
- DocBlock generators drop "|null" from the paginator() @method line; it is only emitted when a paginator is guaranteed at runtime.
- Rename {Page,Offset,Cursor}PaginationPaginationResponse to {Page,Offset,Cursor}PaginationResponse.

Issue: #104, #109, #108