### PR TITLE
feat: boolean filter and unit tests for filters

### DIFF
--- a/Router/Route/Filter/BooleanFilter.php
+++ b/Router/Route/Filter/BooleanFilter.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Router\Route\Filter;
+
+use apivalk\apivalk\Documentation\Property\AbstractProperty;
+use apivalk\apivalk\Documentation\Property\BooleanProperty;
+
+class BooleanFilter implements FilterInterface
+{
+    /** @var string */
+    private $type;
+    /** @var BooleanProperty */
+    private $property;
+    /** @var bool|null */
+    private $value;
+
+    public function __construct(string $type, BooleanProperty $property)
+    {
+        $this->type = $type;
+        $this->property = $property;
+    }
+
+    public static function equals(BooleanProperty $property): self
+    {
+        return new self(self::TYPE_EQUALS, $property);
+    }
+
+    public function getField(): string
+    {
+        return $this->property->getPropertyName();
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /** @return BooleanProperty */
+    public function getProperty(): AbstractProperty
+    {
+        return $this->property;
+    }
+
+    public function setValue($value): void
+    {
+        $this->value = $value !== null ? (bool) $value : null;
+    }
+
+    public function getValue(): ?bool
+    {
+        return $this->value;
+    }
+
+    public function isTypeEquals(): bool
+    {
+        return $this->type === self::TYPE_EQUALS;
+    }
+
+    public function isTypeIn(): bool
+    {
+        return $this->type === self::TYPE_IN;
+    }
+
+    public function isTypeLike(): bool
+    {
+        return $this->type === self::TYPE_LIKE;
+    }
+
+    public function isTypeContains(): bool
+    {
+        return $this->type === self::TYPE_CONTAINS;
+    }
+
+    public function isTypeGreaterThan(): bool
+    {
+        return $this->type === self::TYPE_GREATER_THAN;
+    }
+
+    public function isTypeLessThan(): bool
+    {
+        return $this->type === self::TYPE_LESS_THAN;
+    }
+}

--- a/Tests/PhpUnit/Router/Route/Filter/BinaryFilterTest.php
+++ b/Tests/PhpUnit/Router/Route/Filter/BinaryFilterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Router\Route\Filter;
+
+use apivalk\apivalk\Documentation\Property\BinaryProperty;
+use apivalk\apivalk\Router\Route\Filter\BinaryFilter;
+use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use PHPUnit\Framework\TestCase;
+
+class BinaryFilterTest extends TestCase
+{
+    private function prop(string $name = 'data'): BinaryProperty
+    {
+        return new BinaryProperty($name);
+    }
+
+    public function testFactories(): void
+    {
+        $this->assertSame(FilterInterface::TYPE_EQUALS, BinaryFilter::equals($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_IN, BinaryFilter::in($this->prop())->getType());
+    }
+
+    public function testGetters(): void
+    {
+        $prop = $this->prop('checksum');
+        $filter = BinaryFilter::equals($prop);
+
+        $this->assertSame('checksum', $filter->getField());
+        $this->assertSame(FilterInterface::TYPE_EQUALS, $filter->getType());
+        $this->assertInstanceOf(BinaryProperty::class, $filter->getProperty());
+        $this->assertSame($prop, $filter->getProperty());
+    }
+
+    public function testTypeChecks(): void
+    {
+        $this->assertTrue(BinaryFilter::equals($this->prop())->isTypeEquals());
+        $this->assertFalse(BinaryFilter::equals($this->prop())->isTypeIn());
+        $this->assertFalse(BinaryFilter::equals($this->prop())->isTypeLike());
+        $this->assertFalse(BinaryFilter::equals($this->prop())->isTypeContains());
+        $this->assertFalse(BinaryFilter::equals($this->prop())->isTypeGreaterThan());
+        $this->assertFalse(BinaryFilter::equals($this->prop())->isTypeLessThan());
+
+        $this->assertTrue(BinaryFilter::in($this->prop())->isTypeIn());
+    }
+
+    public function testValueCasting(): void
+    {
+        $filter = BinaryFilter::equals($this->prop());
+
+        $this->assertNull($filter->getValue());
+
+        $filter->setValue('abc123');
+        $this->assertSame('abc123', $filter->getValue());
+
+        $filter->setValue(99);
+        $this->assertSame('99', $filter->getValue());
+
+        $filter->setValue(null);
+        $this->assertNull($filter->getValue());
+    }
+}

--- a/Tests/PhpUnit/Router/Route/Filter/BooleanFilterTest.php
+++ b/Tests/PhpUnit/Router/Route/Filter/BooleanFilterTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Router\Route\Filter;
+
+use apivalk\apivalk\Documentation\Property\BooleanProperty;
+use apivalk\apivalk\Router\Route\Filter\BooleanFilter;
+use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use PHPUnit\Framework\TestCase;
+
+class BooleanFilterTest extends TestCase
+{
+    private function prop(string $name = 'active'): BooleanProperty
+    {
+        return new BooleanProperty($name, '', false);
+    }
+
+    public function testFactory(): void
+    {
+        $this->assertSame(FilterInterface::TYPE_EQUALS, BooleanFilter::equals($this->prop())->getType());
+    }
+
+    public function testGetters(): void
+    {
+        $prop = $this->prop('enabled');
+        $filter = BooleanFilter::equals($prop);
+
+        $this->assertSame('enabled', $filter->getField());
+        $this->assertSame(FilterInterface::TYPE_EQUALS, $filter->getType());
+        $this->assertInstanceOf(BooleanProperty::class, $filter->getProperty());
+        $this->assertSame($prop, $filter->getProperty());
+    }
+
+    public function testTypeChecks(): void
+    {
+        $this->assertTrue(BooleanFilter::equals($this->prop())->isTypeEquals());
+        $this->assertFalse(BooleanFilter::equals($this->prop())->isTypeIn());
+        $this->assertFalse(BooleanFilter::equals($this->prop())->isTypeLike());
+        $this->assertFalse(BooleanFilter::equals($this->prop())->isTypeContains());
+        $this->assertFalse(BooleanFilter::equals($this->prop())->isTypeGreaterThan());
+        $this->assertFalse(BooleanFilter::equals($this->prop())->isTypeLessThan());
+    }
+
+    public function testValueCasting(): void
+    {
+        $filter = BooleanFilter::equals($this->prop());
+
+        $this->assertNull($filter->getValue());
+
+        $filter->setValue(true);
+        $this->assertTrue($filter->getValue());
+
+        $filter->setValue(false);
+        $this->assertFalse($filter->getValue());
+
+        $filter->setValue(1);
+        $this->assertTrue($filter->getValue());
+
+        $filter->setValue(0);
+        $this->assertFalse($filter->getValue());
+
+        $filter->setValue('1');
+        $this->assertTrue($filter->getValue());
+
+        $filter->setValue('');
+        $this->assertFalse($filter->getValue());
+
+        $filter->setValue(null);
+        $this->assertNull($filter->getValue());
+    }
+}

--- a/Tests/PhpUnit/Router/Route/Filter/ByteFilterTest.php
+++ b/Tests/PhpUnit/Router/Route/Filter/ByteFilterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Router\Route\Filter;
+
+use apivalk\apivalk\Documentation\Property\ByteProperty;
+use apivalk\apivalk\Router\Route\Filter\ByteFilter;
+use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use PHPUnit\Framework\TestCase;
+
+class ByteFilterTest extends TestCase
+{
+    private function prop(string $name = 'payload'): ByteProperty
+    {
+        return new ByteProperty($name);
+    }
+
+    public function testFactories(): void
+    {
+        $this->assertSame(FilterInterface::TYPE_EQUALS, ByteFilter::equals($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_IN, ByteFilter::in($this->prop())->getType());
+    }
+
+    public function testGetters(): void
+    {
+        $prop = $this->prop('content');
+        $filter = ByteFilter::equals($prop);
+
+        $this->assertSame('content', $filter->getField());
+        $this->assertSame(FilterInterface::TYPE_EQUALS, $filter->getType());
+        $this->assertInstanceOf(ByteProperty::class, $filter->getProperty());
+        $this->assertSame($prop, $filter->getProperty());
+    }
+
+    public function testTypeChecks(): void
+    {
+        $this->assertTrue(ByteFilter::equals($this->prop())->isTypeEquals());
+        $this->assertFalse(ByteFilter::equals($this->prop())->isTypeIn());
+        $this->assertFalse(ByteFilter::equals($this->prop())->isTypeLike());
+        $this->assertFalse(ByteFilter::equals($this->prop())->isTypeContains());
+        $this->assertFalse(ByteFilter::equals($this->prop())->isTypeGreaterThan());
+        $this->assertFalse(ByteFilter::equals($this->prop())->isTypeLessThan());
+
+        $this->assertTrue(ByteFilter::in($this->prop())->isTypeIn());
+    }
+
+    public function testValueCasting(): void
+    {
+        $filter = ByteFilter::equals($this->prop());
+
+        $this->assertNull($filter->getValue());
+
+        $filter->setValue('dGVzdA==');
+        $this->assertSame('dGVzdA==', $filter->getValue());
+
+        $filter->setValue(0);
+        $this->assertSame('0', $filter->getValue());
+
+        $filter->setValue(null);
+        $this->assertNull($filter->getValue());
+    }
+}

--- a/Tests/PhpUnit/Router/Route/Filter/DateFilterTest.php
+++ b/Tests/PhpUnit/Router/Route/Filter/DateFilterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Router\Route\Filter;
+
+use apivalk\apivalk\Documentation\Property\DateProperty;
+use apivalk\apivalk\Router\Route\Filter\DateFilter;
+use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use PHPUnit\Framework\TestCase;
+
+class DateFilterTest extends TestCase
+{
+    private function prop(string $name = 'created_at'): DateProperty
+    {
+        return new DateProperty($name);
+    }
+
+    public function testFactories(): void
+    {
+        $this->assertSame(FilterInterface::TYPE_EQUALS, DateFilter::equals($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_IN, DateFilter::in($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_GREATER_THAN, DateFilter::greaterThan($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_LESS_THAN, DateFilter::lessThan($this->prop())->getType());
+    }
+
+    public function testGetters(): void
+    {
+        $prop = $this->prop('published_at');
+        $filter = DateFilter::equals($prop);
+
+        $this->assertSame('published_at', $filter->getField());
+        $this->assertSame(FilterInterface::TYPE_EQUALS, $filter->getType());
+        $this->assertInstanceOf(DateProperty::class, $filter->getProperty());
+        $this->assertSame($prop, $filter->getProperty());
+        $this->assertSame('date', $filter->getProperty()->getFormat());
+    }
+
+    public function testTypeChecks(): void
+    {
+        $this->assertTrue(DateFilter::equals($this->prop())->isTypeEquals());
+        $this->assertFalse(DateFilter::equals($this->prop())->isTypeIn());
+        $this->assertFalse(DateFilter::equals($this->prop())->isTypeLike());
+        $this->assertFalse(DateFilter::equals($this->prop())->isTypeContains());
+        $this->assertFalse(DateFilter::equals($this->prop())->isTypeGreaterThan());
+        $this->assertFalse(DateFilter::equals($this->prop())->isTypeLessThan());
+
+        $this->assertTrue(DateFilter::in($this->prop())->isTypeIn());
+        $this->assertTrue(DateFilter::greaterThan($this->prop())->isTypeGreaterThan());
+        $this->assertTrue(DateFilter::lessThan($this->prop())->isTypeLessThan());
+    }
+
+    public function testValueFromString(): void
+    {
+        $filter = DateFilter::equals($this->prop());
+        $filter->setValue('2023-06-15');
+
+        $this->assertInstanceOf(\DateTime::class, $filter->getValue());
+        $this->assertSame('2023-06-15', $filter->getValue()->format('Y-m-d'));
+    }
+
+    public function testValueFromDateTimeObject(): void
+    {
+        $filter = DateFilter::equals($this->prop());
+        $dt = new \DateTime('2023-06-15');
+        $filter->setValue($dt);
+
+        $this->assertSame($dt, $filter->getValue());
+    }
+
+    public function testValueNull(): void
+    {
+        $filter = DateFilter::equals($this->prop());
+        $filter->setValue('2023-06-15');
+        $filter->setValue(null);
+
+        $this->assertNull($filter->getValue());
+    }
+
+    public function testInvalidStringYieldsNull(): void
+    {
+        $filter = DateFilter::equals($this->prop());
+        $filter->setValue('not-a-date-at-all!!!invalid@@@');
+
+        $this->assertNull($filter->getValue());
+    }
+}

--- a/Tests/PhpUnit/Router/Route/Filter/DateTimeFilterTest.php
+++ b/Tests/PhpUnit/Router/Route/Filter/DateTimeFilterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Router\Route\Filter;
+
+use apivalk\apivalk\Documentation\Property\DateTimeProperty;
+use apivalk\apivalk\Router\Route\Filter\DateTimeFilter;
+use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use PHPUnit\Framework\TestCase;
+
+class DateTimeFilterTest extends TestCase
+{
+    private function prop(string $name = 'updated_at'): DateTimeProperty
+    {
+        return new DateTimeProperty($name);
+    }
+
+    public function testFactories(): void
+    {
+        $this->assertSame(FilterInterface::TYPE_EQUALS, DateTimeFilter::equals($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_IN, DateTimeFilter::in($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_GREATER_THAN, DateTimeFilter::greaterThan($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_LESS_THAN, DateTimeFilter::lessThan($this->prop())->getType());
+    }
+
+    public function testGetters(): void
+    {
+        $prop = $this->prop('deleted_at');
+        $filter = DateTimeFilter::equals($prop);
+
+        $this->assertSame('deleted_at', $filter->getField());
+        $this->assertSame(FilterInterface::TYPE_EQUALS, $filter->getType());
+        $this->assertInstanceOf(DateTimeProperty::class, $filter->getProperty());
+        $this->assertSame($prop, $filter->getProperty());
+        $this->assertSame('date-time', $filter->getProperty()->getFormat());
+    }
+
+    public function testTypeChecks(): void
+    {
+        $this->assertTrue(DateTimeFilter::equals($this->prop())->isTypeEquals());
+        $this->assertFalse(DateTimeFilter::equals($this->prop())->isTypeIn());
+        $this->assertFalse(DateTimeFilter::equals($this->prop())->isTypeLike());
+        $this->assertFalse(DateTimeFilter::equals($this->prop())->isTypeContains());
+        $this->assertFalse(DateTimeFilter::equals($this->prop())->isTypeGreaterThan());
+        $this->assertFalse(DateTimeFilter::equals($this->prop())->isTypeLessThan());
+
+        $this->assertTrue(DateTimeFilter::in($this->prop())->isTypeIn());
+        $this->assertTrue(DateTimeFilter::greaterThan($this->prop())->isTypeGreaterThan());
+        $this->assertTrue(DateTimeFilter::lessThan($this->prop())->isTypeLessThan());
+    }
+
+    public function testValueFromString(): void
+    {
+        $filter = DateTimeFilter::equals($this->prop());
+        $filter->setValue('2023-06-15 14:30:00');
+
+        $this->assertInstanceOf(\DateTime::class, $filter->getValue());
+        $this->assertSame('2023-06-15 14:30:00', $filter->getValue()->format('Y-m-d H:i:s'));
+    }
+
+    public function testValueFromDateTimeObject(): void
+    {
+        $filter = DateTimeFilter::equals($this->prop());
+        $dt = new \DateTime('2023-06-15T14:30:00Z');
+        $filter->setValue($dt);
+
+        $this->assertSame($dt, $filter->getValue());
+    }
+
+    public function testValueNull(): void
+    {
+        $filter = DateTimeFilter::equals($this->prop());
+        $filter->setValue('2023-06-15 14:30:00');
+        $filter->setValue(null);
+
+        $this->assertNull($filter->getValue());
+    }
+
+    public function testInvalidStringYieldsNull(): void
+    {
+        $filter = DateTimeFilter::equals($this->prop());
+        $filter->setValue('not-a-datetime-at-all!!!invalid@@@');
+
+        $this->assertNull($filter->getValue());
+    }
+}

--- a/Tests/PhpUnit/Router/Route/Filter/EnumFilterTest.php
+++ b/Tests/PhpUnit/Router/Route/Filter/EnumFilterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Router\Route\Filter;
+
+use apivalk\apivalk\Documentation\Property\EnumProperty;
+use apivalk\apivalk\Router\Route\Filter\EnumFilter;
+use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use PHPUnit\Framework\TestCase;
+
+class EnumFilterTest extends TestCase
+{
+    private function prop(string $name = 'status'): EnumProperty
+    {
+        return new EnumProperty($name, '', ['active', 'inactive']);
+    }
+
+    public function testFactories(): void
+    {
+        $this->assertSame(FilterInterface::TYPE_EQUALS, EnumFilter::equals($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_IN, EnumFilter::in($this->prop())->getType());
+    }
+
+    public function testGetters(): void
+    {
+        $prop = $this->prop('state');
+        $filter = EnumFilter::equals($prop);
+
+        $this->assertSame('state', $filter->getField());
+        $this->assertSame(FilterInterface::TYPE_EQUALS, $filter->getType());
+        $this->assertInstanceOf(EnumProperty::class, $filter->getProperty());
+        $this->assertSame($prop, $filter->getProperty());
+    }
+
+    public function testTypeChecks(): void
+    {
+        $this->assertTrue(EnumFilter::equals($this->prop())->isTypeEquals());
+        $this->assertFalse(EnumFilter::equals($this->prop())->isTypeIn());
+        $this->assertFalse(EnumFilter::equals($this->prop())->isTypeLike());
+        $this->assertFalse(EnumFilter::equals($this->prop())->isTypeContains());
+        $this->assertFalse(EnumFilter::equals($this->prop())->isTypeGreaterThan());
+        $this->assertFalse(EnumFilter::equals($this->prop())->isTypeLessThan());
+
+        $this->assertTrue(EnumFilter::in($this->prop())->isTypeIn());
+    }
+
+    public function testValueCasting(): void
+    {
+        $filter = EnumFilter::equals($this->prop());
+
+        $this->assertNull($filter->getValue());
+
+        $filter->setValue('active');
+        $this->assertSame('active', $filter->getValue());
+
+        $filter->setValue(0);
+        $this->assertSame('0', $filter->getValue());
+
+        $filter->setValue(null);
+        $this->assertNull($filter->getValue());
+    }
+}

--- a/Tests/PhpUnit/Router/Route/Filter/FilterTest.php
+++ b/Tests/PhpUnit/Router/Route/Filter/FilterTest.php
@@ -4,97 +4,18 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Router\Route\Filter;
 
-use apivalk\apivalk\Documentation\Property\DateProperty;
-use apivalk\apivalk\Documentation\Property\DateTimeProperty;
-use apivalk\apivalk\Documentation\Property\FloatProperty;
-use apivalk\apivalk\Documentation\Property\IntegerProperty;
-use apivalk\apivalk\Documentation\Property\StringProperty;
-use apivalk\apivalk\Router\Route\Filter\DateFilter;
-use apivalk\apivalk\Router\Route\Filter\DateTimeFilter;
 use apivalk\apivalk\Router\Route\Filter\FilterInterface;
-use apivalk\apivalk\Router\Route\Filter\FloatFilter;
-use apivalk\apivalk\Router\Route\Filter\IntegerFilter;
-use apivalk\apivalk\Router\Route\Filter\StringFilter;
 use PHPUnit\Framework\TestCase;
 
 class FilterTest extends TestCase
 {
-    public function testGetters(): void
+    public function testInterfaceConstants(): void
     {
-        $filter = new StringFilter(FilterInterface::TYPE_EQUALS, new StringProperty('status'));
-        $this->assertSame('status', $filter->getField());
-        $this->assertSame(FilterInterface::TYPE_EQUALS, $filter->getType());
-    }
-
-    public function testStaticFactories(): void
-    {
-        $prop = new StringProperty('f');
-        $this->assertSame(FilterInterface::TYPE_EQUALS, StringFilter::equals($prop)->getType());
-        $this->assertSame(FilterInterface::TYPE_IN, StringFilter::in($prop)->getType());
-        $this->assertSame(FilterInterface::TYPE_LIKE, StringFilter::like($prop)->getType());
-        $this->assertSame(FilterInterface::TYPE_CONTAINS, StringFilter::contains($prop)->getType());
-
-        $intProp = new IntegerProperty('n');
-        $this->assertSame(FilterInterface::TYPE_EQUALS, IntegerFilter::equals($intProp)->getType());
-        $this->assertSame(FilterInterface::TYPE_IN, IntegerFilter::in($intProp)->getType());
-        $this->assertSame(FilterInterface::TYPE_GREATER_THAN, IntegerFilter::greaterThan($intProp)->getType());
-        $this->assertSame(FilterInterface::TYPE_LESS_THAN, IntegerFilter::lessThan($intProp)->getType());
-    }
-
-    public function testTypeChecks(): void
-    {
-        $prop = new StringProperty('f');
-        $intProp = new IntegerProperty('n');
-        $this->assertTrue(StringFilter::equals($prop)->isTypeEquals());
-        $this->assertTrue(StringFilter::in($prop)->isTypeIn());
-        $this->assertTrue(StringFilter::like($prop)->isTypeLike());
-        $this->assertTrue(StringFilter::contains($prop)->isTypeContains());
-
-        $this->assertTrue(IntegerFilter::greaterThan($intProp)->isTypeGreaterThan());
-        $this->assertTrue(IntegerFilter::lessThan($intProp)->isTypeLessThan());
-
-        $filter = StringFilter::equals($prop);
-        $this->assertFalse($filter->isTypeIn());
-    }
-
-    public function testGetDefaultProperty(): void
-    {
-        $property = new StringProperty('status', 'Filter results by `status` (equals).');
-        $property->setIsRequired(false);
-        $filter = StringFilter::equals($property);
-
-        $this->assertInstanceOf(StringProperty::class, $filter->getProperty());
-        $this->assertSame('status', $filter->getProperty()->getPropertyName());
-    }
-
-    public function testValueCasting(): void
-    {
-        $filter = StringFilter::equals(new StringProperty('status'));
-        $filter->setValue('123');
-        $this->assertSame('123', $filter->getValue());
-
-        $intProp = new IntegerProperty('count', '', IntegerProperty::FORMAT_INT32);
-        $intFilter = IntegerFilter::equals($intProp);
-        $intFilter->setValue('10');
-        $this->assertSame(10, $intFilter->getValue());
-
-        $floatProp = new FloatProperty('price', '', FloatProperty::FORMAT_FLOAT);
-        $floatFilter = FloatFilter::equals($floatProp);
-        $floatFilter->setValue('10.5');
-        $this->assertSame(10.5, $floatFilter->getValue());
-
-        $dateProp = new DateProperty('created_at');
-        $dateFilter = DateFilter::equals($dateProp);
-        $dateFilter->setValue('2023-01-01');
-        $this->assertInstanceOf(\DateTime::class, $dateFilter->getValue());
-        $this->assertSame('2023-01-01', $dateFilter->getValue()->format('Y-m-d'));
-        $this->assertSame('date', $dateFilter->getProperty()->getFormat());
-
-        $dateTimeProp = new DateTimeProperty('updated_at');
-        $dateTimeFilter = DateTimeFilter::equals($dateTimeProp);
-        $dateTimeFilter->setValue('2023-01-01 12:00:00');
-        $this->assertInstanceOf(\DateTime::class, $dateTimeFilter->getValue());
-        $this->assertSame('2023-01-01 12:00:00', $dateTimeFilter->getValue()->format('Y-m-d H:i:s'));
-        $this->assertSame('date-time', $dateTimeFilter->getProperty()->getFormat());
+        $this->assertSame('equals', FilterInterface::TYPE_EQUALS);
+        $this->assertSame('in', FilterInterface::TYPE_IN);
+        $this->assertSame('like', FilterInterface::TYPE_LIKE);
+        $this->assertSame('greater_than', FilterInterface::TYPE_GREATER_THAN);
+        $this->assertSame('less_than', FilterInterface::TYPE_LESS_THAN);
+        $this->assertSame('contains', FilterInterface::TYPE_CONTAINS);
     }
 }

--- a/Tests/PhpUnit/Router/Route/Filter/FloatFilterTest.php
+++ b/Tests/PhpUnit/Router/Route/Filter/FloatFilterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Router\Route\Filter;
+
+use apivalk\apivalk\Documentation\Property\FloatProperty;
+use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use apivalk\apivalk\Router\Route\Filter\FloatFilter;
+use PHPUnit\Framework\TestCase;
+
+class FloatFilterTest extends TestCase
+{
+    private function prop(string $name = 'price'): FloatProperty
+    {
+        return new FloatProperty($name);
+    }
+
+    public function testFactories(): void
+    {
+        $this->assertSame(FilterInterface::TYPE_EQUALS, FloatFilter::equals($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_IN, FloatFilter::in($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_GREATER_THAN, FloatFilter::greaterThan($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_LESS_THAN, FloatFilter::lessThan($this->prop())->getType());
+    }
+
+    public function testGetters(): void
+    {
+        $prop = $this->prop('amount');
+        $filter = FloatFilter::equals($prop);
+
+        $this->assertSame('amount', $filter->getField());
+        $this->assertSame(FilterInterface::TYPE_EQUALS, $filter->getType());
+        $this->assertInstanceOf(FloatProperty::class, $filter->getProperty());
+        $this->assertSame($prop, $filter->getProperty());
+    }
+
+    public function testTypeChecks(): void
+    {
+        $this->assertTrue(FloatFilter::equals($this->prop())->isTypeEquals());
+        $this->assertFalse(FloatFilter::equals($this->prop())->isTypeIn());
+        $this->assertFalse(FloatFilter::equals($this->prop())->isTypeLike());
+        $this->assertFalse(FloatFilter::equals($this->prop())->isTypeContains());
+        $this->assertFalse(FloatFilter::equals($this->prop())->isTypeGreaterThan());
+        $this->assertFalse(FloatFilter::equals($this->prop())->isTypeLessThan());
+
+        $this->assertTrue(FloatFilter::in($this->prop())->isTypeIn());
+        $this->assertTrue(FloatFilter::greaterThan($this->prop())->isTypeGreaterThan());
+        $this->assertTrue(FloatFilter::lessThan($this->prop())->isTypeLessThan());
+    }
+
+    public function testValueCasting(): void
+    {
+        $filter = FloatFilter::equals($this->prop());
+
+        $this->assertNull($filter->getValue());
+
+        $filter->setValue(10.5);
+        $this->assertSame(10.5, $filter->getValue());
+
+        $filter->setValue('3.14');
+        $this->assertSame(3.14, $filter->getValue());
+
+        $filter->setValue(42);
+        $this->assertSame(42.0, $filter->getValue());
+
+        $filter->setValue(null);
+        $this->assertNull($filter->getValue());
+    }
+}

--- a/Tests/PhpUnit/Router/Route/Filter/IntegerFilterTest.php
+++ b/Tests/PhpUnit/Router/Route/Filter/IntegerFilterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Router\Route\Filter;
+
+use apivalk\apivalk\Documentation\Property\IntegerProperty;
+use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use apivalk\apivalk\Router\Route\Filter\IntegerFilter;
+use PHPUnit\Framework\TestCase;
+
+class IntegerFilterTest extends TestCase
+{
+    private function prop(string $name = 'count'): IntegerProperty
+    {
+        return new IntegerProperty($name);
+    }
+
+    public function testFactories(): void
+    {
+        $this->assertSame(FilterInterface::TYPE_EQUALS, IntegerFilter::equals($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_IN, IntegerFilter::in($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_GREATER_THAN, IntegerFilter::greaterThan($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_LESS_THAN, IntegerFilter::lessThan($this->prop())->getType());
+    }
+
+    public function testGetters(): void
+    {
+        $prop = $this->prop('age');
+        $filter = IntegerFilter::equals($prop);
+
+        $this->assertSame('age', $filter->getField());
+        $this->assertSame(FilterInterface::TYPE_EQUALS, $filter->getType());
+        $this->assertInstanceOf(IntegerProperty::class, $filter->getProperty());
+        $this->assertSame($prop, $filter->getProperty());
+    }
+
+    public function testTypeChecks(): void
+    {
+        $this->assertTrue(IntegerFilter::equals($this->prop())->isTypeEquals());
+        $this->assertFalse(IntegerFilter::equals($this->prop())->isTypeIn());
+        $this->assertFalse(IntegerFilter::equals($this->prop())->isTypeLike());
+        $this->assertFalse(IntegerFilter::equals($this->prop())->isTypeContains());
+        $this->assertFalse(IntegerFilter::equals($this->prop())->isTypeGreaterThan());
+        $this->assertFalse(IntegerFilter::equals($this->prop())->isTypeLessThan());
+
+        $this->assertTrue(IntegerFilter::in($this->prop())->isTypeIn());
+        $this->assertTrue(IntegerFilter::greaterThan($this->prop())->isTypeGreaterThan());
+        $this->assertTrue(IntegerFilter::lessThan($this->prop())->isTypeLessThan());
+    }
+
+    public function testValueCasting(): void
+    {
+        $filter = IntegerFilter::equals($this->prop());
+
+        $this->assertNull($filter->getValue());
+
+        $filter->setValue(10);
+        $this->assertSame(10, $filter->getValue());
+
+        $filter->setValue('42');
+        $this->assertSame(42, $filter->getValue());
+
+        $filter->setValue(3.9);
+        $this->assertSame(3, $filter->getValue());
+
+        $filter->setValue(null);
+        $this->assertNull($filter->getValue());
+    }
+}

--- a/Tests/PhpUnit/Router/Route/Filter/StringFilterTest.php
+++ b/Tests/PhpUnit/Router/Route/Filter/StringFilterTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Router\Route\Filter;
+
+use apivalk\apivalk\Documentation\Property\StringProperty;
+use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use apivalk\apivalk\Router\Route\Filter\StringFilter;
+use PHPUnit\Framework\TestCase;
+
+class StringFilterTest extends TestCase
+{
+    private function prop(string $name = 'field'): StringProperty
+    {
+        return new StringProperty($name);
+    }
+
+    public function testFactories(): void
+    {
+        $this->assertSame(FilterInterface::TYPE_EQUALS, StringFilter::equals($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_IN, StringFilter::in($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_LIKE, StringFilter::like($this->prop())->getType());
+        $this->assertSame(FilterInterface::TYPE_CONTAINS, StringFilter::contains($this->prop())->getType());
+    }
+
+    public function testGetters(): void
+    {
+        $prop = $this->prop('status');
+        $filter = StringFilter::equals($prop);
+
+        $this->assertSame('status', $filter->getField());
+        $this->assertSame(FilterInterface::TYPE_EQUALS, $filter->getType());
+        $this->assertInstanceOf(StringProperty::class, $filter->getProperty());
+        $this->assertSame($prop, $filter->getProperty());
+    }
+
+    public function testTypeChecks(): void
+    {
+        $this->assertTrue(StringFilter::equals($this->prop())->isTypeEquals());
+        $this->assertFalse(StringFilter::equals($this->prop())->isTypeIn());
+        $this->assertFalse(StringFilter::equals($this->prop())->isTypeLike());
+        $this->assertFalse(StringFilter::equals($this->prop())->isTypeContains());
+        $this->assertFalse(StringFilter::equals($this->prop())->isTypeGreaterThan());
+        $this->assertFalse(StringFilter::equals($this->prop())->isTypeLessThan());
+
+        $this->assertTrue(StringFilter::in($this->prop())->isTypeIn());
+        $this->assertTrue(StringFilter::like($this->prop())->isTypeLike());
+        $this->assertTrue(StringFilter::contains($this->prop())->isTypeContains());
+    }
+
+    public function testValueCasting(): void
+    {
+        $filter = StringFilter::equals($this->prop());
+
+        $this->assertNull($filter->getValue());
+
+        $filter->setValue('hello');
+        $this->assertSame('hello', $filter->getValue());
+
+        $filter->setValue(42);
+        $this->assertSame('42', $filter->getValue());
+
+        $filter->setValue(null);
+        $this->assertNull($filter->getValue());
+    }
+}

--- a/docs/how-to/filtering.mdx
+++ b/docs/how-to/filtering.mdx
@@ -38,6 +38,7 @@ Each factory (`::equals`, `::in`, `::like`, `::contains`, `::greaterThan`, `::le
 | `EnumFilter` | `equals`, `in` |
 | `IntegerFilter`, `FloatFilter`, `DateFilter`, `DateTimeFilter` | `equals`, `in`, `greaterThan`, `lessThan` |
 | `ByteFilter`, `BinaryFilter` | `equals`, `in` |
+| `BooleanFilter` | `equals` |
 
 ## 2. Clients send filters as flat query parameters
 

--- a/docs/http/filtering.mdx
+++ b/docs/http/filtering.mdx
@@ -16,6 +16,7 @@ use apivalk\apivalk\Router\Route\Filter\IntegerFilter;
 use apivalk\apivalk\Router\Route\Filter\FloatFilter;
 use apivalk\apivalk\Router\Route\Filter\DateFilter;
 use apivalk\apivalk\Router\Route\Filter\DateTimeFilter;
+use apivalk\apivalk\Router\Route\Filter\BooleanFilter;
 use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Documentation\Property\EnumProperty;
@@ -23,6 +24,7 @@ use apivalk\apivalk\Documentation\Property\IntegerProperty;
 use apivalk\apivalk\Documentation\Property\FloatProperty;
 use apivalk\apivalk\Documentation\Property\DateProperty;
 use apivalk\apivalk\Documentation\Property\DateTimeProperty;
+use apivalk\apivalk\Documentation\Property\BooleanProperty;
 
 public static function getRoute(): Route
 {
@@ -34,6 +36,7 @@ public static function getRoute(): Route
             IntegerFilter::lessThan(new IntegerProperty('id', 'Filter by ID (less than)')),
             DateFilter::greaterThan(new DateProperty('created_at', 'Filter by creation date (greater than)')),
             DateTimeFilter::lessThan(new DateTimeProperty('updated_at', 'Filter by update date (less than)')),
+            BooleanFilter::equals(new BooleanProperty('is_active', 'Filter by active flag', false)),
         ]);
 }
 ```
@@ -50,6 +53,7 @@ Apivalk provides specialized filter classes for different property types. Each f
 6.  **DateTimeFilter**: Linked to `DateTimeProperty`. Supports `equals`, `in`, `greaterThan`, and `lessThan`. Returns `\DateTime` values.
 7.  **ByteFilter**: Linked to `ByteProperty`. Supports `equals` and `in`.
 8.  **BinaryFilter**: Linked to `BinaryProperty`. Supports `equals` and `in`.
+9.  **BooleanFilter**: Linked to `BooleanProperty`. Supports `equals`. Returns `bool` values.
 
 Benefits:
 -   **OpenAPI Accuracy**: The documentation reflects the correct data type (e.g., `number`, `integer`, `string`).
@@ -103,6 +107,9 @@ IntegerFilter::equals(new IntegerProperty('id', 'Filter by ID (equals)', Integer
 #### BinaryFilter
 - `BinaryFilter::equals(BinaryProperty $property)`: Exact binary match.
 - `BinaryFilter::in(BinaryProperty $property)`: Match against a list of binary values.
+
+#### BooleanFilter
+- `BooleanFilter::equals(BooleanProperty $property)`: Exact boolean match. Returns a `bool` value.
 
 ---
 


### PR DESCRIPTION
- Add comprehensive PHPUnit tests for various `Filter` implementations, including `StringFilter`, `IntegerFilter`, `FloatFilter`, `BinaryFilter`, `EnumFilter`, `ByteFilter`, `BooleanFilter`, `DateFilter`, and `DateTimeFilter`.
- Ensure thorough coverage of factory methods, type checks, value casting, and getter methods.
- Adds BooleanFilter

Issue: #103