### PR TITLE
feat: introduce `pathProperty()` for typed path parameter definitions

### DIFF
--- a/Documentation/DocBlock/DocBlockRequestGenerator.php
+++ b/Documentation/DocBlock/DocBlockRequestGenerator.php
@@ -35,6 +35,10 @@ final class DocBlockRequestGenerator
             $pathShape->addProperty($property);
         }
 
+        foreach ($route->getPathProperties() as $property) {
+            $pathShape->addProperty($property);
+        }
+
         foreach ($documentation->getQueryProperties() as $property) {
             $queryShape->addProperty($property);
         }

--- a/Documentation/OpenAPI/Generator/PathItemGenerator.php
+++ b/Documentation/OpenAPI/Generator/PathItemGenerator.php
@@ -111,9 +111,14 @@ class PathItemGenerator
         $requestClass = $controllerClass::getRequestClass();
         $responseClasses = $controllerClass::getResponseClasses();
 
+        $requestDocumentation = $requestClass::getDocumentation();
+        foreach ($route->getPathProperties() as $property) {
+            $requestDocumentation->addPathProperty($property);
+        }
+
         return $operationGenerator->generate(
             $route,
-            $requestClass::getDocumentation(),
+            $requestDocumentation,
             $responseClasses
         );
     }

--- a/Documentation/Request/RequestDocumentationFactory.php
+++ b/Documentation/Request/RequestDocumentationFactory.php
@@ -83,6 +83,10 @@ final class RequestDocumentationFactory
             }
         }
 
+        foreach ($route->getPathProperties() as $property) {
+            $documentation->addPathProperty($property);
+        }
+
         foreach (OperationGenerator::getPaginationProperties($route) as $property) {
             $documentation->addQueryProperty($property);
         }

--- a/Http/Request/Parameter/ParameterBagFactory.php
+++ b/Http/Request/Parameter/ParameterBagFactory.php
@@ -74,12 +74,12 @@ final class ParameterBagFactory
     {
         $pathBag = new ParameterBag();
 
-        preg_match_all('/\{([a-zA-Z0-9]+)\}/', $route->getUrl(), $keyMatches);
+        preg_match_all('/\{([a-zA-Z0-9_]+)\}/', $route->getUrl(), $keyMatches);
         $parameterNames = $keyMatches[1];
 
         $url = $route->getUrl();
         $escapedUrl = preg_replace_callback(
-            '/(\{[a-zA-Z0-9]+\})|([^{]+)/',
+            '/(\{[a-zA-Z0-9_]+\})|([^{]+)/',
             static function ($matches) {
                 if (!empty($matches[1])) {
                     return '([a-zA-Z0-9-_]+)';

--- a/Router/Route/Route.php
+++ b/Router/Route/Route.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Router\Route;
 
 use apivalk\apivalk\Documentation\OpenAPI\Object\TagObject;
+use apivalk\apivalk\Documentation\Property\AbstractProperty;
 use apivalk\apivalk\Http\Method\DeleteMethod;
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Method\MethodInterface;
@@ -40,6 +41,8 @@ class Route
     private $filters;
     /** @var Pagination|null */
     private $pagination;
+    /** @var AbstractProperty[] */
+    private $pathProperties = [];
 
     /**
      * @param string                  $url
@@ -187,6 +190,14 @@ class Route
         return $this;
     }
 
+    public function pathProperty(AbstractProperty $property): self
+    {
+        $property->setIsRequired(true);
+        $this->pathProperties[$property->getPropertyName()] = $property;
+
+        return $this;
+    }
+
     public function description(string $description): self
     {
         $this->description = $description;
@@ -256,5 +267,13 @@ class Route
     public function getFilters(): array
     {
         return $this->filters;
+    }
+
+    /**
+     * @return AbstractProperty[]
+     */
+    public function getPathProperties(): array
+    {
+        return $this->pathProperties;
     }
 }

--- a/Router/Route/RouteJsonSerializer.php
+++ b/Router/Route/RouteJsonSerializer.php
@@ -53,6 +53,11 @@ class RouteJsonSerializer
      *              description: string,
      *              format: string|null
      *          }
+     *     }>|null,
+     *     pathProperties: array<int, array{
+     *          class: class-string<AbstractProperty>,
+     *          name: string,
+     *          description: string
      *     }>|null
      * }
      */
@@ -108,6 +113,13 @@ class RouteJsonSerializer
             }
         }
 
+        $pathProperties = $route->getPathProperties();
+        if (\count($pathProperties) > 0) {
+            foreach ($pathProperties as $property) {
+                $pathPropertiesData[] = PropertySerializer::serialize($property);
+            }
+        }
+
         return [
             'url' => $route->getUrl(),
             'method' => $route->getMethod()->getName(),
@@ -119,6 +131,7 @@ class RouteJsonSerializer
             'sortings' => $orderingsData ?? null,
             'pagination' => $paginationData ?? null,
             'filters' => $filtersData ?? null,
+            'pathProperties' => $pathPropertiesData ?? null,
         ];
     }
 
@@ -190,7 +203,7 @@ class RouteJsonSerializer
             }
         }
 
-        return new Route(
+        $route = new Route(
             $jsonArray['url'],
             MethodFactory::create($jsonArray['method']),
             $jsonArray['description'] ?? null,
@@ -202,5 +215,14 @@ class RouteJsonSerializer
             $pagination,
             $filters
         );
+
+        $pathPropertiesData = $jsonArray['pathProperties'] ?? null;
+        if ($pathPropertiesData !== null) {
+            foreach ($pathPropertiesData as $data) {
+                $route->pathProperty(PropertySerializer::deserialize($data));
+            }
+        }
+
+        return $route;
     }
 }

--- a/Tests/PhpUnit/Documentation/DocBlock/DocBlockRequestGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/DocBlock/DocBlockRequestGeneratorTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Documentation\DocBlock;
 
+use apivalk\apivalk\Documentation\Property\IntegerProperty;
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Router\Route\Route;
 use PHPUnit\Framework\TestCase;
 use apivalk\apivalk\Documentation\DocBlock\DocBlockRequestGenerator;
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
-use apivalk\apivalk\Documentation\Property\StringProperty;
-use apivalk\apivalk\Documentation\Property\IntegerProperty;
 
 class TestRequest extends AbstractApivalkRequest {
     public static function getDocumentation(): ApivalkRequestDocumentation {
@@ -47,5 +47,30 @@ class DocBlockRequestGeneratorTest extends TestCase
         $this->assertStringContainsString('@property-read string $slug', $pathString);
 
         $orderingString = $docBlockRequest->getSortingShape()->toString('App\\Shape');
+    }
+
+    public function testRoutePathPropertyAppearsInPathShape(): void
+    {
+        $generator = new DocBlockRequestGenerator();
+        $request = new TestRequest();
+        $route = Route::get('/items/{item_id}')->pathProperty(new IntegerProperty('item_id', 'Item ID'));
+
+        $docBlockRequest = $generator->generate($request, $route);
+        $pathString = $docBlockRequest->getPathShape()->toString('App\\Shape');
+
+        $this->assertStringContainsString('@property-read int $item_id', $pathString);
+    }
+
+    public function testRoutePathPropertyDoesNotDuplicateRequestClassProperty(): void
+    {
+        $generator = new DocBlockRequestGenerator();
+        $request = new TestRequest();
+        $route = Route::get('/items/{slug}')->pathProperty(new StringProperty('extra', 'Extra'));
+
+        $docBlockRequest = $generator->generate($request, $route);
+        $pathString = $docBlockRequest->getPathShape()->toString('App\\Shape');
+
+        $this->assertStringContainsString('@property-read string $slug', $pathString);
+        $this->assertStringContainsString('@property-read string $extra', $pathString);
     }
 }

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/PathItemGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/PathItemGeneratorTest.php
@@ -6,6 +6,7 @@ namespace apivalk\apivalk\Tests\PhpUnit\Documentation\OpenAPI\Generator;
 
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Documentation\OpenAPI\Generator\PathItemGenerator;
+use apivalk\apivalk\Documentation\Property\IntegerProperty;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Http\i18n\Locale;
 use apivalk\apivalk\Http\Method\GetMethod;
@@ -162,6 +163,44 @@ class PathItemTestRequest implements ApivalkRequestInterface
     }
 }
 
+class PathItemWithRoutePathPropertyController extends AbstractApivalkController
+{
+    public static function getRoute(): Route
+    {
+        return Route::get('/items/{item_id}')->pathProperty(new IntegerProperty('item_id', 'Item ID'));
+    }
+
+    public static function getRequestClass(): string
+    {
+        return PathItemTestRequest::class;
+    }
+
+    public static function getResponseClasses(): array
+    {
+        return [];
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): \apivalk\apivalk\Http\Response\AbstractApivalkResponse
+    {
+        return new class extends \apivalk\apivalk\Http\Response\AbstractApivalkResponse {
+            public static function getDocumentation(): \apivalk\apivalk\Documentation\ApivalkResponseDocumentation
+            {
+                return new \apivalk\apivalk\Documentation\ApivalkResponseDocumentation();
+            }
+
+            public static function getStatusCode(): int
+            {
+                return 200;
+            }
+
+            public function toArray(): array
+            {
+                return [];
+            }
+        };
+    }
+}
+
 class PathItemGeneratorTest extends TestCase
 {
     public function testPathItemGenerator(): void
@@ -282,6 +321,27 @@ class PathItemGeneratorTest extends TestCase
         }
 
         $this->assertContains(204, $statusCodes, 'Delete operation must declare a 204 (DeletedApivalkResponse) status.');
+    }
+
+    public function testRoutePathPropertyAppearsAsPathParameterInOpenApiOperation(): void
+    {
+        $generator = new PathItemGenerator();
+        $route = PathItemWithRoutePathPropertyController::getRoute();
+
+        $pathItem = $generator->generate([
+            ['route' => $route, 'controllerClass' => PathItemWithRoutePathPropertyController::class],
+        ]);
+
+        $this->assertNotNull($pathItem->getGet());
+
+        $hasPathParam = false;
+        foreach ($pathItem->getGet()->getParameters() as $parameter) {
+            if ($parameter->getName() === 'item_id' && $parameter->getIn() === 'path') {
+                $hasPathParam = true;
+            }
+        }
+
+        $this->assertTrue($hasPathParam, 'Route pathProperty() must appear as a path parameter in the OpenAPI operation.');
     }
 
     public function testListResourceControllerExposesPaginationQueryParameters(): void

--- a/Tests/PhpUnit/Documentation/Request/RequestDocumentationFactoryTest.php
+++ b/Tests/PhpUnit/Documentation/Request/RequestDocumentationFactoryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Documentation\Request;
+
+use apivalk\apivalk\Documentation\Property\IntegerProperty;
+use apivalk\apivalk\Documentation\Property\StringProperty;
+use apivalk\apivalk\Documentation\Request\RequestDocumentationFactory;
+use apivalk\apivalk\Http\Controller\AbstractApivalkController;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
+use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use apivalk\apivalk\Http\Method\GetMethod;
+use apivalk\apivalk\Router\Route\Route;
+use PHPUnit\Framework\TestCase;
+
+class FactoryTestRequest implements ApivalkRequestInterface
+{
+    public static function getDocumentation(): ApivalkRequestDocumentation
+    {
+        $doc = new ApivalkRequestDocumentation();
+        $doc->addPathProperty(new StringProperty('slug', 'Slug'));
+        return $doc;
+    }
+
+    public function populate(Route $route, ApivalkRequestDocumentation $documentation): void {}
+    public function getRuntimeDocumentation(): ApivalkRequestDocumentation { return self::getDocumentation(); }
+    public function getMethod(): \apivalk\apivalk\Http\Method\MethodInterface { return new GetMethod(); }
+    public function header(): \apivalk\apivalk\Http\Request\Parameter\ParameterBag { return new \apivalk\apivalk\Http\Request\Parameter\ParameterBag(); }
+    public function query(): \apivalk\apivalk\Http\Request\Parameter\ParameterBag { return new \apivalk\apivalk\Http\Request\Parameter\ParameterBag(); }
+    public function body(): \apivalk\apivalk\Http\Request\Parameter\ParameterBag { return new \apivalk\apivalk\Http\Request\Parameter\ParameterBag(); }
+    public function path(): \apivalk\apivalk\Http\Request\Parameter\ParameterBag { return new \apivalk\apivalk\Http\Request\Parameter\ParameterBag(); }
+    public function file(): \apivalk\apivalk\Http\Request\File\FileBag { return new \apivalk\apivalk\Http\Request\File\FileBag(); }
+    public function getAuthIdentity(): \apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity { return new \apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity([]); }
+    public function setAuthIdentity(\apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity $authIdentity): void {}
+    public function getIp(): ?string { return null; }
+    public function getRateLimitResult(): ?\apivalk\apivalk\Router\RateLimit\RateLimitResult { return null; }
+    public function setRateLimitResult(\apivalk\apivalk\Router\RateLimit\RateLimitResult $rateLimitResult): void {}
+    public function getLocale(): \apivalk\apivalk\Http\i18n\Locale { return \apivalk\apivalk\Http\i18n\Locale::en(); }
+    public function setLocale(\apivalk\apivalk\Http\i18n\Locale $locale): void {}
+    public function sorting(): \apivalk\apivalk\Router\Route\Sort\SortBag { return new \apivalk\apivalk\Router\Route\Sort\SortBag(); }
+    public function filtering(): \apivalk\apivalk\Router\Route\Filter\FilterBag { return new \apivalk\apivalk\Router\Route\Filter\FilterBag(); }
+    public function paginator() { return null; }
+    public function setIp(?string $ip): void {}
+}
+
+class FactoryTestController extends AbstractApivalkController
+{
+    public static function getRoute(): Route
+    {
+        return Route::get('/items/{id}')->pathProperty(new IntegerProperty('id', 'ID'));
+    }
+
+    public static function getRequestClass(): string
+    {
+        return FactoryTestRequest::class;
+    }
+
+    public static function getResponseClasses(): array
+    {
+        return [];
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        return new class extends AbstractApivalkResponse {
+            public static function getDocumentation(): ApivalkResponseDocumentation { return new ApivalkResponseDocumentation(); }
+            public static function getStatusCode(): int { return 200; }
+            public function toArray(): array { return []; }
+        };
+    }
+}
+
+class RequestDocumentationFactoryTest extends TestCase
+{
+    public function testBuildRuntimeDocumentationMergesRoutePathProperties(): void
+    {
+        $route = Route::get('/items/{id}')->pathProperty(new IntegerProperty('id', 'ID'));
+
+        $documentation = RequestDocumentationFactory::buildRuntimeDocumentation($route, FactoryTestController::class);
+
+        $pathProperties = $documentation->getPathProperties();
+
+        $this->assertArrayHasKey('slug', $pathProperties);
+        $this->assertArrayHasKey('id', $pathProperties);
+    }
+
+    public function testBuildRuntimeDocumentationWithoutRoutePathProperties(): void
+    {
+        $route = Route::get('/items/{slug}');
+
+        $documentation = RequestDocumentationFactory::buildRuntimeDocumentation($route, FactoryTestController::class);
+
+        $pathProperties = $documentation->getPathProperties();
+        $this->assertArrayHasKey('slug', $pathProperties);
+        $this->assertArrayNotHasKey('id', $pathProperties);
+    }
+}

--- a/Tests/PhpUnit/Http/Request/Parameter/ParameterBagFactoryTest.php
+++ b/Tests/PhpUnit/Http/Request/Parameter/ParameterBagFactoryTest.php
@@ -91,6 +91,20 @@ class ParameterBagFactoryTest extends TestCase
         $this->assertIsInt($bag->age);
     }
 
+    public function testCreatePathBagWithUnderscoreParam(): void
+    {
+        $doc = new ApivalkRequestDocumentation();
+        $doc->addPathProperty(new StringProperty('animal_uuid', 'UUID'));
+
+        $route = $this->createMock(Route::class);
+        $route->method('getUrl')->willReturn('/animals/{animal_uuid}');
+
+        $_SERVER['REQUEST_URI'] = '/animals/abc-123';
+
+        $bag = ParameterBagFactory::createPathBag($route, $doc->getPathProperties());
+        $this->assertEquals('abc-123', $bag->animal_uuid);
+    }
+
     public function testTypeCastValue(): void
     {
         $prop = new IntegerProperty('test', '', IntegerProperty::FORMAT_INT32);

--- a/Tests/PhpUnit/Router/RouteRegexFactoryTest.php
+++ b/Tests/PhpUnit/Router/RouteRegexFactoryTest.php
@@ -24,4 +24,12 @@ class RouteRegexFactoryTest extends TestCase
         $route = new Route('/users/{id}/profile/{type}', $method);
         $this->assertEquals('#^\/users\/([a-zA-Z0-9_-]+)\/profile\/([a-zA-Z0-9_-]+)$#', RouteRegexFactory::build($route));
     }
+
+    public function testUnderscoreInParamNames(): void
+    {
+        $method = new GetMethod();
+
+        $route = new Route('/animals/{animal_uuid}', $method);
+        $this->assertEquals('#^\/animals\/([a-zA-Z0-9_-]+)$#', RouteRegexFactory::build($route));
+    }
 }

--- a/Tests/PhpUnit/Router/RouteTest.php
+++ b/Tests/PhpUnit/Router/RouteTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace apivalk\apivalk\Tests\PhpUnit\Router;
 
 use apivalk\apivalk\Documentation\OpenAPI\Object\TagObject;
+use apivalk\apivalk\Documentation\Property\IntegerProperty;
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Method\PostMethod;
 use apivalk\apivalk\Router\RateLimit\IpRateLimit;
@@ -55,6 +57,37 @@ class RouteTest extends TestCase
                 ->rateLimit(new IpRateLimit('test', 20, 5))
                 ->routeAuthorization(new RouteAuthorization('api', ['test'], ['test:read']))
         );
+    }
+
+    public function testPathProperty(): void
+    {
+        $route = Route::get('/users/{id}')->pathProperty(new IntegerProperty('id', 'ID'));
+
+        $this->assertCount(1, $route->getPathProperties());
+        $this->assertArrayHasKey('id', $route->getPathProperties());
+
+        $route2 = Route::get('/orgs/{org}/users/{user}')
+            ->pathProperty(new StringProperty('org', 'Org'))
+            ->pathProperty(new IntegerProperty('user', 'User'));
+
+        $this->assertCount(2, $route2->getPathProperties());
+        $this->assertArrayHasKey('org', $route2->getPathProperties());
+        $this->assertArrayHasKey('user', $route2->getPathProperties());
+    }
+
+    public function testPathPropertyJsonRoundTrip(): void
+    {
+        $route = Route::get('/sessions/{session_uuid}')
+            ->pathProperty(new StringProperty('session_uuid', 'Session UUID'));
+
+        $json = json_encode(RouteJsonSerializer::serialize($route));
+        $this->assertIsString($json);
+
+        $restored = RouteJsonSerializer::deserialize($json);
+
+        $this->assertCount(1, $restored->getPathProperties());
+        $this->assertArrayHasKey('session_uuid', $restored->getPathProperties());
+        $this->assertEquals('session_uuid', $restored->getPathProperties()['session_uuid']->getPropertyName());
     }
 
     public function testJsonSerialization(): void

--- a/docs/how-to/manual-crud.mdx
+++ b/docs/how-to/manual-crud.mdx
@@ -187,6 +187,8 @@ final class CreatePetController extends AbstractApivalkController
 
 ### `ViewPetRequest`
 
+No request-specific properties needed — the path parameter is declared on the route.
+
 ```php
 <?php
 
@@ -194,19 +196,10 @@ declare(strict_types=1);
 
 namespace App\Http\Request\Pet;
 
-use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
-use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
 
 class ViewPetRequest extends AbstractApivalkRequest
 {
-    public static function getDocumentation(): ApivalkRequestDocumentation
-    {
-        $doc = new ApivalkRequestDocumentation();
-        $doc->addPathProperty(new StringProperty('pet_uuid', 'Pet identifier'));
-
-        return $doc;
-    }
 }
 ```
 
@@ -266,6 +259,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controller\Pet;
 
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
@@ -291,6 +285,7 @@ final class ViewPetController extends AbstractApivalkController
     {
         return Route::get('/api/v1/pets/{pet_uuid}')
             ->summary('Get a pet by UUID')
+            ->pathProperty(new StringProperty('pet_uuid', 'Pet identifier'))
             ->routeAuthorization(new RouteAuthorization('BearerAuth', ['pet'], ['pet:read']));
     }
 
@@ -324,6 +319,8 @@ final class ViewPetController extends AbstractApivalkController
 
 ### `UpdatePetRequest`
 
+Only body properties live in the request class. The path parameter is declared on the route.
+
 ```php
 <?php
 
@@ -341,7 +338,6 @@ class UpdatePetRequest extends AbstractApivalkRequest
     public static function getDocumentation(): ApivalkRequestDocumentation
     {
         $doc = new ApivalkRequestDocumentation();
-        $doc->addPathProperty(new StringProperty('pet_uuid', 'Pet identifier'));
 
         // Patch semantics — every body field is optional
         $doc->addBodyProperty((new StringProperty('name', 'Pet name'))->setIsRequired(false));
@@ -405,6 +401,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controller\Pet;
 
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
@@ -430,6 +427,7 @@ final class UpdatePetController extends AbstractApivalkController
     {
         return Route::patch('/api/v1/pets/{pet_uuid}')
             ->summary('Update a pet')
+            ->pathProperty(new StringProperty('pet_uuid', 'Pet identifier'))
             ->routeAuthorization(new RouteAuthorization('BearerAuth', ['pet'], ['pet:write']));
     }
 
@@ -474,6 +472,8 @@ final class UpdatePetController extends AbstractApivalkController
 
 ### `DeletePetRequest`
 
+No request-specific properties needed — the path parameter is declared on the route.
+
 ```php
 <?php
 
@@ -481,19 +481,10 @@ declare(strict_types=1);
 
 namespace App\Http\Request\Pet;
 
-use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
-use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
 
 class DeletePetRequest extends AbstractApivalkRequest
 {
-    public static function getDocumentation(): ApivalkRequestDocumentation
-    {
-        $doc = new ApivalkRequestDocumentation();
-        $doc->addPathProperty(new StringProperty('pet_uuid', 'Pet identifier'));
-
-        return $doc;
-    }
 }
 ```
 
@@ -551,6 +542,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controller\Pet;
 
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
@@ -576,6 +568,7 @@ final class DeletePetController extends AbstractApivalkController
     {
         return Route::delete('/api/v1/pets/{pet_uuid}')
             ->summary('Delete a pet')
+            ->pathProperty(new StringProperty('pet_uuid', 'Pet identifier'))
             ->routeAuthorization(new RouteAuthorization('BearerAuth', ['pet'], ['pet:delete']));
     }
 

--- a/docs/routing/route.mdx
+++ b/docs/routing/route.mdx
@@ -16,16 +16,77 @@ A `Route` instance contains the following information:
 * **Sorting**: A collection of `Sort` instances defining allowed sorting fields for the endpoint.
 * **Pagination**: A `Pagination` instance defining the pagination strategy (Page, Offset, or Cursor).
 * **Filtering**: A collection of `FilterInterface` instances defining allowed filtering fields for the endpoint.
+* **Path Properties**: Typed `AbstractProperty` instances defining each path parameter (e.g. `{id}`, `{user_uuid}`), declared via chained `pathProperty()` calls.
 
 ## Path Parameters
 
-Routes support dynamic path parameters using the `{parameterName}` syntax. For example:
+Routes support dynamic path parameters using the `{parameterName}` syntax. Parameter names may contain letters, digits, and underscores (`[a-zA-Z0-9_]`).
+
+Define the type and description of each path parameter directly on the route using `pathProperty()`:
 
 ```php
-Route::get('/users/{id}/profile');
+use apivalk\apivalk\Documentation\Property\StringProperty;
+use apivalk\apivalk\Documentation\Property\IntegerProperty;
+
+// Single parameter
+Route::get('/users/{id}')
+    ->pathProperty(new IntegerProperty('id', 'User ID'));
+
+// Multiple parameters — chain the calls
+Route::get('/orgs/{org_id}/users/{user_id}')
+    ->pathProperty(new IntegerProperty('org_id', 'Organisation ID'))
+    ->pathProperty(new StringProperty('user_id', 'User UUID'));
 ```
 
-These parameters are automatically identified and converted into capture groups in the internal regex generation logic.
+This is the preferred way to declare path parameters. Defining them on the route means the type, validation, and OpenAPI documentation are all co-located with the URL pattern rather than split across a separate request class.
+
+Path parameters defined via `pathProperty()` are automatically:
+- **Validated and type-cast** when the request is populated
+- **Included in the OpenAPI spec** as `in: path` parameters
+- **Included in the generated path shape** for IDE type hints
+
+### Validators
+
+Any property constraint supported by Apivalk can be applied to a path parameter:
+
+```php
+use apivalk\apivalk\Documentation\Property\IntegerProperty;
+use apivalk\apivalk\Documentation\Property\StringProperty;
+
+Route::get('/users/{id}')
+    ->pathProperty(
+        (new IntegerProperty('id', 'User ID'))
+            ->setMinimumValue(1)
+    );
+
+Route::get('/articles/{slug}')
+    ->pathProperty(
+        (new StringProperty('slug', 'Article slug'))
+            ->setMinLength(1)
+            ->setMaxLength(100)
+            ->setPattern('/^[a-z0-9-]+$/')
+    );
+```
+
+Constraints are serialized with the route when route caching is enabled and are fully restored on cache load.
+
+### Path parameters are always required
+
+`pathProperty()` always enforces `isRequired(true)` regardless of what is set on the property. Path parameters are structurally required — the route only matches when they are present in the URL. Marking one optional would produce an invalid OpenAPI spec (`required: false` on a `path` parameter violates the OpenAPI specification).
+
+### Accessing path parameters
+
+```php
+public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+{
+    $id = $request->path()->id;           // magic accessor
+    $id = $request->path()->get('id');    // explicit accessor
+}
+```
+
+### Backward compatibility
+
+Path properties can also be declared in the request class via `addPathProperty()` in `getDocumentation()`. Both sources are merged — you can use either or both. `pathProperty()` on the route is preferred for new code.
 
 ## Security and Authorization
 


### PR DESCRIPTION
- Add `pathProperty()` to `Route` for defining path parameter types and descriptions.
- Enable validation and type-casting of path parameters during request population.
- Automatically include path parameters in OpenAPI specifications and generated path shapes.
- Refactor existing logic to support underscores in path parameter names.
- Update tests and documentation to reflect new functionality.

Issue: #128