### PR TITLE
fix: add schema to Content-Language response header

### DIFF
--- a/Documentation/OpenAPI/Generator/OperationGenerator.php
+++ b/Documentation/OpenAPI/Generator/OperationGenerator.php
@@ -336,8 +336,11 @@ class OperationGenerator
         $headers = [];
 
         if ($this->documentLocaleHeaders) {
-            $headers['Content-Language'] =
-                new HeaderObject('The locale of the response content (BCP 47 language tag).');
+            $headers['Content-Language'] = new HeaderObject(
+                'The locale of the response content (BCP 47 language tag).',
+                false,
+                ['type' => 'string', 'example' => 'en']
+            );
         }
 
         if ($route->getRateLimit() !== null) {

--- a/Documentation/OpenAPI/Object/HeaderObject.php
+++ b/Documentation/OpenAPI/Object/HeaderObject.php
@@ -17,11 +17,17 @@ class HeaderObject implements ObjectInterface
     private $description;
     /** @var bool */
     private $required;
+    /** @var array<string, mixed>|null */
+    private $schema;
 
-    public function __construct(?string $description, bool $required = false)
+    /**
+     * @param array<string, mixed>|null $schema
+     */
+    public function __construct(?string $description, bool $required = false, ?array $schema = null)
     {
         $this->description = $description;
         $this->required = $required;
+        $this->schema = $schema;
     }
 
     public function getDescription(): ?string
@@ -34,11 +40,25 @@ class HeaderObject implements ObjectInterface
         return $this->required;
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getSchema(): ?array
+    {
+        return $this->schema;
+    }
+
     public function toArray(): array
     {
-        return [
+        $array = [
             'description' => $this->description,
-            'required' => $this->required
+            'required' => $this->required,
         ];
+
+        if ($this->schema !== null) {
+            $array['schema'] = $this->schema;
+        }
+
+        return $array;
     }
 }

--- a/Tests/PhpUnit/Documentation/OpenAPI/Object/HeaderObjectTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Object/HeaderObjectTest.php
@@ -12,14 +12,30 @@ class HeaderObjectTest extends TestCase
     public function testHeaderObjectToArray(): void
     {
         $header = new HeaderObject('Header description', true);
-        
+
         $expected = [
             'description' => 'Header description',
-            'required' => true
+            'required' => true,
         ];
 
         $this->assertEquals($expected, $header->toArray());
         $this->assertEquals('Header description', $header->getDescription());
         $this->assertTrue($header->isRequired());
+        $this->assertNull($header->getSchema());
+    }
+
+    public function testHeaderObjectToArrayWithSchema(): void
+    {
+        $schema = ['type' => 'string', 'example' => 'en'];
+        $header = new HeaderObject('Header description', false, $schema);
+
+        $expected = [
+            'description' => 'Header description',
+            'required' => false,
+            'schema' => ['type' => 'string', 'example' => 'en'],
+        ];
+
+        $this->assertEquals($expected, $header->toArray());
+        $this->assertEquals($schema, $header->getSchema());
     }
 }


### PR DESCRIPTION
- The generated Content-Language header object was missing the `schema` field, making the output non-compliant with the OpenAPI spec. Added optional schema support to HeaderObject and pass `{type: string, example: en}` for the locale header.

Issue: #111