### PR TITLE
fix: add raw value support to filters and improve validation middleware)

### DIFF
--- a/Http/Request/Population/Strategy/FilteringPopulationStrategy.php
+++ b/Http/Request/Population/Strategy/FilteringPopulationStrategy.php
@@ -20,9 +20,11 @@ class FilteringPopulationStrategy implements PopulationStrategyInterface
 
             $clonedFilter = clone $filter;
             if ($queryParameter !== null) {
+                $rawValue = $queryParameter->getRawValue();
+                $clonedFilter->setRawValue(\is_scalar($rawValue) ? (string) $rawValue : null);
                 $clonedFilter->setValue(
                     ParameterBagFactory::typeCastValueByProperty(
-                        $queryParameter->getRawValue(),
+                        $rawValue,
                         $filter->getProperty()
                     )
                 );

--- a/Middleware/RequestValidationMiddleware.php
+++ b/Middleware/RequestValidationMiddleware.php
@@ -68,21 +68,22 @@ class RequestValidationMiddleware implements MiddlewareInterface
         /** @var FilterInterface $filter */
         foreach ($filterBag->getIterator() as $filter) {
             $value = $filter->getValue();
+            $rawValue = $filter->getRawValue();
             $property = $filter->getProperty();
 
-            if ($value === null && !$property->isRequired()) {
+            $isSupplied = $rawValue !== null || $value !== null;
+
+            if (!$isSupplied) {
+                if ($property->isRequired()) {
+                    $this->errors[] = ValidationErrorObject::createByValidatorResult(
+                        $filter->getField(),
+                        new ValidatorResult(false, ValidatorResult::FIELD_IS_REQUIRED)
+                    );
+                }
                 continue;
             }
 
-            if ($value === null && $property->isRequired()) {
-                $this->errors[] = ValidationErrorObject::createByValidatorResult(
-                    $filter->getField(),
-                    new ValidatorResult(false, ValidatorResult::FIELD_IS_REQUIRED)
-                );
-                continue;
-            }
-
-            $parameter = new Parameter($filter->getField(), $value, (string)$value);
+            $parameter = new Parameter($filter->getField(), $value, $rawValue);
 
             foreach ($property->getValidators() as $validator) {
                 $result = $validator->validate($parameter);

--- a/Router/Route/Filter/BinaryFilter.php
+++ b/Router/Route/Filter/BinaryFilter.php
@@ -15,6 +15,8 @@ class BinaryFilter implements FilterInterface
     private $property;
     /** @var string|null */
     private $value;
+    /** @var string|null */
+    private $rawValue;
 
     public function __construct(string $type, BinaryProperty $property)
     {
@@ -56,6 +58,16 @@ class BinaryFilter implements FilterInterface
     public function getValue(): ?string
     {
         return $this->value;
+    }
+
+    public function setRawValue(?string $rawValue): void
+    {
+        $this->rawValue = $rawValue;
+    }
+
+    public function getRawValue(): ?string
+    {
+        return $this->rawValue;
     }
 
     public function isTypeEquals(): bool

--- a/Router/Route/Filter/BooleanFilter.php
+++ b/Router/Route/Filter/BooleanFilter.php
@@ -15,6 +15,8 @@ class BooleanFilter implements FilterInterface
     private $property;
     /** @var bool|null */
     private $value;
+    /** @var string|null */
+    private $rawValue;
 
     public function __construct(string $type, BooleanProperty $property)
     {
@@ -51,6 +53,16 @@ class BooleanFilter implements FilterInterface
     public function getValue(): ?bool
     {
         return $this->value;
+    }
+
+    public function setRawValue(?string $rawValue): void
+    {
+        $this->rawValue = $rawValue;
+    }
+
+    public function getRawValue(): ?string
+    {
+        return $this->rawValue;
     }
 
     public function isTypeEquals(): bool

--- a/Router/Route/Filter/ByteFilter.php
+++ b/Router/Route/Filter/ByteFilter.php
@@ -15,6 +15,8 @@ class ByteFilter implements FilterInterface
     private $property;
     /** @var string|null */
     private $value;
+    /** @var string|null */
+    private $rawValue;
 
     public function __construct(string $type, ByteProperty $property)
     {
@@ -56,6 +58,16 @@ class ByteFilter implements FilterInterface
     public function getValue(): ?string
     {
         return $this->value;
+    }
+
+    public function setRawValue(?string $rawValue): void
+    {
+        $this->rawValue = $rawValue;
+    }
+
+    public function getRawValue(): ?string
+    {
+        return $this->rawValue;
     }
 
     public function isTypeEquals(): bool

--- a/Router/Route/Filter/DateFilter.php
+++ b/Router/Route/Filter/DateFilter.php
@@ -15,6 +15,8 @@ class DateFilter implements FilterInterface
     private $property;
     /** @var \DateTime|null */
     private $value;
+    /** @var string|null */
+    private $rawValue;
 
     public function __construct(string $type, DateProperty $property)
     {
@@ -82,6 +84,16 @@ class DateFilter implements FilterInterface
     public function getValue(): ?\DateTime
     {
         return $this->value;
+    }
+
+    public function setRawValue(?string $rawValue): void
+    {
+        $this->rawValue = $rawValue;
+    }
+
+    public function getRawValue(): ?string
+    {
+        return $this->rawValue;
     }
 
     public function isTypeEquals(): bool

--- a/Router/Route/Filter/DateTimeFilter.php
+++ b/Router/Route/Filter/DateTimeFilter.php
@@ -15,6 +15,8 @@ class DateTimeFilter implements FilterInterface
     private $property;
     /** @var \DateTime|null */
     private $value;
+    /** @var string|null */
+    private $rawValue;
 
     public function __construct(string $type, DateTimeProperty $property)
     {
@@ -82,6 +84,16 @@ class DateTimeFilter implements FilterInterface
     public function getValue(): ?\DateTime
     {
         return $this->value;
+    }
+
+    public function setRawValue(?string $rawValue): void
+    {
+        $this->rawValue = $rawValue;
+    }
+
+    public function getRawValue(): ?string
+    {
+        return $this->rawValue;
     }
 
     public function isTypeEquals(): bool

--- a/Router/Route/Filter/EnumFilter.php
+++ b/Router/Route/Filter/EnumFilter.php
@@ -15,6 +15,8 @@ class EnumFilter implements FilterInterface
     private $property;
     /** @var string|null */
     private $value;
+    /** @var string|null */
+    private $rawValue;
 
     public function __construct(string $type, EnumProperty $property)
     {
@@ -56,6 +58,16 @@ class EnumFilter implements FilterInterface
     public function getValue(): ?string
     {
         return $this->value;
+    }
+
+    public function setRawValue(?string $rawValue): void
+    {
+        $this->rawValue = $rawValue;
+    }
+
+    public function getRawValue(): ?string
+    {
+        return $this->rawValue;
     }
 
     public function isTypeEquals(): bool

--- a/Router/Route/Filter/FilterInterface.php
+++ b/Router/Route/Filter/FilterInterface.php
@@ -31,6 +31,10 @@ interface FilterInterface
      */
     public function getValue();
 
+    public function setRawValue(?string $rawValue): void;
+
+    public function getRawValue(): ?string;
+
     public function isTypeEquals(): bool;
 
     public function isTypeIn(): bool;

--- a/Router/Route/Filter/FloatFilter.php
+++ b/Router/Route/Filter/FloatFilter.php
@@ -15,6 +15,8 @@ class FloatFilter implements FilterInterface
     private $property;
     /** @var float|null */
     private $value;
+    /** @var string|null */
+    private $rawValue;
 
     public function __construct(string $type, FloatProperty $property)
     {
@@ -66,6 +68,16 @@ class FloatFilter implements FilterInterface
     public function getValue(): ?float
     {
         return $this->value;
+    }
+
+    public function setRawValue(?string $rawValue): void
+    {
+        $this->rawValue = $rawValue;
+    }
+
+    public function getRawValue(): ?string
+    {
+        return $this->rawValue;
     }
 
     public function isTypeEquals(): bool

--- a/Router/Route/Filter/IntegerFilter.php
+++ b/Router/Route/Filter/IntegerFilter.php
@@ -15,6 +15,8 @@ class IntegerFilter implements FilterInterface
     private $property;
     /** @var int|null */
     private $value;
+    /** @var string|null */
+    private $rawValue;
 
     public function __construct(string $type, IntegerProperty $property)
     {
@@ -66,6 +68,16 @@ class IntegerFilter implements FilterInterface
     public function getValue(): ?int
     {
         return $this->value;
+    }
+
+    public function setRawValue(?string $rawValue): void
+    {
+        $this->rawValue = $rawValue;
+    }
+
+    public function getRawValue(): ?string
+    {
+        return $this->rawValue;
     }
 
     public function isTypeEquals(): bool

--- a/Router/Route/Filter/StringFilter.php
+++ b/Router/Route/Filter/StringFilter.php
@@ -15,6 +15,8 @@ class StringFilter implements FilterInterface
     private $property;
     /** @var string|null */
     private $value;
+    /** @var string|null */
+    private $rawValue;
 
     public function __construct(string $type, StringProperty $property)
     {
@@ -66,6 +68,16 @@ class StringFilter implements FilterInterface
     public function getValue(): ?string
     {
         return $this->value;
+    }
+
+    public function setRawValue(?string $rawValue): void
+    {
+        $this->rawValue = $rawValue;
+    }
+
+    public function getRawValue(): ?string
+    {
+        return $this->rawValue;
     }
 
     public function isTypeEquals(): bool

--- a/Tests/PhpUnit/Integration/ListAnimalsIntegrationTest.php
+++ b/Tests/PhpUnit/Integration/ListAnimalsIntegrationTest.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Integration;
+
+use apivalk\apivalk\Apivalk;
+use apivalk\apivalk\ApivalkConfiguration;
+use apivalk\apivalk\Cache\CacheInterface;
+use apivalk\apivalk\Cache\CacheItem;
+use apivalk\apivalk\Documentation\Property\DateTimeProperty;
+use apivalk\apivalk\Documentation\Property\IntegerProperty;
+use apivalk\apivalk\Documentation\Property\StringProperty;
+use apivalk\apivalk\Http\Controller\ApivalkControllerFactoryInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\BadValidationApivalkResponse;
+use apivalk\apivalk\Middleware\MiddlewareStack;
+use apivalk\apivalk\Middleware\RequestValidationMiddleware;
+use apivalk\apivalk\Router\AbstractRouter;
+use apivalk\apivalk\Router\Route\Filter\DateTimeFilter;
+use apivalk\apivalk\Router\Route\Filter\IntegerFilter;
+use apivalk\apivalk\Router\Route\Filter\StringFilter;
+use apivalk\apivalk\Router\Route\Pagination\Pagination;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Router\Route\RouteJsonSerializer;
+use apivalk\apivalk\Router\Route\RouteRegexFactory;
+use apivalk\apivalk\Router\Route\Sort\Sort;
+use apivalk\apivalk\Router\Router;
+use apivalk\apivalk\Util\ClassLocator;
+use PHPUnit\Framework\TestCase;
+
+class ListAnimalsIntegrationTest extends TestCase
+{
+    /** @var array<string, mixed> */
+    private $serverBackup = [];
+    /** @var array<string, mixed> */
+    private $getBackup = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        if (class_exists('ListAnimalsIntegrationTestController', false)) {
+            return;
+        }
+
+        // Eval'd into the global namespace so that ::class strings resolve cleanly when
+        // RouteJsonSerializer round-trips controllerClass through the cache layer.
+        eval(<<<'PHP'
+            class ListAnimalsIntegrationTestRequest extends \apivalk\apivalk\Http\Request\AbstractApivalkRequest {
+                public static function getDocumentation(): \apivalk\apivalk\Documentation\ApivalkRequestDocumentation {
+                    return new \apivalk\apivalk\Documentation\ApivalkRequestDocumentation();
+                }
+            }
+
+            class ListAnimalsIntegrationTestResponse extends \apivalk\apivalk\Http\Response\AbstractApivalkResponse {
+                public static function getDocumentation(): \apivalk\apivalk\Documentation\ApivalkResponseDocumentation {
+                    return new \apivalk\apivalk\Documentation\ApivalkResponseDocumentation();
+                }
+                public static function getStatusCode(): int { return 200; }
+                public function toArray(): array { return ['data' => []]; }
+            }
+
+            class ListAnimalsIntegrationTestController extends \apivalk\apivalk\Http\Controller\AbstractApivalkController {
+                public static $wasInvoked = false;
+                public static $capturedRequest = null;
+
+                public static function reset(): void {
+                    self::$wasInvoked = false;
+                    self::$capturedRequest = null;
+                }
+
+                public function __invoke(\apivalk\apivalk\Http\Request\ApivalkRequestInterface $request): \apivalk\apivalk\Http\Response\AbstractApivalkResponse {
+                    self::$wasInvoked = true;
+                    self::$capturedRequest = $request;
+                    return new ListAnimalsIntegrationTestResponse();
+                }
+
+                public static function getRoute(): \apivalk\apivalk\Router\Route\Route {
+                    return \apivalk\apivalk\Router\Route\Route::get('/animals');
+                }
+                public static function getRequestClass(): string { return 'ListAnimalsIntegrationTestRequest'; }
+                public static function getResponseClasses(): array { return ['ListAnimalsIntegrationTestResponse']; }
+            }
+PHP
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $this->serverBackup = $_SERVER;
+        $this->getBackup = $_GET;
+
+        \ListAnimalsIntegrationTestController::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        $_SERVER = $this->serverBackup;
+        $_GET = $this->getBackup;
+    }
+
+    public function testHappyPathPopulatesFiltersSortAndPagination(): void
+    {
+        $_GET = [
+            'species' => 'cat',
+            'min_weight_kg' => '5',
+            'born_after' => '2020-01-15T00:00:00+00:00',
+            'order_by' => '+name,-id',
+            'page' => '2',
+        ];
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/animals';
+
+        $response = $this->dispatch();
+
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+        $this->assertTrue(\ListAnimalsIntegrationTestController::$wasInvoked);
+
+        $request = \ListAnimalsIntegrationTestController::$capturedRequest;
+        $this->assertNotNull($request);
+
+        $species = $request->filtering()->__get('species');
+        $this->assertNotNull($species);
+        $this->assertSame('cat', $species->getValue());
+        $this->assertSame('cat', $species->getRawValue());
+
+        $minWeight = $request->filtering()->__get('min_weight_kg');
+        $this->assertNotNull($minWeight);
+        $this->assertSame(5, $minWeight->getValue());
+        $this->assertSame('5', $minWeight->getRawValue());
+
+        $bornAfter = $request->filtering()->__get('born_after');
+        $this->assertNotNull($bornAfter);
+        $this->assertInstanceOf(\DateTime::class, $bornAfter->getValue());
+        $this->assertSame('2020-01-15T00:00:00+00:00', $bornAfter->getRawValue());
+    }
+
+    /**
+     * Regression for the "(string) \DateTime" fatal in RequestValidationMiddleware.
+     * A populated DateTimeFilter must not blow up the request lifecycle.
+     */
+    public function testDateTimeFilterDoesNotFatalDuringDispatch(): void
+    {
+        $_GET = ['born_after' => '2020-01-15T00:00:00+00:00'];
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/animals';
+
+        $response = $this->dispatch();
+
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+        $this->assertTrue(\ListAnimalsIntegrationTestController::$wasInvoked);
+    }
+
+    public function testInvalidDateTimeFilterReturnsValidationError(): void
+    {
+        $_GET = ['born_after' => 'not-a-datetime'];
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/animals';
+
+        $response = $this->dispatch();
+
+        $this->assertInstanceOf(BadValidationApivalkResponse::class, $response);
+        $this->assertFalse(\ListAnimalsIntegrationTestController::$wasInvoked);
+    }
+
+    /**
+     * Sort precedence behavior introduced in b857a7c: user-requested sorts come first
+     * in iteration order, route defaults appended for fields the user didn't specify.
+     */
+    public function testUserSortsTakePrecedenceOverRouteDefaults(): void
+    {
+        $_GET = ['order_by' => '+name'];
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/animals';
+
+        $response = $this->dispatch();
+
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+
+        $sortBag = \ListAnimalsIntegrationTestController::$capturedRequest->sorting();
+        $sorts = iterator_to_array($sortBag, false);
+
+        $this->assertCount(2, $sorts, 'Expected user sort + route default');
+        $this->assertSame('name', $sorts[0]->getField());
+        $this->assertTrue($sorts[0]->isAsc());
+        $this->assertTrue($sorts[0]->isRequested());
+
+        $this->assertSame('id', $sorts[1]->getField());
+        $this->assertFalse($sorts[1]->isAsc());
+        $this->assertFalse($sorts[1]->isRequested());
+
+        $requested = $sortBag->getRequested();
+        $this->assertCount(1, $requested);
+        $this->assertSame('name', $requested[0]->getField());
+    }
+
+    /**
+     * When the user sorts on the same field as a route default, the user's direction wins
+     * AND the field appears at the position the user requested it.
+     */
+    public function testUserSortOverridesRouteDefaultOnSameField(): void
+    {
+        $_GET = ['order_by' => '+id'];
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/animals';
+
+        $response = $this->dispatch();
+
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+
+        $sortBag = \ListAnimalsIntegrationTestController::$capturedRequest->sorting();
+        $sorts = iterator_to_array($sortBag, false);
+
+        // User's `id` first (asc, overriding the route's desc default), then route default `name`.
+        $this->assertCount(2, $sorts);
+        $this->assertSame('id', $sorts[0]->getField());
+        $this->assertTrue($sorts[0]->isAsc(), 'User-supplied direction should override route default');
+        $this->assertTrue($sorts[0]->isRequested());
+
+        $this->assertSame('name', $sorts[1]->getField());
+        $this->assertFalse($sorts[1]->isRequested());
+    }
+
+    /**
+     * Sorting on a field not declared in the route's available sort fields
+     * is rejected by RequestValidationMiddleware.
+     */
+    public function testUnknownSortFieldIsRejected(): void
+    {
+        $_GET = ['order_by' => '+unknown_field'];
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/animals';
+
+        $response = $this->dispatch();
+
+        $this->assertInstanceOf(BadValidationApivalkResponse::class, $response);
+        $this->assertFalse(\ListAnimalsIntegrationTestController::$wasInvoked);
+    }
+
+    /**
+     * Without ?order_by the route defaults are used and getRequested() is empty.
+     */
+    public function testRouteDefaultsApplyWhenUserDidNotRequestSort(): void
+    {
+        $_GET = [];
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/animals';
+
+        $response = $this->dispatch();
+
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+
+        $sortBag = \ListAnimalsIntegrationTestController::$capturedRequest->sorting();
+        $sorts = iterator_to_array($sortBag, false);
+
+        $this->assertCount(2, $sorts);
+        $this->assertSame('name', $sorts[0]->getField());
+        $this->assertTrue($sorts[0]->isAsc());
+        $this->assertFalse($sorts[0]->isRequested());
+
+        $this->assertSame('id', $sorts[1]->getField());
+        $this->assertFalse($sorts[1]->isAsc());
+        $this->assertFalse($sorts[1]->isRequested());
+
+        $this->assertSame([], $sortBag->getRequested());
+    }
+
+    public function testIntegerFilterBelowMinimumReturnsValidationError(): void
+    {
+        $_GET = ['min_weight_kg' => '-5'];
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/animals';
+
+        $response = $this->dispatch();
+
+        $this->assertInstanceOf(BadValidationApivalkResponse::class, $response);
+        $this->assertFalse(\ListAnimalsIntegrationTestController::$wasInvoked);
+    }
+
+    private function dispatch(): AbstractApivalkResponse
+    {
+        $route = self::buildAnimalsRoute();
+        $controllerClass = 'ListAnimalsIntegrationTestController';
+
+        $indexData = [
+            [
+                'regex' => RouteRegexFactory::build($route),
+                'method' => 'GET',
+                'key' => 'route_animals_list',
+                'controllerClass' => $controllerClass,
+            ],
+        ];
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('get')->willReturnCallback(static function ($key) use ($indexData, $route) {
+            if ($key === AbstractRouter::CACHE_INDEX_KEY) {
+                return new CacheItem(AbstractRouter::CACHE_INDEX_KEY, json_encode($indexData));
+            }
+            if ($key === 'route_animals_list') {
+                return new CacheItem('route_animals_list', json_encode(RouteJsonSerializer::serialize($route)));
+            }
+            return null;
+        });
+
+        $controllerFactory = $this->createMock(ApivalkControllerFactoryInterface::class);
+        $controllerFactory->method('create')
+            ->willReturnCallback(static function () {
+                return new \ListAnimalsIntegrationTestController();
+            });
+
+        $router = new Router($this->createMock(ClassLocator::class), $cache, $controllerFactory);
+        $apivalk = new Apivalk(new ApivalkConfiguration($router));
+        $router->setApivalk($apivalk);
+
+        $stack = new MiddlewareStack();
+        $stack->add(new RequestValidationMiddleware());
+
+        return $router->dispatch($stack);
+    }
+
+    private static function buildAnimalsRoute(): Route
+    {
+        $species = new StringProperty('species', '');
+        $species->init();
+        $minWeight = new IntegerProperty('min_weight_kg', '');
+        $minWeight->setMinimumValue(0);
+        $minWeight->init();
+        $bornAfter = new DateTimeProperty('born_after', '');
+        $bornAfter->init();
+
+        return Route::get('/animals')
+            ->filtering([
+                StringFilter::equals($species),
+                IntegerFilter::greaterThan($minWeight),
+                DateTimeFilter::greaterThan($bornAfter),
+            ])
+            ->sorting([Sort::asc('name'), Sort::desc('id')])
+            ->pagination(Pagination::page());
+    }
+}

--- a/Tests/PhpUnit/Middleware/RequestValidationMiddlewareTest.php
+++ b/Tests/PhpUnit/Middleware/RequestValidationMiddlewareTest.php
@@ -6,6 +6,14 @@ namespace apivalk\apivalk\Tests\PhpUnit\Middleware;
 
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Documentation\Property\AbstractProperty;
+use apivalk\apivalk\Documentation\Property\BinaryProperty;
+use apivalk\apivalk\Documentation\Property\BooleanProperty;
+use apivalk\apivalk\Documentation\Property\ByteProperty;
+use apivalk\apivalk\Documentation\Property\DateProperty;
+use apivalk\apivalk\Documentation\Property\DateTimeProperty;
+use apivalk\apivalk\Documentation\Property\EnumProperty;
+use apivalk\apivalk\Documentation\Property\FloatProperty;
+use apivalk\apivalk\Documentation\Property\IntegerProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Documentation\Property\Validator\AbstractValidator;
 use apivalk\apivalk\Documentation\Property\Validator\ValidatorResult;
@@ -18,7 +26,16 @@ use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\BadValidationApivalkResponse;
 use apivalk\apivalk\Middleware\RequestValidationMiddleware;
 use apivalk\apivalk\Router\RateLimit\RateLimitResult;
+use apivalk\apivalk\Router\Route\Filter\BinaryFilter;
+use apivalk\apivalk\Router\Route\Filter\BooleanFilter;
+use apivalk\apivalk\Router\Route\Filter\ByteFilter;
+use apivalk\apivalk\Router\Route\Filter\DateFilter;
+use apivalk\apivalk\Router\Route\Filter\DateTimeFilter;
+use apivalk\apivalk\Router\Route\Filter\EnumFilter;
 use apivalk\apivalk\Router\Route\Filter\FilterBag;
+use apivalk\apivalk\Router\Route\Filter\FilterInterface;
+use apivalk\apivalk\Router\Route\Filter\FloatFilter;
+use apivalk\apivalk\Router\Route\Filter\IntegerFilter;
 use apivalk\apivalk\Router\Route\Filter\StringFilter;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
 use apivalk\apivalk\Router\Route\Sort\SortBag;
@@ -403,6 +420,195 @@ class RequestValidationMiddlewareTest extends TestCase
         $this->assertInstanceOf(BadValidationApivalkResponse::class, $response);
         /** @var BadValidationApivalkResponse $response */
         $this->assertCount(1, $response->getErrors());
+    }
+
+    public function testDateTimeFilterDoesNotFatalOnTypedValue(): void
+    {
+        $property = new DateTimeProperty('started_from', '');
+        $property->init();
+        $property->setIsRequired(false);
+
+        $filter = DateTimeFilter::greaterThan($property);
+        $filter->setValue(new \DateTime('2024-01-15T14:30:00+00:00'));
+        $filter->setRawValue('2024-01-15T14:30:00+00:00');
+
+        $response = $this->runFilterMiddleware($filter);
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    public function testDateTimeFilterReportsErrorForUnparseableInput(): void
+    {
+        $property = new DateTimeProperty('started_from', '');
+        $property->init();
+        $property->setIsRequired(false);
+
+        $filter = DateTimeFilter::greaterThan($property);
+        $filter->setRawValue('not-a-datetime');
+
+        $response = $this->runFilterMiddleware($filter);
+        $this->assertInstanceOf(BadValidationApivalkResponse::class, $response);
+        /** @var BadValidationApivalkResponse $response */
+        $this->assertCount(1, $response->getErrors());
+    }
+
+    public function testDateFilterDoesNotFatalOnTypedValue(): void
+    {
+        $property = new DateProperty('born_on', '');
+        $property->init();
+        $property->setIsRequired(false);
+
+        $filter = DateFilter::equals($property);
+        $filter->setValue(new \DateTime('2024-01-15'));
+        $filter->setRawValue('2024-01-15');
+
+        $response = $this->runFilterMiddleware($filter);
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    public function testDateFilterReportsErrorForUnparseableInput(): void
+    {
+        $property = new DateProperty('born_on', '');
+        $property->init();
+        $property->setIsRequired(false);
+
+        $filter = DateFilter::equals($property);
+        $filter->setRawValue('15/01/2024');
+
+        $response = $this->runFilterMiddleware($filter);
+        $this->assertInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    public function testIntegerFilterPassesValidValue(): void
+    {
+        $property = new IntegerProperty('age', '');
+        $property->init();
+        $property->setIsRequired(false);
+
+        $filter = IntegerFilter::equals($property);
+        $filter->setValue(42);
+        $filter->setRawValue('42');
+
+        $response = $this->runFilterMiddleware($filter);
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    public function testFloatFilterPassesValidValue(): void
+    {
+        $property = new FloatProperty('rating', '');
+        $property->init();
+        $property->setIsRequired(false);
+
+        $filter = FloatFilter::equals($property);
+        $filter->setValue(4.5);
+        $filter->setRawValue('4.5');
+
+        $response = $this->runFilterMiddleware($filter);
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    public function testBooleanFilterPassesValidValue(): void
+    {
+        $property = new BooleanProperty('is_active', '', false);
+        $property->init();
+        $property->setIsRequired(false);
+
+        $filter = BooleanFilter::equals($property);
+        $filter->setValue(true);
+        $filter->setRawValue('true');
+
+        $response = $this->runFilterMiddleware($filter);
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    public function testEnumFilterPassesValidValue(): void
+    {
+        $property = new EnumProperty('status', '', ['active', 'inactive']);
+        $property->init();
+        $property->setIsRequired(false);
+
+        $filter = EnumFilter::equals($property);
+        $filter->setValue('active');
+        $filter->setRawValue('active');
+
+        $response = $this->runFilterMiddleware($filter);
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    public function testEnumFilterRejectsValueOutsideAllowedSet(): void
+    {
+        $property = new EnumProperty('status', '', ['active', 'inactive']);
+        $property->init();
+        $property->setIsRequired(false);
+
+        $filter = EnumFilter::equals($property);
+        $filter->setValue('archived');
+        $filter->setRawValue('archived');
+
+        $response = $this->runFilterMiddleware($filter);
+        $this->assertInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    public function testBinaryFilterPassesValidValue(): void
+    {
+        $property = new BinaryProperty('blob', '');
+        $property->init();
+        $property->setIsRequired(false);
+
+        $filter = BinaryFilter::equals($property);
+        $filter->setValue('payload');
+        $filter->setRawValue('payload');
+
+        $response = $this->runFilterMiddleware($filter);
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    public function testByteFilterPassesValidValue(): void
+    {
+        $property = new ByteProperty('blob', '');
+        $property->init();
+        $property->setIsRequired(false);
+
+        $filter = ByteFilter::equals($property);
+        $base64 = base64_encode('payload');
+        $filter->setValue($base64);
+        $filter->setRawValue($base64);
+
+        $response = $this->runFilterMiddleware($filter);
+        $this->assertNotInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    public function testRawValueOnlyTriggersValidation(): void
+    {
+        $property = new StringProperty('status', '');
+        $property->setIsRequired(false);
+
+        $validator = $this->createMock(AbstractValidator::class);
+        $validator->method('validate')->willReturn(new ValidatorResult(false, 'Invalid value'));
+        $property->addValidator($validator);
+
+        $filter = StringFilter::equals($property);
+        $filter->setRawValue('something');
+
+        $response = $this->runFilterMiddleware($filter);
+        $this->assertInstanceOf(BadValidationApivalkResponse::class, $response);
+    }
+
+    private function runFilterMiddleware(FilterInterface $filter): AbstractApivalkResponse
+    {
+        $filterBag = new FilterBag();
+        $filterBag->set($filter);
+
+        $request = $this->createRequest(new ApivalkRequestDocumentation(), $filterBag);
+
+        $next = function ($req) {
+            return $this->createMock(AbstractApivalkResponse::class);
+        };
+
+        return (new RequestValidationMiddleware())->process(
+            $request,
+            $this->createMock(AbstractApivalkController::class),
+            $next
+        );
     }
 
     private function createRequest(


### PR DESCRIPTION
- Introduced `rawValue` property to filters (`StringFilter`, `IntegerFilter`, `FloatFilter`, `DateFilter`, `DateTimeFilter`, `BooleanFilter`, `BinaryFilter`, `ByteFilter`, `EnumFilter`) for handling raw input alongside typed values.
- Updated `RequestValidationMiddleware` to prioritize `rawValue` for validation and required checks.
- Enhanced `FilteringPopulationStrategy` to set both raw and typed values during population.
- Added extensive PHPUnit test coverage to verify `rawValue` behavior in filters and middleware.
- Included a new `ListAnimalsIntegrationTest` to validate filter behavior and request lifecycle.

Issue: #120