### PR TITLE
docs: clarify `getRawValue()` usage in filter documentation

### DIFF
--- a/docs/http/filtering.mdx
+++ b/docs/http/filtering.mdx
@@ -58,6 +58,7 @@ Apivalk provides specialized filter classes for different property types. Each f
 Benefits:
 -   **OpenAPI Accuracy**: The documentation reflects the correct data type (e.g., `number`, `integer`, `string`).
 -   **Automatic Casting**: `getValue()` returns the correct PHP type (`string`, `int`, `float`, or `\DateTime`), or `null` if the filter was not provided by the client.
+-   **Raw Access**: `getRawValue()` returns the original query string the client sent (e.g. `"2024-01-15T14:30:00+00:00"` for a `DateTimeFilter`), or `null` if the filter wasn't provided. Useful for audit logs, error messages that quote the user's literal input, or distinguishing "client supplied an unparseable value" (`getRawValue() !== null && getValue() === null`) from "client omitted the filter" (both `null`).
 -   **Detailed Documentation**: You can add custom descriptions, examples, and constraints to your filters.
 
 ```php


### PR DESCRIPTION
- Highlight the benefits of `getRawValue()` for audit logs, error handling, and distinguishing omitted vs. unparseable values in client inputs.

Issue: #126