### PR TITLE
fix: add user-requested sort tracking and route default handling in `…

### DIFF
--- a/Http/Request/Population/Strategy/SortingPopulationStrategy.php
+++ b/Http/Request/Population/Strategy/SortingPopulationStrategy.php
@@ -15,12 +15,6 @@ class SortingPopulationStrategy implements PopulationStrategyInterface
     {
         $sortBag = new SortBag();
 
-        foreach ($context->getRoute()->getSortings() as $ordering) {
-            if (!$sortBag->has($ordering->getField())) {
-                $sortBag->set($ordering);
-            }
-        }
-
         $rawOrderBy = isset($_GET['order_by']) ? (string)$_GET['order_by'] : null;
 
         if ($rawOrderBy !== null && $rawOrderBy !== '') {
@@ -42,7 +36,16 @@ class SortingPopulationStrategy implements PopulationStrategyInterface
                     continue;
                 }
 
-                $sortBag->set($direction === '-' ? Sort::desc($field) : Sort::asc($field));
+                $sort = $direction === '-' ? Sort::desc($field) : Sort::asc($field);
+                $sort->markAsRequested();
+
+                $sortBag->set($sort);
+            }
+        }
+
+        foreach ($context->getRoute()->getSortings() as $sort) {
+            if (!$sortBag->has($sort->getField())) {
+                $sortBag->set($sort);
             }
         }
 

--- a/Router/Route/Sort/Sort.php
+++ b/Router/Route/Sort/Sort.php
@@ -10,6 +10,8 @@ class Sort
     private $asc = true;
     /** @var string */
     private $field;
+    /** @var bool */
+    private $requested = false;
 
     public function __construct(string $field)
     {
@@ -53,5 +55,21 @@ class Sort
     public function getField(): string
     {
         return $this->field;
+    }
+
+    /**
+     * True only if this sort was set by the user via `?order_by=…`.
+     * False for sorts seeded from the route's default declaration.
+     */
+    public function isRequested(): bool
+    {
+        return $this->requested;
+    }
+
+    public function markAsRequested(): self
+    {
+        $this->requested = true;
+
+        return $this;
     }
 }

--- a/Router/Route/Sort/SortBag.php
+++ b/Router/Route/Sort/SortBag.php
@@ -10,21 +10,50 @@ namespace apivalk\apivalk\Router\Route\Sort;
 class SortBag implements \IteratorAggregate, \Countable
 {
     /** @var Sort[] */
-    private $orders = [];
+    private $sorts = [];
+    /** @var null|Sort[] */
+    private $requested = null;
 
-    public function set(Sort $order): void
+    public function set(Sort $sort): void
     {
-        $this->orders[$order->getField()] = $order;
+        $this->sorts[$sort->getField()] = $sort;
+        $this->requested = null;
     }
 
     public function has(string $field): bool
     {
-        return isset($this->orders[$field]);
+        return isset($this->sorts[$field]);
     }
 
     public function get(string $field): ?Sort
     {
-        return $this->orders[$field] ?? null;
+        return $this->sorts[$field] ?? null;
+    }
+
+    /**
+     * Sorts the user explicitly requested via `?order_by=…`, in submission order.
+     *
+     * Empty if the user did not provide `order_by`. Route-default sorts are excluded.
+     *
+     * @return list<Sort>
+     */
+    public function getRequested(): array
+    {
+        if ($this->requested !== null) {
+            return $this->requested;
+        }
+
+        $requested = [];
+
+        foreach ($this->sorts as $sort) {
+            if ($sort->isRequested()) {
+                $requested[] = $sort;
+            }
+        }
+
+        $this->requested = $requested;
+
+        return $this->requested;
     }
 
     /**
@@ -32,12 +61,12 @@ class SortBag implements \IteratorAggregate, \Countable
      */
     public function getIterator(): \Iterator
     {
-        return new \ArrayIterator($this->orders);
+        return new \ArrayIterator($this->sorts);
     }
 
     public function count(): int
     {
-        return \count($this->orders);
+        return \count($this->sorts);
     }
 
     /**
@@ -52,11 +81,8 @@ class SortBag implements \IteratorAggregate, \Countable
      */
     public function __get(string $key): ?Sort
     {
-        $order = $this->get($key);
-        if ($order === null) {
-            return null;
-        }
+        $sort = $this->get($key);
 
-        return $order;
+        return $sort ?? null;
     }
 }

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/SortingPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/SortingPopulationStrategyTest.php
@@ -138,6 +138,79 @@ class SortingPopulationStrategyTest extends TestCase
         self::assertCount(1, $request->sorting());
     }
 
+    public function testUserRequestedSortsIterateBeforeDefaults(): void
+    {
+        $_GET['order_by'] = '-id';
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route->sorting([Sort::desc('created_at'), Sort::asc('id'), Sort::asc('name')]);
+
+        $request = $this->makeRequest();
+        $strategy = new SortingPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        $fields = [];
+        foreach ($request->sorting() as $sort) {
+            $fields[] = $sort->getField();
+        }
+
+        self::assertSame(['id', 'created_at', 'name'], $fields);
+        self::assertTrue($request->sorting()->get('id')->isDesc());
+    }
+
+    public function testIsRequestedFlagDiscriminatesUserVsDefault(): void
+    {
+        $_GET['order_by'] = '-id';
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route->sorting([Sort::desc('created_at'), Sort::asc('id'), Sort::asc('name')]);
+
+        $request = $this->makeRequest();
+        $strategy = new SortingPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        $bag = $request->sorting();
+        self::assertTrue($bag->get('id')->isRequested());
+        self::assertFalse($bag->get('created_at')->isRequested());
+        self::assertFalse($bag->get('name')->isRequested());
+    }
+
+    public function testGetRequestedReturnsOnlyUserSubmittedSortsInOrder(): void
+    {
+        $_GET['order_by'] = '-id,+name';
+
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route->sorting([Sort::desc('created_at'), Sort::asc('id'), Sort::asc('name')]);
+
+        $request = $this->makeRequest();
+        $strategy = new SortingPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        $requested = $request->sorting()->getRequested();
+
+        self::assertCount(2, $requested);
+        self::assertSame('id', $requested[0]->getField());
+        self::assertTrue($requested[0]->isDesc());
+        self::assertSame('name', $requested[1]->getField());
+        self::assertTrue($requested[1]->isAsc());
+    }
+
+    public function testGetRequestedIsEmptyWhenUserOmitsOrderBy(): void
+    {
+        $resource = new AnimalResource();
+        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route->sorting([Sort::asc('name')]);
+
+        $request = $this->makeRequest();
+        $strategy = new SortingPopulationStrategy();
+        $strategy->populate($request, new RequestPopulationContext($route, new ApivalkRequestDocumentation()));
+
+        self::assertSame([], $request->sorting()->getRequested());
+    }
+
     private function makeRequest(): AbstractApivalkRequest
     {
         return new class extends AbstractApivalkRequest {

--- a/Tests/PhpUnit/Router/Route/Sort/SortBagTest.php
+++ b/Tests/PhpUnit/Router/Route/Sort/SortBagTest.php
@@ -88,4 +88,44 @@ class SortBagTest extends TestCase
 
         $this->assertNull($sortBag->unknown);
     }
+
+    public function testGetRequestedReturnsOnlyRequestedSortsInInsertionOrder(): void
+    {
+        $sortBag = new SortBag();
+        $sortBag->set(Sort::asc('id')->markAsRequested());
+        $sortBag->set(Sort::desc('created_at')); // route default
+        $sortBag->set(Sort::asc('name')->markAsRequested());
+
+        $requested = $sortBag->getRequested();
+
+        $this->assertCount(2, $requested);
+        $this->assertSame('id', $requested[0]->getField());
+        $this->assertSame('name', $requested[1]->getField());
+    }
+
+    public function testGetRequestedReturnsEmptyArrayWhenNoneAreRequested(): void
+    {
+        $sortBag = new SortBag();
+        $sortBag->set(Sort::asc('id'));
+        $sortBag->set(Sort::desc('created_at'));
+
+        $this->assertSame([], $sortBag->getRequested());
+    }
+
+    public function testGetRequestedCacheIsInvalidatedOnSet(): void
+    {
+        $sortBag = new SortBag();
+        $sortBag->set(Sort::asc('id'));
+
+        // Prime the cache.
+        $this->assertSame([], $sortBag->getRequested());
+
+        // Mutating the bag must invalidate the cached result.
+        $sortBag->set(Sort::desc('name')->markAsRequested());
+
+        $requested = $sortBag->getRequested();
+        $this->assertCount(1, $requested);
+        $this->assertSame('name', $requested[0]->getField());
+        $this->assertTrue($requested[0]->isDesc());
+    }
 }

--- a/Tests/PhpUnit/Router/Route/Sort/SortTest.php
+++ b/Tests/PhpUnit/Router/Route/Sort/SortTest.php
@@ -46,4 +46,20 @@ class SortTest extends TestCase
         $this->assertSame(!$ascSort->isAsc(), $ascSort->isDesc());
         $this->assertSame(!$descSort->isAsc(), $descSort->isDesc());
     }
+
+    public function testIsRequestedDefaultsToFalse(): void
+    {
+        $this->assertFalse(Sort::asc('foo')->isRequested());
+        $this->assertFalse(Sort::desc('foo')->isRequested());
+        $this->assertFalse((new Sort('foo'))->isRequested());
+    }
+
+    public function testMarkAsRequestedFlipsFlagAndReturnsSelf(): void
+    {
+        $sort = Sort::asc('foo');
+        $returned = $sort->markAsRequested();
+
+        $this->assertSame($sort, $returned);
+        $this->assertTrue($sort->isRequested());
+    }
 }

--- a/docs/how-to/sorting.mdx
+++ b/docs/how-to/sorting.mdx
@@ -55,15 +55,29 @@ public function __invoke(ApivalkRequestInterface $request): AbstractApivalkRespo
 
 The bag is **always populated** — if the client omits `order_by`, it contains the defaults from `Sort::asc(...)` / `Sort::desc(...)` in the order you declared them.
 
-## 4. Check a specific field
+Iteration order matches user intent: any sorts the client submitted via `?order_by=` come first (in submission order), followed by the route's defaults for fields the client didn't specify. So `foreach` produces the right `ORDER BY` sequence — primary user choice first, defaults as tiebreakers — without you having to merge anything.
+
+## 4. Tell user-requested sorts from defaults
+
+Each `Sort` knows whether it came from `?order_by=` or from the route declaration. Branch on `isRequested()` when you need to:
 
 ```php
-if ($request->sorting()->has('created_at')) {
-    $isAsc = $request->sorting()->created_at->isAsc();
+if ($request->sorting()->created_at->isRequested()) {
+    // The client explicitly asked to sort by created_at.
 }
 ```
 
-The magic getter returns `Sort|null`. `has()` returns `true` if the field was declared on the route **and** is either defaulted or requested by the client.
+To get only the user's submitted sorts (without route defaults), use `getRequested()`:
+
+```php
+foreach ($request->sorting()->getRequested() as $sort) {
+    // Empty array if the client did not send order_by at all.
+}
+```
+
+<Note>
+`has($field)` only tells you whether the field is in the bag at all — for declared fields, that's always `true` because defaults seed the bag. Use `isRequested()` to ask "did the user ask for this?".
+</Note>
 
 ## Inside a resource
 

--- a/docs/http/controller.mdx
+++ b/docs/http/controller.mdx
@@ -51,16 +51,18 @@ class GetPetController extends AbstractApivalkController
         // $request is already populated and validated!
         $id = $request->path()->id;
 
-        // Access populated sorting filters. SortBag is iterable — iterate
-        // directly. The bag is always populated: if the user does not provide
-        // order_by, it contains the default sorting from the route.
+        // Access populated sorting. SortBag is iterable — iterate directly.
+        // The bag is always populated: if the user does not provide order_by,
+        // it contains the default sorting from the route. Iteration order is
+        // user-requested sorts first (in submission order), then route defaults
+        // as tiebreakers — perfect for building an ORDER BY clause.
         foreach ($request->sorting() as $field => $sort) {
             $direction = $sort->isAsc() ? 'ASC' : 'DESC';
         }
 
-        // or directly access populated filters.
-        // If the user did not pass order_by=+status or -status, the magic getter returns
-        // the default Sort object for status if it was defined on the route.
+        // Or directly access a specific field via the magic getter. If the user
+        // did not pass order_by for status, this returns the route's default Sort.
+        // Use $sort->isRequested() to discriminate user intent from defaults.
         $isAsc = $request->sorting()->status->isAsc();
 
         $pet = $this->petRepository->find($id);

--- a/docs/http/request.mdx
+++ b/docs/http/request.mdx
@@ -66,7 +66,8 @@ public function __invoke(ApivalkRequestInterface $request): AbstractApivalkRespo
     // Access populated sorting (as defined in Route). SortBag is iterable —
     // iterate directly. The bag is always populated: if the user does not
     // provide an order_by parameter, it contains the default sorting defined
-    // on the route.
+    // on the route. User-requested sorts iterate first, route defaults last.
+    // Each Sort knows its origin via $sort->isRequested().
     foreach ($request->sorting() as $field => $sort) {
         $isAsc = $sort->isAsc();
     }

--- a/docs/http/sorting.mdx
+++ b/docs/http/sorting.mdx
@@ -30,29 +30,50 @@ By default, an `Sort` object just defines that a field is "sortable".
 
 ## Usage in Controller
 
-When a route has sorting enabled, you can access the resolved sortings from the request via the `sorting()` method, which returns an `SortBag`.
+When a route has sorting enabled, you can access the resolved sortings from the request via the `sorting()` method, which returns a `SortBag`.
+
+The bag is **always populated** for declared fields. If the client omits `order_by`, the bag holds the route's defaults; if the client sends `order_by`, the requested sorts come first in iteration order, followed by any remaining defaults as tiebreakers.
 
 ```php
 public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
 {
     $sorting = $request->sorting();
 
-    // Check if a specific field was sorted by the client
-    if ($sorting->has('name')) {
-        $nameSort = $sorting->name; // returns Sort|null
-        $direction = $nameSort->isAsc() ? 'ASC' : 'DESC';
+    // Iterate over all sortings (user-requested first, then route defaults).
+    // Perfect for building an ORDER BY: the user's primary intent comes first.
+    foreach ($sorting as $field => $sort) {
+        $direction = $sort->isAsc() ? 'ASC' : 'DESC';
         // apply to your query...
     }
 
-    // Iterate over all provided sortings (SortBag implements IteratorAggregate)
-    foreach ($sorting as $field => $sort) {
-        $direction = $sort->isAsc() ? 'ASC' : 'DESC';
-        // ...
-    }
+    // Or read a specific field directly via the magic getter.
+    $direction = $sorting->name->isAsc() ? 'ASC' : 'DESC';
 
     // ...
 }
 ```
+
+### Did the user pick this sort, or is it a default?
+
+Each `Sort` knows whether it came from the user (`?order_by=…`) or from the route declaration. Use `isRequested()` when behavior should depend on user intent:
+
+```php
+if ($sorting->status->isRequested()) {
+    // The user explicitly asked to sort by status.
+}
+```
+
+`SortBag::getRequested()` returns only the user-submitted sorts in the order they were sent — useful when you need user intent without route defaults mixed in:
+
+```php
+foreach ($sorting->getRequested() as $sort) {
+    // Only user-submitted sorts. Empty if the client did not send order_by.
+}
+```
+
+<Note>
+`has($field)` only tells you whether the field is in the bag at all (which, for declared fields, is always `true`). To check whether the **user** requested a field, use `isRequested()` on the corresponding `Sort`.
+</Note>
 
 ---
 


### PR DESCRIPTION
…SortBag`

- Introduce `isRequested()` to `Sort` for distinguishing user-requested sorts from route defaults.
- Implement `SortBag::getRequested()` to retrieve only user-submitted sorts in submission order.
- Refactor `SortingPopulationStrategy` to combine user-requested sorts and route-defined defaults seamlessly, prioritizing user intent in iteration order.
- Update documentation and examples to reflect changes in sorting behavior and usage.
- Add PHPUnit tests to verify user-requested sort tracking, default handling, and caching behavior in `SortBag`.

Issue: #121