### PR TITLE
fix: remove unused methods and refactor resource-related controllers …

### DIFF
--- a/Documentation/DocBlock/DocBlockResourceGenerator.php
+++ b/Documentation/DocBlock/DocBlockResourceGenerator.php
@@ -12,8 +12,6 @@ final class DocBlockResourceGenerator
     {
         $docBlockResource = new DocBlockResource();
 
-        $docBlockResource->addProperty($resource->getIdentifierProperty());
-
         foreach ($resource->getProperties() as $property) {
             $docBlockResource->addProperty($property);
         }

--- a/Documentation/DocBlock/DocBlockResourceRequestGenerator.php
+++ b/Documentation/DocBlock/DocBlockResourceRequestGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Documentation\DocBlock;
 
+use apivalk\apivalk\Documentation\Request\RequestDocumentationFactory;
 use apivalk\apivalk\Http\Controller\Resource\AbstractListResourceController;
 use apivalk\apivalk\Http\Request\Pagination\CursorPaginator;
 use apivalk\apivalk\Http\Request\Pagination\OffsetPaginator;
@@ -21,7 +22,7 @@ final class DocBlockResourceRequestGenerator
     public function generate(string $controllerClass): DocBlockResourceRequest
     {
         $resource = $controllerClass::getEmptyResource();
-        $requestName = \ucfirst($resource->getName()) . \ucfirst($controllerClass::getMode());
+        $requestName = \ucfirst($resource->getName()) . \ucfirst(RequestDocumentationFactory::getModeFromController($controllerClass));
 
         $sortingShape = new DocBlockShape($requestName, 'Sorting');
         $filteringShape = new DocBlockShape($requestName, 'Filtering');
@@ -36,7 +37,7 @@ final class DocBlockResourceRequestGenerator
         }
 
         $paginatorClass = null;
-        $pagination = $controllerClass::pagination();
+        $pagination = $controllerClass::getRoute()->getPagination();
 
         if ($pagination !== null) {
             switch ($pagination->getType()) {

--- a/Documentation/OpenAPI/Generator/PathItemGenerator.php
+++ b/Documentation/OpenAPI/Generator/PathItemGenerator.php
@@ -11,13 +11,13 @@ use apivalk\apivalk\Documentation\Response\ResponseDocumentationFactory;
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Http\Controller\Resource\AbstractDeleteResourceController;
 use apivalk\apivalk\Http\Controller\Resource\AbstractResourceController;
+use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Http\Method\DeleteMethod;
 use apivalk\apivalk\Http\Method\GetMethod;
 use apivalk\apivalk\Http\Method\PatchMethod;
 use apivalk\apivalk\Http\Method\PostMethod;
 use apivalk\apivalk\Http\Method\PutMethod;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
-use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\Route\Route;
 
 class PathItemGenerator
@@ -136,9 +136,12 @@ class PathItemGenerator
         string $controllerClass
     ): OperationObject {
         $resource = $controllerClass::getEmptyResource();
-        $mode = $controllerClass::getMode();
+        $mode = RequestDocumentationFactory::getModeFromController($controllerClass);
 
         $requestDocumentation = RequestDocumentationFactory::createRequestDocumentation($resource, $mode);
+        foreach ($route->getPathProperties() as $property) {
+            $requestDocumentation->addPathProperty($property);
+        }
         $responseDocumentation = ResponseDocumentationFactory::create($resource, $mode);
 
         $responseDocumentations = [];

--- a/Documentation/Request/RequestDocumentationFactory.php
+++ b/Documentation/Request/RequestDocumentationFactory.php
@@ -6,14 +6,20 @@ namespace apivalk\apivalk\Documentation\Request;
 
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Documentation\OpenAPI\Generator\OperationGenerator;
+use apivalk\apivalk\Http\Controller\Resource\AbstractCreateResourceController;
+use apivalk\apivalk\Http\Controller\Resource\AbstractDeleteResourceController;
+use apivalk\apivalk\Http\Controller\Resource\AbstractListResourceController;
 use apivalk\apivalk\Http\Controller\Resource\AbstractResourceController;
+use apivalk\apivalk\Http\Controller\Resource\AbstractUpdateResourceController;
+use apivalk\apivalk\Http\Controller\Resource\AbstractViewResourceController;
 use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\Route\Route;
 
 final class RequestDocumentationFactory
 {
     /**
-     * Request documentation for a resource in a given mode — path and body properties only.
+     * Request documentation for a resource in a given mode — body properties only.
+     * Path properties come from Route::getPathProperties() (declared explicitly in getRoute()).
      * Route-derived query properties (pagination, sorting, filtering) are intentionally excluded
      * so that OperationGenerator can add them without duplication when building OpenAPI specs.
      *
@@ -25,13 +31,6 @@ final class RequestDocumentationFactory
         string $mode
     ): ApivalkRequestDocumentation {
         $documentation = new ApivalkRequestDocumentation();
-
-        if ($mode === AbstractResource::MODE_VIEW
-            || $mode === AbstractResource::MODE_DELETE
-            || $mode === AbstractResource::MODE_UPDATE
-        ) {
-            $documentation->addPathProperty($resource->getIdentifierProperty());
-        }
 
         if ($mode === AbstractResource::MODE_CREATE || $mode === AbstractResource::MODE_UPDATE) {
             $excluded = $resource->excludeFromMode($mode);
@@ -55,8 +54,8 @@ final class RequestDocumentationFactory
 
     /**
      * Fully merged documentation for request population and validation at runtime. Combines base
-     * request documentation, resource path/body properties, and route-derived query properties
-     * (pagination, sorting, filtering).
+     * request documentation, resource body properties, and route-derived path/query properties
+     * (path params, pagination, sorting, filtering).
      *
      * @param Route  $route
      * @param string $controllerClass class-string<\apivalk\apivalk\Http\Controller\AbstractApivalkController>
@@ -71,12 +70,8 @@ final class RequestDocumentationFactory
 
         if (\is_subclass_of($controllerClass, AbstractResourceController::class)) {
             $resource = $controllerClass::getEmptyResource();
-            $mode = $controllerClass::getMode();
+            $mode = self::getModeFromController($controllerClass);
             $resourceDocumentation = self::createRequestDocumentation($resource, $mode);
-
-            foreach ($resourceDocumentation->getPathProperties() as $property) {
-                $documentation->addPathProperty($property);
-            }
 
             foreach ($resourceDocumentation->getBodyProperties() as $property) {
                 $documentation->addBodyProperty($property);
@@ -105,5 +100,29 @@ final class RequestDocumentationFactory
         }
 
         return $documentation;
+    }
+
+    /**
+     * @param class-string<AbstractResourceController<AbstractResource>> $controllerClass
+     */
+    public static function getModeFromController(string $controllerClass): string
+    {
+        if (\is_subclass_of($controllerClass, AbstractCreateResourceController::class)) {
+            return AbstractResource::MODE_CREATE;
+        }
+        if (\is_subclass_of($controllerClass, AbstractUpdateResourceController::class)) {
+            return AbstractResource::MODE_UPDATE;
+        }
+        if (\is_subclass_of($controllerClass, AbstractDeleteResourceController::class)) {
+            return AbstractResource::MODE_DELETE;
+        }
+        if (\is_subclass_of($controllerClass, AbstractViewResourceController::class)) {
+            return AbstractResource::MODE_VIEW;
+        }
+        if (\is_subclass_of($controllerClass, AbstractListResourceController::class)) {
+            return AbstractResource::MODE_LIST;
+        }
+
+        return AbstractResource::MODE_VIEW;
     }
 }

--- a/Documentation/Response/ResponseDocumentationFactory.php
+++ b/Documentation/Response/ResponseDocumentationFactory.php
@@ -21,8 +21,6 @@ final class ResponseDocumentationFactory
 
         $excluded = $resource->excludeFromMode($mode);
 
-        $documentation->addProperty($resource->getIdentifierProperty());
-
         foreach ($resource->getProperties() as $property) {
             if (\in_array($property->getPropertyName(), $excluded, true)) {
                 continue;

--- a/Http/Controller/Resource/AbstractCreateResourceController.php
+++ b/Http/Controller/Resource/AbstractCreateResourceController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Http\Controller\Resource;
 
-use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Request\Resource\ResourceRequest;
 use apivalk\apivalk\Http\Response\BadRequestApivalkResponse;
 use apivalk\apivalk\Http\Response\ForbiddenApivalkResponse;
@@ -17,16 +16,6 @@ use apivalk\apivalk\Resource\AbstractResource;
  */
 abstract class AbstractCreateResourceController extends AbstractResourceController
 {
-    public static function getDescription(): string
-    {
-        return \sprintf('Create %s', self::getEmptyResource()->getName());
-    }
-
-    public static function getMode(): string
-    {
-        return AbstractResource::MODE_CREATE;
-    }
-
     public static function getRequestClass(): string
     {
         return ResourceRequest::class;
@@ -39,14 +28,5 @@ abstract class AbstractCreateResourceController extends AbstractResourceControll
             BadRequestApivalkResponse::class,
             ForbiddenApivalkResponse::class,
         ];
-    }
-
-    /** @return TResource */
-    public function getResource(ApivalkRequestInterface $apivalkRequest): AbstractResource
-    {
-        /** @var class-string<AbstractResource> $resourceClass */
-        $resourceClass = static::getResourceClass();
-
-        return $resourceClass::byRequest($apivalkRequest);
     }
 }

--- a/Http/Controller/Resource/AbstractDeleteResourceController.php
+++ b/Http/Controller/Resource/AbstractDeleteResourceController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Http\Controller\Resource;
 
-use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Request\Resource\ResourceRequest;
 use apivalk\apivalk\Http\Response\BadRequestApivalkResponse;
 use apivalk\apivalk\Http\Response\DeletedApivalkResponse;
@@ -17,31 +16,9 @@ use apivalk\apivalk\Resource\AbstractResource;
  */
 abstract class AbstractDeleteResourceController extends AbstractResourceController
 {
-    public static function getDescription(): string
-    {
-        return \sprintf('Delete %s', self::getEmptyResource()->getName());
-    }
-
-    public static function getMode(): string
-    {
-        return AbstractResource::MODE_DELETE;
-    }
-
     public static function getRequestClass(): string
     {
         return ResourceRequest::class;
-    }
-
-    public function getResourceIdentifier(ApivalkRequestInterface $request): ?string
-    {
-        $identifierPropertyName = self::getEmptyResource()->getIdentifierProperty()->getPropertyName();
-        $identifierParameter = $request->path()->get($identifierPropertyName);
-
-        if ($identifierParameter === null) {
-            throw new \InvalidArgumentException(\sprintf('Missing path parameter "%s"', $identifierPropertyName));
-        }
-
-        return $identifierParameter->getValue();
     }
 
     public static function getResponseClasses(): array

--- a/Http/Controller/Resource/AbstractListResourceController.php
+++ b/Http/Controller/Resource/AbstractListResourceController.php
@@ -9,8 +9,6 @@ use apivalk\apivalk\Http\Response\BadRequestApivalkResponse;
 use apivalk\apivalk\Http\Response\ForbiddenApivalkResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceListResponse;
 use apivalk\apivalk\Resource\AbstractResource;
-use apivalk\apivalk\Router\Route\Pagination\Pagination;
-use apivalk\apivalk\Router\Route\Route;
 
 /**
  * @template TResource of AbstractResource
@@ -18,32 +16,6 @@ use apivalk\apivalk\Router\Route\Route;
  */
 abstract class AbstractListResourceController extends AbstractResourceController
 {
-    public static function getDescription(): string
-    {
-        return \sprintf('List %s', self::getEmptyResource()->getPluralName());
-    }
-
-    public static function pagination(): ?Pagination
-    {
-        return null;
-    }
-
-    protected static function configureRoute(Route $route): void
-    {
-        $route->filtering(self::getEmptyResource()->availableFilters());
-        $route->sorting(self::getEmptyResource()->availableSortings());
-
-        $pagination = static::pagination();
-        if ($pagination !== null) {
-            $route->pagination($pagination);
-        }
-    }
-
-    public static function getMode(): string
-    {
-        return AbstractResource::MODE_LIST;
-    }
-
     public static function getRequestClass(): string
     {
         return ResourceRequest::class;

--- a/Http/Controller/Resource/AbstractResourceController.php
+++ b/Http/Controller/Resource/AbstractResourceController.php
@@ -6,9 +6,6 @@ namespace apivalk\apivalk\Http\Controller\Resource;
 
 use apivalk\apivalk\Http\Controller\AbstractApivalkController;
 use apivalk\apivalk\Resource\AbstractResource;
-use apivalk\apivalk\Router\RateLimit\RateLimitInterface;
-use apivalk\apivalk\Router\Route\Route;
-use apivalk\apivalk\Security\RouteAuthorization;
 
 /**
  * @template TResource of AbstractResource
@@ -21,8 +18,6 @@ abstract class AbstractResourceController extends AbstractApivalkController impl
      */
     abstract public static function getResourceClass(): string;
 
-    abstract public static function getDescription(): string;
-
     /**
      * @return TResource
      */
@@ -32,46 +27,5 @@ abstract class AbstractResourceController extends AbstractApivalkController impl
         $resourceClass = static::getResourceClass();
 
         return new $resourceClass();
-    }
-
-    public static function getRoute(): Route
-    {
-        $resource = self::getEmptyResource();
-        $route = Route::resource($resource, static::getMode());
-
-        $route->description(static::getDescription());
-        $route->tags(static::getEmptyResource()->tags());
-
-        $rateLimit = static::rateLimit();
-        if ($rateLimit !== null) {
-            $route->rateLimit($rateLimit);
-        }
-
-        $authorization = static::routeAuthorization();
-        if ($authorization !== null) {
-            $route->routeAuthorization($authorization);
-        }
-
-        static::configureRoute($route);
-
-        return $route;
-    }
-
-    /**
-     * Hook for mode-specific route configuration. Default is a no-op; modes that need extra
-     * wiring (e.g. list filters/sortings/pagination) override this.
-     */
-    protected static function configureRoute(Route $route): void
-    {
-    }
-
-    public static function rateLimit(): ?RateLimitInterface
-    {
-        return null;
-    }
-
-    public static function routeAuthorization(): ?RouteAuthorization
-    {
-        return null;
     }
 }

--- a/Http/Controller/Resource/AbstractUpdateResourceController.php
+++ b/Http/Controller/Resource/AbstractUpdateResourceController.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Http\Controller\Resource;
 
-use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
-use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Request\Resource\ResourceRequest;
 use apivalk\apivalk\Http\Response\BadRequestApivalkResponse;
 use apivalk\apivalk\Http\Response\ForbiddenApivalkResponse;
@@ -18,16 +16,6 @@ use apivalk\apivalk\Resource\AbstractResource;
  */
 abstract class AbstractUpdateResourceController extends AbstractResourceController
 {
-    public static function getDescription(): string
-    {
-        return \sprintf('Update %s', self::getEmptyResource()->getName());
-    }
-
-    public static function getMode(): string
-    {
-        return AbstractResource::MODE_UPDATE;
-    }
-
     public static function getRequestClass(): string
     {
         return ResourceRequest::class;
@@ -40,25 +28,5 @@ abstract class AbstractUpdateResourceController extends AbstractResourceControll
             BadRequestApivalkResponse::class,
             ForbiddenApivalkResponse::class,
         ];
-    }
-
-    public function getResourceIdentifier(ApivalkRequestInterface $request): ?string
-    {
-        $identifierPropertyName = self::getEmptyResource()->getIdentifierProperty()->getPropertyName();
-        $identifierParameter = $request->path()->get($identifierPropertyName);
-
-        if ($identifierParameter === null) {
-            throw new \InvalidArgumentException(\sprintf('Missing path parameter "%s"', $identifierPropertyName));
-        }
-
-        return $identifierParameter->getValue();
-    }
-
-    public function getResource(AbstractApivalkRequest $apivalkRequest): AbstractResource
-    {
-        /** @var class-string<AbstractResource> $resourceClass */
-        $resourceClass = static::getResourceClass();
-
-        return $resourceClass::byRequest($apivalkRequest);
     }
 }

--- a/Http/Controller/Resource/AbstractViewResourceController.php
+++ b/Http/Controller/Resource/AbstractViewResourceController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Http\Controller\Resource;
 
-use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Request\Resource\ResourceRequest;
 use apivalk\apivalk\Http\Response\BadRequestApivalkResponse;
 use apivalk\apivalk\Http\Response\ForbiddenApivalkResponse;
@@ -17,31 +16,9 @@ use apivalk\apivalk\Resource\AbstractResource;
  */
 abstract class AbstractViewResourceController extends AbstractResourceController
 {
-    public static function getDescription(): string
-    {
-        return \sprintf('Get %s', self::getEmptyResource()->getName());
-    }
-
-    public static function getMode(): string
-    {
-        return AbstractResource::MODE_VIEW;
-    }
-
     public static function getRequestClass(): string
     {
         return ResourceRequest::class;
-    }
-
-    public function getResourceIdentifier(ApivalkRequestInterface $request): ?string
-    {
-        $identifierPropertyName = self::getEmptyResource()->getIdentifierProperty()->getPropertyName();
-        $identifierParameter = $request->path()->get($identifierPropertyName);
-
-        if ($identifierParameter === null) {
-            throw new \InvalidArgumentException(\sprintf('Missing path parameter "%s"', $identifierPropertyName));
-        }
-
-        return $identifierParameter->getValue();
     }
 
     public static function getResponseClasses(): array

--- a/Http/Controller/Resource/ResourceControllerInterface.php
+++ b/Http/Controller/Resource/ResourceControllerInterface.php
@@ -13,6 +13,4 @@ interface ResourceControllerInterface
 {
     /** @return class-string<AbstractResource> */
     public static function getResourceClass(): string;
-
-    public static function getMode(): string;
 }

--- a/Resource/AbstractResource.php
+++ b/Resource/AbstractResource.php
@@ -39,11 +39,6 @@ abstract class AbstractResource
 
     abstract protected function init(): void;
 
-    abstract public function getIdentifierProperty(): AbstractProperty;
-
-    /** Returns base url for resource. Example: /api/v1 */
-    abstract public function getBaseUrl(): string;
-
     abstract public function getName(): string;
 
     public function getPluralName(): string
@@ -123,26 +118,16 @@ abstract class AbstractResource
     public static function byArray(array $data): self
     {
         $resource = new static();
-        $identifierPropertyName = $resource->getIdentifierProperty()->getPropertyName();
 
         foreach ($data as $propertyName => $value) {
-            if ($identifierPropertyName !== $propertyName
-                && !$resource->hasProperty($propertyName)
-            ) {
+            if (!$resource->hasProperty($propertyName)) {
                 continue;
             }
 
-            if ($identifierPropertyName === $propertyName) {
-                $resource->__set(
-                    $propertyName,
-                    ParameterBagFactory::typeCastValueByProperty($value, $resource->getIdentifierProperty())
-                );
-            } else {
-                $resource->__set(
-                    $propertyName,
-                    ParameterBagFactory::typeCastValueByProperty($value, $resource->getProperties()[$propertyName])
-                );
-            }
+            $resource->__set(
+                $propertyName,
+                ParameterBagFactory::typeCastValueByProperty($value, $resource->getProperties()[$propertyName])
+            );
         }
 
         return $resource;
@@ -158,13 +143,6 @@ abstract class AbstractResource
             }
 
             $resource->__set($bodyParameter->getName(), $bodyParameter->getValue());
-        }
-
-        $resourceIdentifierPropertyName = $resource->getIdentifierProperty()->getPropertyName();
-
-        $pathIdentifier = $apivalkRequest->path()->get($resourceIdentifierPropertyName);
-        if ($pathIdentifier !== null) {
-            $resource->__set($resourceIdentifierPropertyName, $pathIdentifier->getValue());
         }
 
         return $resource;

--- a/Router/Route/Route.php
+++ b/Router/Route/Route.php
@@ -12,7 +12,6 @@ use apivalk\apivalk\Http\Method\MethodInterface;
 use apivalk\apivalk\Http\Method\PatchMethod;
 use apivalk\apivalk\Http\Method\PostMethod;
 use apivalk\apivalk\Http\Method\PutMethod;
-use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\RateLimit\RateLimitInterface;
 use apivalk\apivalk\Router\Route\Filter\FilterInterface;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
@@ -103,38 +102,6 @@ class Route
     public static function put(string $url): self
     {
         return new self($url, new PutMethod());
-    }
-
-    public static function resource(AbstractResource $resource, string $mode): self
-    {
-        $route = null;
-        $url = \sprintf('%s/%s', $resource->getBaseUrl(), $resource->getPluralName());
-
-        if ($mode === AbstractResource::MODE_DELETE) {
-            $route = self::delete($url);
-        }
-
-        if ($mode === AbstractResource::MODE_LIST) {
-            $route = self::get($url);
-        }
-
-        if ($mode === AbstractResource::MODE_CREATE) {
-            $route = self::post($url);
-        }
-
-        if ($mode === AbstractResource::MODE_UPDATE) {
-            $route = self::patch(\sprintf('%s/{%s}', $url, $resource->getIdentifierProperty()->getPropertyName()));
-        }
-
-        if ($mode === AbstractResource::MODE_VIEW) {
-            $route = self::get(\sprintf('%s/{%s}', $url, $resource->getIdentifierProperty()->getPropertyName()));
-        }
-
-        if ($route === null) {
-            throw new \InvalidArgumentException(\sprintf('Resource Mode "%s" not supported', $mode));
-        }
-
-        return $route;
     }
 
     /**

--- a/Tests/PhpUnit/Documentation/DocBlock/DocBlockGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/DocBlock/DocBlockGeneratorTest.php
@@ -125,24 +125,18 @@ PHP;
 
 namespace TestNamespace\\Resource;
 
-use apivalk\\apivalk\\Documentation\\Property\\AbstractProperty;
 use apivalk\\apivalk\\Documentation\\Property\\FloatProperty;
 use apivalk\\apivalk\\Documentation\\Property\\StringProperty;
 use apivalk\\apivalk\\Resource\\AbstractResource;
 
 class {$resourceClassName} extends AbstractResource
 {
-    public function getIdentifierProperty(): AbstractProperty
-    {
-        return new StringProperty('thing_uuid', 'Identifier of the thing');
-    }
-
-    public function getBaseUrl(): string { return '/api/v1'; }
     public function getName(): string { return 'thing'; }
     public function excludeFromMode(string \$mode): array { return []; }
 
     protected function init(): void
     {
+        \$this->addProperty(new StringProperty('thing_uuid', 'Identifier of the thing'));
         \$this->addProperty(new StringProperty('name', 'Name of the thing'));
         \$this->addProperty((new FloatProperty('weight'))->setIsRequired(false));
     }
@@ -163,10 +157,16 @@ use apivalk\\apivalk\\Http\\Request\\ApivalkRequestInterface;
 use apivalk\\apivalk\\Http\\Response\\AbstractApivalkResponse;
 use apivalk\\apivalk\\Http\\Response\\Resource\\ResourceListResponse;
 use apivalk\\apivalk\\Http\\Response\\Pagination\\PagePaginationResponse;
+use apivalk\\apivalk\\Router\\Route\\Route;
 use TestNamespace\\Resource\\{$resourceClassName};
 
 class {$controllerClassName} extends AbstractListResourceController
 {
+    public static function getRoute(): Route
+    {
+        return Route::get('/api/v1/things');
+    }
+
     public static function getResourceClass(): string
     {
         return {$resourceClassName}::class;
@@ -208,23 +208,17 @@ PHP;
 
 namespace TestNamespace\\Resource;
 
-use apivalk\\apivalk\\Documentation\\Property\\AbstractProperty;
 use apivalk\\apivalk\\Documentation\\Property\\StringProperty;
 use apivalk\\apivalk\\Resource\\AbstractResource;
 
 class {$resourceClassName} extends AbstractResource
 {
-    public function getIdentifierProperty(): AbstractProperty
-    {
-        return new StringProperty('shared_uuid');
-    }
-
-    public function getBaseUrl(): string { return '/api/v1'; }
     public function getName(): string { return 'shared'; }
     public function excludeFromMode(string \$mode): array { return []; }
 
     protected function init(): void
     {
+        \$this->addProperty(new StringProperty('shared_uuid'));
         \$this->addProperty(new StringProperty('name'));
     }
 }
@@ -248,10 +242,12 @@ use apivalk\\apivalk\\Http\\Request\\ApivalkRequestInterface;
 use apivalk\\apivalk\\Http\\Response\\AbstractApivalkResponse;
 use apivalk\\apivalk\\Http\\Response\\Resource\\ResourceListResponse;
 use apivalk\\apivalk\\Http\\Response\\Pagination\\PagePaginationResponse;
+use apivalk\\apivalk\\Router\\Route\\Route;
 use TestNamespace\\Resource\\{$resourceClassName};
 
 class {$listClassName} extends AbstractListResourceController
 {
+    public static function getRoute(): Route { return Route::get('/api/v1/shareds'); }
     public static function getResourceClass(): string { return {$resourceClassName}::class; }
     public function __invoke(ApivalkRequestInterface \$request): AbstractApivalkResponse
     {
@@ -269,10 +265,16 @@ use apivalk\\apivalk\\Http\\Controller\\Resource\\AbstractViewResourceController
 use apivalk\\apivalk\\Http\\Request\\ApivalkRequestInterface;
 use apivalk\\apivalk\\Http\\Response\\AbstractApivalkResponse;
 use apivalk\\apivalk\\Http\\Response\\Resource\\ResourceViewResponse;
+use apivalk\\apivalk\\Router\\Route\\Route;
+use apivalk\\apivalk\\Documentation\\Property\\StringProperty;
 use TestNamespace\\Resource\\{$resourceClassName};
 
 class {$viewClassName} extends AbstractViewResourceController
 {
+    public static function getRoute(): Route {
+        return Route::get('/api/v1/shareds/{shared_uuid}')
+            ->pathProperty(new StringProperty('shared_uuid', 'Shared UUID'));
+    }
     public static function getResourceClass(): string { return {$resourceClassName}::class; }
     public function __invoke(ApivalkRequestInterface \$request): AbstractApivalkResponse
     {

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/AuthIdentityPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/AuthIdentityPopulationStrategyTest.php
@@ -8,19 +8,16 @@ use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
 use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
 use apivalk\apivalk\Http\Request\Population\Strategy\AuthIdentityPopulationStrategy;
-use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\AuthIdentity\AbstractAuthIdentity;
 use apivalk\apivalk\Security\AuthIdentity\GuestAuthIdentity;
-use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
 use PHPUnit\Framework\TestCase;
 
 class AuthIdentityPopulationStrategyTest extends TestCase
 {
     public function testSetsGuestAuthIdentityByDefault(): void
     {
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
 
         $request = $this->makeRequest();
         $strategy = new AuthIdentityPopulationStrategy();

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/FilteringPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/FilteringPopulationStrategyTest.php
@@ -11,11 +11,9 @@ use apivalk\apivalk\Http\Request\Parameter\Parameter;
 use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
 use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
 use apivalk\apivalk\Http\Request\Population\Strategy\FilteringPopulationStrategy;
-use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\Route\Filter\FilterBag;
 use apivalk\apivalk\Router\Route\Filter\StringFilter;
 use apivalk\apivalk\Router\Route\Route;
-use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
 use PHPUnit\Framework\TestCase;
 
 class FilteringPopulationStrategyTest extends TestCase
@@ -25,8 +23,7 @@ class FilteringPopulationStrategyTest extends TestCase
         $property = new StringProperty('status');
         $filter = StringFilter::equals($property);
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
         $route->filtering([$filter]);
 
         $queryBag = new ParameterBag();
@@ -45,8 +42,7 @@ class FilteringPopulationStrategyTest extends TestCase
         $property = new StringProperty('status');
         $filter = StringFilter::equals($property);
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
         $route->filtering([$filter]);
 
         $queryBag = new ParameterBag();
@@ -65,8 +61,7 @@ class FilteringPopulationStrategyTest extends TestCase
         $property = new StringProperty('status');
         $filter = StringFilter::equals($property);
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
         $route->filtering([$filter]);
 
         $queryBag = new ParameterBag();
@@ -81,8 +76,7 @@ class FilteringPopulationStrategyTest extends TestCase
 
     public function testEmptyRouteFiltersProducesEmptyFilterBag(): void
     {
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
 
         $request = $this->makeRequest(new ParameterBag());
 

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/IpPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/IpPopulationStrategyTest.php
@@ -8,9 +8,7 @@ use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
 use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
 use apivalk\apivalk\Http\Request\Population\Strategy\IpPopulationStrategy;
-use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\Route\Route;
-use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
 use PHPUnit\Framework\TestCase;
 
 class IpPopulationStrategyTest extends TestCase
@@ -27,8 +25,7 @@ class IpPopulationStrategyTest extends TestCase
 
     public function testSetsIpFromServer(): void
     {
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
 
         $request = $this->makeRequest();
         $strategy = new IpPopulationStrategy();

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/MethodPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/MethodPopulationStrategyTest.php
@@ -9,17 +9,14 @@ use apivalk\apivalk\Http\Method\MethodInterface;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
 use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
 use apivalk\apivalk\Http\Request\Population\Strategy\MethodPopulationStrategy;
-use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\Route\Route;
-use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
 use PHPUnit\Framework\TestCase;
 
 class MethodPopulationStrategyTest extends TestCase
 {
     public function testSetsMethodFromRoute(): void
     {
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
 
         $request = $this->makeRequest();
         $strategy = new MethodPopulationStrategy();

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/PaginationPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/PaginationPopulationStrategyTest.php
@@ -11,10 +11,8 @@ use apivalk\apivalk\Http\Request\Pagination\PagePaginator;
 use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
 use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
 use apivalk\apivalk\Http\Request\Population\Strategy\PaginationPopulationStrategy;
-use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
 use apivalk\apivalk\Router\Route\Route;
-use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
 use PHPUnit\Framework\TestCase;
 
 class PaginationPopulationStrategyTest extends TestCase
@@ -31,8 +29,7 @@ class PaginationPopulationStrategyTest extends TestCase
 
     public function testNoPaginationOnRouteLeavesPaginatorNull(): void
     {
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
 
         $request = $this->makeRequest();
         $strategy = new PaginationPopulationStrategy();
@@ -46,8 +43,7 @@ class PaginationPopulationStrategyTest extends TestCase
         $_GET['page'] = '2';
         $_GET['per_page'] = '10';
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
         $route->pagination(new Pagination(Pagination::TYPE_PAGE, 100));
 
         $request = $this->makeRequest();
@@ -62,8 +58,7 @@ class PaginationPopulationStrategyTest extends TestCase
         $_GET['limit'] = '20';
         $_GET['offset'] = '40';
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
         $route->pagination(new Pagination(Pagination::TYPE_OFFSET, 100));
 
         $request = $this->makeRequest();

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/QueryParameterPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/QueryParameterPopulationStrategyTest.php
@@ -10,9 +10,7 @@ use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
 use apivalk\apivalk\Http\Request\Parameter\ParameterBag;
 use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
 use apivalk\apivalk\Http\Request\Population\Strategy\QueryParameterPopulationStrategy;
-use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\Route\Route;
-use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
 use PHPUnit\Framework\TestCase;
 
 class QueryParameterPopulationStrategyTest extends TestCase
@@ -34,8 +32,7 @@ class QueryParameterPopulationStrategyTest extends TestCase
         $doc = new ApivalkRequestDocumentation();
         $doc->addQueryProperty(new StringProperty('search'));
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
 
         $request = $this->makeRequest();
         $strategy = new QueryParameterPopulationStrategy();
@@ -49,8 +46,7 @@ class QueryParameterPopulationStrategyTest extends TestCase
     {
         $_GET['unknown'] = 'foo';
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
 
         $request = $this->makeRequest();
         $strategy = new QueryParameterPopulationStrategy();
@@ -63,8 +59,7 @@ class QueryParameterPopulationStrategyTest extends TestCase
     {
         $_GET['order_by'] = 'name';
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
 
         $request = $this->makeRequest();
         $strategy = new QueryParameterPopulationStrategy();

--- a/Tests/PhpUnit/Http/Request/Population/Strategy/SortingPopulationStrategyTest.php
+++ b/Tests/PhpUnit/Http/Request/Population/Strategy/SortingPopulationStrategyTest.php
@@ -8,11 +8,9 @@ use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
 use apivalk\apivalk\Http\Request\Population\RequestPopulationContext;
 use apivalk\apivalk\Http\Request\Population\Strategy\SortingPopulationStrategy;
-use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Router\Route\Sort\Sort;
 use apivalk\apivalk\Router\Route\Sort\SortBag;
-use apivalk\apivalk\Tests\PhpUnit\Resource\Stub\AnimalResource;
 use PHPUnit\Framework\TestCase;
 
 class SortingPopulationStrategyTest extends TestCase
@@ -29,8 +27,7 @@ class SortingPopulationStrategyTest extends TestCase
 
     public function testPopulatesDefaultSortingsFromRoute(): void
     {
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
         $route->sorting([Sort::asc('name'), Sort::desc('weight')]);
 
         $request = $this->makeRequest();
@@ -48,8 +45,7 @@ class SortingPopulationStrategyTest extends TestCase
     {
         $_GET['order_by'] = '-name';
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
         $route->sorting([Sort::asc('name')]);
 
         $request = $this->makeRequest();
@@ -65,8 +61,7 @@ class SortingPopulationStrategyTest extends TestCase
     {
         $_GET['order_by'] = '+name';
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
 
         $request = $this->makeRequest();
         $strategy = new SortingPopulationStrategy();
@@ -81,8 +76,7 @@ class SortingPopulationStrategyTest extends TestCase
     {
         $_GET['order_by'] = 'name';
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
 
         $request = $this->makeRequest();
         $strategy = new SortingPopulationStrategy();
@@ -97,8 +91,7 @@ class SortingPopulationStrategyTest extends TestCase
     {
         $_GET['order_by'] = '+name,-weight';
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
 
         $request = $this->makeRequest();
         $strategy = new SortingPopulationStrategy();
@@ -115,8 +108,7 @@ class SortingPopulationStrategyTest extends TestCase
     {
         $_GET['order_by'] = '';
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
 
         $request = $this->makeRequest();
         $strategy = new SortingPopulationStrategy();
@@ -127,8 +119,7 @@ class SortingPopulationStrategyTest extends TestCase
 
     public function testNoOrderByLeavesRouteDefaults(): void
     {
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
         $route->sorting([Sort::asc('name')]);
 
         $request = $this->makeRequest();
@@ -142,8 +133,7 @@ class SortingPopulationStrategyTest extends TestCase
     {
         $_GET['order_by'] = '-id';
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
         $route->sorting([Sort::desc('created_at'), Sort::asc('id'), Sort::asc('name')]);
 
         $request = $this->makeRequest();
@@ -163,8 +153,7 @@ class SortingPopulationStrategyTest extends TestCase
     {
         $_GET['order_by'] = '-id';
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
         $route->sorting([Sort::desc('created_at'), Sort::asc('id'), Sort::asc('name')]);
 
         $request = $this->makeRequest();
@@ -181,8 +170,7 @@ class SortingPopulationStrategyTest extends TestCase
     {
         $_GET['order_by'] = '-id,+name';
 
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
         $route->sorting([Sort::desc('created_at'), Sort::asc('id'), Sort::asc('name')]);
 
         $request = $this->makeRequest();
@@ -200,8 +188,7 @@ class SortingPopulationStrategyTest extends TestCase
 
     public function testGetRequestedIsEmptyWhenUserOmitsOrderBy(): void
     {
-        $resource = new AnimalResource();
-        $route = Route::resource($resource, AbstractResource::MODE_LIST);
+        $route = Route::get('/api/v1/animals');
         $route->sorting([Sort::asc('name')]);
 
         $request = $this->makeRequest();

--- a/Tests/PhpUnit/Resource/Stub/AnimalResource.php
+++ b/Tests/PhpUnit/Resource/Stub/AnimalResource.php
@@ -4,23 +4,12 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Resource\Stub;
 
-use apivalk\apivalk\Documentation\Property\AbstractProperty;
 use apivalk\apivalk\Documentation\Property\FloatProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Resource\AbstractResource;
 
 class AnimalResource extends AbstractResource
 {
-    public function getIdentifierProperty(): AbstractProperty
-    {
-        return new StringProperty('animal_uuid', 'Unique identifier of the animal');
-    }
-
-    public function getBaseUrl(): string
-    {
-        return '/api/v1';
-    }
-
     public function getName(): string
     {
         return 'animal';
@@ -37,6 +26,7 @@ class AnimalResource extends AbstractResource
 
     protected function init(): void
     {
+        $this->addProperty(new StringProperty('animal_uuid', 'Unique identifier of the animal'));
         $this->addProperty(new StringProperty('name', 'Name of the animal'));
         $this->addProperty(new StringProperty('type', 'Type of the animal'));
         $this->addProperty((new FloatProperty('weight', 'Weight of the animal in kg'))->setIsRequired(false));

--- a/Tests/PhpUnit/Resource/Stub/CreateAnimalController.php
+++ b/Tests/PhpUnit/Resource/Stub/CreateAnimalController.php
@@ -8,9 +8,17 @@ use apivalk\apivalk\Http\Controller\Resource\AbstractCreateResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceCreatedResponse;
+use apivalk\apivalk\Router\Route\Route;
 
 class CreateAnimalController extends AbstractCreateResourceController
 {
+    public static function getRoute(): Route
+    {
+        return Route::post('/api/v1/animals')
+            ->description('Create animal')
+            ->tags(self::getEmptyResource()->tags());
+    }
+
     public static function getResourceClass(): string
     {
         return AnimalResource::class;
@@ -18,6 +26,6 @@ class CreateAnimalController extends AbstractCreateResourceController
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
-        return new ResourceCreatedResponse($this->getResource($request));
+        return new ResourceCreatedResponse(AnimalResource::byRequest($request));
     }
 }

--- a/Tests/PhpUnit/Resource/Stub/DeleteAnimalController.php
+++ b/Tests/PhpUnit/Resource/Stub/DeleteAnimalController.php
@@ -4,13 +4,23 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Resource\Stub;
 
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Controller\Resource\AbstractDeleteResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\DeletedApivalkResponse;
+use apivalk\apivalk\Router\Route\Route;
 
 class DeleteAnimalController extends AbstractDeleteResourceController
 {
+    public static function getRoute(): Route
+    {
+        return Route::delete('/api/v1/animals/{animal_uuid}')
+            ->pathProperty(new StringProperty('animal_uuid', 'Unique identifier of the animal'))
+            ->description('Delete animal')
+            ->tags(self::getEmptyResource()->tags());
+    }
+
     public static function getResourceClass(): string
     {
         return AnimalResource::class;

--- a/Tests/PhpUnit/Resource/Stub/ListAnimalsController.php
+++ b/Tests/PhpUnit/Resource/Stub/ListAnimalsController.php
@@ -10,17 +10,25 @@ use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\Pagination\PagePaginationResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceListResponse;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
+use apivalk\apivalk\Router\Route\Route;
 
 class ListAnimalsController extends AbstractListResourceController
 {
+    public static function getRoute(): Route
+    {
+        $resource = self::getEmptyResource();
+
+        return Route::get('/api/v1/animals')
+            ->description('List animals')
+            ->tags($resource->tags())
+            ->filtering($resource->availableFilters())
+            ->sorting($resource->availableSortings())
+            ->pagination(Pagination::page()->setMaxLimit(25));
+    }
+
     public static function getResourceClass(): string
     {
         return AnimalResource::class;
-    }
-
-    public static function pagination(): ?Pagination
-    {
-        return Pagination::page()->setMaxLimit(25);
     }
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse

--- a/Tests/PhpUnit/Resource/Stub/UpdateAnimalController.php
+++ b/Tests/PhpUnit/Resource/Stub/UpdateAnimalController.php
@@ -4,13 +4,23 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Resource\Stub;
 
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Controller\Resource\AbstractUpdateResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceUpdatedResponse;
+use apivalk\apivalk\Router\Route\Route;
 
 class UpdateAnimalController extends AbstractUpdateResourceController
 {
+    public static function getRoute(): Route
+    {
+        return Route::patch('/api/v1/animals/{animal_uuid}')
+            ->pathProperty(new StringProperty('animal_uuid', 'Unique identifier of the animal'))
+            ->description('Update animal')
+            ->tags(self::getEmptyResource()->tags());
+    }
+
     public static function getResourceClass(): string
     {
         return AnimalResource::class;
@@ -18,7 +28,8 @@ class UpdateAnimalController extends AbstractUpdateResourceController
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
-        $animal = $this->getResource($request);
+        $animal = AnimalResource::byRequest($request);
+        $animal->animal_uuid = $request->path()->get('animal_uuid')->getValue();
 
         return new ResourceUpdatedResponse($animal);
     }

--- a/Tests/PhpUnit/Resource/Stub/ViewAnimalController.php
+++ b/Tests/PhpUnit/Resource/Stub/ViewAnimalController.php
@@ -4,13 +4,23 @@ declare(strict_types=1);
 
 namespace apivalk\apivalk\Tests\PhpUnit\Resource\Stub;
 
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Controller\Resource\AbstractViewResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceViewResponse;
+use apivalk\apivalk\Router\Route\Route;
 
 class ViewAnimalController extends AbstractViewResourceController
 {
+    public static function getRoute(): Route
+    {
+        return Route::get('/api/v1/animals/{animal_uuid}')
+            ->pathProperty(new StringProperty('animal_uuid', 'Unique identifier of the animal'))
+            ->description('Get animal')
+            ->tags(self::getEmptyResource()->tags());
+    }
+
     public static function getResourceClass(): string
     {
         return AnimalResource::class;
@@ -18,7 +28,9 @@ class ViewAnimalController extends AbstractViewResourceController
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
-        $animal = AnimalResource::byRequest($request);
+        $animal = AnimalResource::byArray([
+            'animal_uuid' => $request->path()->get('animal_uuid')->getValue(),
+        ]);
 
         return new ResourceViewResponse($animal);
     }

--- a/Tests/PhpUnit/Resource/old/Documentation/ResourceDocumentationFactoryTest.php
+++ b/Tests/PhpUnit/Resource/old/Documentation/ResourceDocumentationFactoryTest.php
@@ -76,7 +76,6 @@ class RequestDocumentationFactoryTest extends TestCase
         );
 
         $bodyPropertyNames = array_keys($doc->getBodyProperties());
-        $pathPropertyNames = array_keys($doc->getPathProperties());
 
         // All body properties present but not required
         $this->assertContains('name', $bodyPropertyNames);
@@ -90,8 +89,8 @@ class RequestDocumentationFactoryTest extends TestCase
             );
         }
 
-        // Identifier as path property
-        $this->assertContains('animal_uuid', $pathPropertyNames);
+        // Path properties come from the route's pathProperty() declarations, not from the resource
+        $this->assertEmpty($doc->getPathProperties());
     }
 
     public function testCreateRequestDocumentationViewMode(): void
@@ -102,11 +101,9 @@ class RequestDocumentationFactoryTest extends TestCase
             AbstractResource::MODE_VIEW
         );
 
-        $bodyPropertyNames = array_keys($doc->getBodyProperties());
-        $pathPropertyNames = array_keys($doc->getPathProperties());
-
-        $this->assertEmpty($bodyPropertyNames);
-        $this->assertContains('animal_uuid', $pathPropertyNames);
+        // View mode has no body and no path properties; path params come from the route
+        $this->assertEmpty($doc->getBodyProperties());
+        $this->assertEmpty($doc->getPathProperties());
     }
 
     public function testCreateRequestDocumentationDeleteMode(): void
@@ -117,11 +114,9 @@ class RequestDocumentationFactoryTest extends TestCase
             AbstractResource::MODE_DELETE
         );
 
-        $bodyPropertyNames = array_keys($doc->getBodyProperties());
-        $pathPropertyNames = array_keys($doc->getPathProperties());
-
-        $this->assertEmpty($bodyPropertyNames);
-        $this->assertContains('animal_uuid', $pathPropertyNames);
+        // Delete mode has no body and no path properties; path params come from the route
+        $this->assertEmpty($doc->getBodyProperties());
+        $this->assertEmpty($doc->getPathProperties());
     }
 
     public function testCreateRequestDocumentationListMode(): void

--- a/docs/how-to/resource-crud.mdx
+++ b/docs/how-to/resource-crud.mdx
@@ -31,7 +31,6 @@ declare(strict_types=1);
 namespace App\Resource;
 
 use apivalk\apivalk\Documentation\OpenAPI\Object\TagObject;
-use apivalk\apivalk\Documentation\Property\AbstractProperty;
 use apivalk\apivalk\Documentation\Property\EnumProperty;
 use apivalk\apivalk\Documentation\Property\FloatProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
@@ -42,16 +41,6 @@ use apivalk\apivalk\Router\Route\Sort\Sort;
 
 class AnimalResource extends AbstractResource
 {
-    public function getIdentifierProperty(): AbstractProperty
-    {
-        return new StringProperty('animal_uuid', 'Unique identifier of the animal');
-    }
-
-    public function getBaseUrl(): string
-    {
-        return '/api/v1';
-    }
-
     public function getName(): string
     {
         return 'animal';
@@ -77,9 +66,12 @@ class AnimalResource extends AbstractResource
 
     public function excludeFromMode(string $mode): array
     {
-        // Hide heavy field from list responses to keep payloads small
+        if ($mode === self::MODE_CREATE) {
+            return ['animal_uuid']; // server generates the identifier
+        }
+
         if ($mode === self::MODE_LIST) {
-            return ['weight'];
+            return ['weight']; // keep list payloads small
         }
 
         return [];
@@ -87,6 +79,7 @@ class AnimalResource extends AbstractResource
 
     protected function init(): void
     {
+        $this->addProperty(new StringProperty('animal_uuid', 'Unique identifier of the animal'));
         $this->addProperty(new StringProperty('name', 'Animal name'));
         $this->addProperty(new EnumProperty('status', 'Lifecycle status', ['active', 'archived']));
         $this->addProperty((new FloatProperty('weight', 'Weight in kg'))->setIsRequired(false));
@@ -94,11 +87,11 @@ class AnimalResource extends AbstractResource
 }
 ```
 
-`Route::resource()` uses `getBaseUrl()` + `getPluralName()` to build URLs: `/api/v1/animals` and `/api/v1/animals/{animal_uuid}`.
+The identifier (`animal_uuid`) is a regular property declared first by convention. Excluding it from `MODE_CREATE` removes it from the create request body documentation — the server generates it.
 
 ## 2. Wire the five controllers
 
-Each controller is a thin subclass. The base class fills in the route, request class, response classes, and OpenAPI schema.
+Each controller is a thin subclass. You implement `getResourceClass()`, `getRoute()`, and `__invoke()`.
 
 ### Create
 
@@ -113,6 +106,7 @@ use apivalk\apivalk\Http\Controller\Resource\AbstractCreateResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceCreatedResponse;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 use App\Domain\Animal\AnimalRepository;
 use App\Resource\AnimalResource;
@@ -135,14 +129,17 @@ final class CreateAnimalController extends AbstractCreateResourceController
         return AnimalResource::class;
     }
 
-    public static function routeAuthorization(): ?RouteAuthorization
+    public static function getRoute(): Route
     {
-        return new RouteAuthorization('BearerAuth', ['animal'], ['animal:create']);
+        return Route::post('/api/v1/animals')
+            ->description('Create animal')
+            ->tags(self::getEmptyResource()->tags())
+            ->routeAuthorization(new RouteAuthorization('BearerAuth', ['animal'], ['animal:create']));
     }
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
-        $animal = $this->getResource($request); // AnimalResource hydrated from body
+        $animal = AnimalResource::byRequest($request); // hydrated from validated body
         $animal->animal_uuid = $this->repository->persist($animal);
 
         return new ResourceCreatedResponse($animal);
@@ -159,11 +156,13 @@ declare(strict_types=1);
 
 namespace App\Http\Controller\Animal;
 
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Controller\Resource\AbstractViewResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\NotFoundApivalkResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceViewResponse;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 use App\Domain\Animal\AnimalRepository;
 use App\Resource\AnimalResource;
@@ -186,14 +185,20 @@ final class ViewAnimalController extends AbstractViewResourceController
         return AnimalResource::class;
     }
 
-    public static function routeAuthorization(): ?RouteAuthorization
+    public static function getRoute(): Route
     {
-        return new RouteAuthorization('BearerAuth', ['animal'], ['animal:read']);
+        return Route::get('/api/v1/animals/{animal_uuid}')
+            ->pathProperty(new StringProperty('animal_uuid', 'Animal UUID'))
+            ->description('Get animal')
+            ->tags(self::getEmptyResource()->tags())
+            ->routeAuthorization(new RouteAuthorization('BearerAuth', ['animal'], ['animal:read']));
     }
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
-        $row = $this->repository->findByUuid($this->getResourceIdentifier($request));
+        $uuid = $request->path()->get('animal_uuid')->getValue();
+        $row  = $this->repository->findByUuid($uuid);
+
         if ($row === null) {
             return new NotFoundApivalkResponse();
         }
@@ -212,10 +217,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controller\Animal;
 
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Controller\Resource\AbstractUpdateResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceUpdatedResponse;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 use App\Domain\Animal\AnimalRepository;
 use App\Resource\AnimalResource;
@@ -238,14 +245,20 @@ final class UpdateAnimalController extends AbstractUpdateResourceController
         return AnimalResource::class;
     }
 
-    public static function routeAuthorization(): ?RouteAuthorization
+    public static function getRoute(): Route
     {
-        return new RouteAuthorization('BearerAuth', ['animal'], ['animal:update']);
+        return Route::patch('/api/v1/animals/{animal_uuid}')
+            ->pathProperty(new StringProperty('animal_uuid', 'Animal UUID'))
+            ->description('Update animal')
+            ->tags(self::getEmptyResource()->tags())
+            ->routeAuthorization(new RouteAuthorization('BearerAuth', ['animal'], ['animal:update']));
     }
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
-        $animal = $this->getResource($request); // body + path identifier merged
+        $animal = AnimalResource::byRequest($request); // body fields only
+        $animal->animal_uuid = $request->path()->get('animal_uuid')->getValue();
+
         $this->repository->update($animal);
 
         return new ResourceUpdatedResponse($animal);
@@ -262,10 +275,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controller\Animal;
 
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Controller\Resource\AbstractDeleteResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\DeletedApivalkResponse;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 use App\Domain\Animal\AnimalRepository;
 use App\Resource\AnimalResource;
@@ -288,14 +303,20 @@ final class DeleteAnimalController extends AbstractDeleteResourceController
         return AnimalResource::class;
     }
 
-    public static function routeAuthorization(): ?RouteAuthorization
+    public static function getRoute(): Route
     {
-        return new RouteAuthorization('BearerAuth', ['animal'], ['animal:delete']);
+        return Route::delete('/api/v1/animals/{animal_uuid}')
+            ->pathProperty(new StringProperty('animal_uuid', 'Animal UUID'))
+            ->description('Delete animal')
+            ->tags(self::getEmptyResource()->tags())
+            ->routeAuthorization(new RouteAuthorization('BearerAuth', ['animal'], ['animal:delete']));
     }
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
-        $this->repository->delete($this->getResourceIdentifier($request));
+        $this->repository->delete(
+            $request->path()->get('animal_uuid')->getValue()
+        );
 
         return new DeletedApivalkResponse();
     }
@@ -317,6 +338,7 @@ use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\Pagination\PagePaginationResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceListResponse;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
+use apivalk\apivalk\Router\Route\Route;
 use apivalk\apivalk\Security\RouteAuthorization;
 use App\Domain\Animal\AnimalRepository;
 use App\Resource\AnimalResource;
@@ -339,14 +361,17 @@ final class ListAnimalController extends AbstractListResourceController
         return AnimalResource::class;
     }
 
-    public static function pagination(): ?Pagination
+    public static function getRoute(): Route
     {
-        return Pagination::page()->setMaxLimit(50);
-    }
+        $resource = self::getEmptyResource();
 
-    public static function routeAuthorization(): ?RouteAuthorization
-    {
-        return new RouteAuthorization('BearerAuth', ['animal'], ['animal:read']);
+        return Route::get('/api/v1/animals')
+            ->description('List animals')
+            ->tags($resource->tags())
+            ->filtering($resource->availableFilters())
+            ->sorting($resource->availableSortings())
+            ->pagination(Pagination::page()->setMaxLimit(50))
+            ->routeAuthorization(new RouteAuthorization('BearerAuth', ['animal'], ['animal:read']));
     }
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
@@ -380,11 +405,37 @@ final class ListAnimalController extends AbstractListResourceController
 
 ## What the framework handles for you
 
-- **URL + verb per mode** — `Route::resource()` picks `POST /api/v1/animals`, `GET /api/v1/animals/{animal_uuid}`, `PATCH` for update, `DELETE` for delete, `GET` collection for list. You can't accidentally violate REST conventions.
 - **Body / path / filter / sort validation** — `RequestValidationMiddleware` validates against the runtime documentation derived from `AnimalResource`. Unknown `?order_by=hacked_field` → 422 before your controller runs.
 - **Response envelope** — `Resource*Response` classes emit the standard `{"data": ...}` (and `"pagination"` for list). No `toArray()` to write.
-- **Per-mode field visibility** — `excludeFromMode()` hides `weight` from the list endpoint; the rest of the endpoints still see it.
+- **Per-mode field visibility** — `excludeFromMode()` hides `animal_uuid` from the create body and `weight` from list responses; the rest of the endpoints still see both.
 - **OpenAPI** — all five operations are generated from the single resource. Add a field to `AnimalResource::init()` and every operation updates at once.
+
+## Nested resources
+
+Because `getRoute()` is fully explicit, nested URLs require no special setup — add more path segments and declare each one via `->pathProperty()`:
+
+```php
+// GET /api/v1/animals/{animal_uuid}/kids/{kid_uuid}
+public static function getRoute(): Route
+{
+    return Route::get('/api/v1/animals/{animal_uuid}/kids/{kid_uuid}')
+        ->pathProperty(new StringProperty('animal_uuid', 'Parent animal UUID'))
+        ->pathProperty(new StringProperty('kid_uuid', 'Kid UUID'))
+        ->description('Get animal kid')
+        ->tags(self::getEmptyResource()->tags())
+        ->routeAuthorization(new RouteAuthorization('BearerAuth', ['animal'], ['animal:read']));
+}
+
+public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+{
+    $animalUuid = $request->path()->get('animal_uuid')->getValue();
+    $kidUuid    = $request->path()->get('kid_uuid')->getValue();
+
+    // ...
+}
+```
+
+Both path parameters are validated, documented in OpenAPI, and typed in the path bag.
 
 ## Optional: IDE autocomplete via the DocBlock generator
 

--- a/docs/resources/controllers.mdx
+++ b/docs/resources/controllers.mdx
@@ -5,138 +5,243 @@ description: "Five abstract controllers — Create, View, Update, Delete, List �
 
 ## The Five Controllers
 
-| Base class | HTTP | Path | Response (default) |
-|---|---|---|---|
-| `AbstractCreateResourceController` | `POST` | `/{base}/{plural}` | `ResourceCreatedResponse` (201) |
-| `AbstractViewResourceController` | `GET` | `/{base}/{plural}/{id}` | `ResourceViewResponse` (200) |
-| `AbstractUpdateResourceController` | `PATCH` | `/{base}/{plural}/{id}` | `ResourceUpdatedResponse` (200) |
-| `AbstractDeleteResourceController` | `DELETE` | `/{base}/{plural}/{id}` | `ResourceDeletedResponse` (200) |
-| `AbstractListResourceController` | `GET` | `/{base}/{plural}` | `ResourceListResponse` (200) |
+| Base class | HTTP | Default response |
+|---|---|---|
+| `AbstractCreateResourceController` | `POST` | `ResourceCreatedResponse` (201) |
+| `AbstractViewResourceController` | `GET` | `ResourceViewResponse` (200) |
+| `AbstractUpdateResourceController` | `PATCH` | `ResourceUpdatedResponse` (200) |
+| `AbstractDeleteResourceController` | `DELETE` | `DeletedApivalkResponse` (200) |
+| `AbstractListResourceController` | `GET` | `ResourceListResponse` (200) |
 
-`{base}` comes from `$resource->getBaseUrl()`, `{plural}` from `$resource->getPluralName()`, `{id}` from `$resource->getIdentifierProperty()->getPropertyName()`.
-
-All five are generic over the resource type: `@template TResource of AbstractResource`. When you subclass, declare your concrete resource so static analysis propagates the type through.
+All five are generic over the resource type: `@template TResource of AbstractResource`. Declare the concrete type via the `@extends` annotation so static analysis and IDE autocompletion work.
 
 ## What You Write
 
-A resource controller is **one small class** — a `getResourceClass()` method plus your business logic. The `@extends Abstract...<YourResource>` annotation is what gives you IDE autocompletion and static analysis on the typed helpers the base class exposes.
+Every resource controller implements three things:
 
-### Example: Create
+1. `getResourceClass(): string` — return your resource class name.
+2. `getRoute(): Route` — declare the URL, method, description, tags, auth, and (for list) filters/sortings/pagination.
+3. `__invoke(ApivalkRequestInterface $request): AbstractApivalkResponse` — your business logic.
 
-`AbstractCreateResourceController` provides `$this->getResource($request)` which builds a typed resource instance from the validated request body (and path, for `Update`). Because of the `@template TResource`, `$customer` below is known to be a `CustomerResource` — your IDE and PHPStan both know it.
+The base class provides `getRequestClass()`, `getResponseClasses()`, and `getEmptyResource()`. Everything else is explicit in your controller.
+
+## Examples
+
+### Create
 
 ```php
-namespace App\Http\Controller\Customer;
+namespace App\Http\Controller\Animal;
 
 use apivalk\apivalk\Http\Controller\Resource\AbstractCreateResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceCreatedResponse;
-use App\Resource\CustomerResource;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Security\RouteAuthorization;
+use App\Domain\Animal\AnimalRepository;
+use App\Resource\AnimalResource;
 
 /**
- * @extends AbstractCreateResourceController<CustomerResource>
+ * @extends AbstractCreateResourceController<AnimalResource>
  */
-final class CreateCustomerController extends AbstractCreateResourceController
+final class CreateAnimalController extends AbstractCreateResourceController
 {
+    /** @var AnimalRepository */
+    private $repository;
+
+    public function __construct(AnimalRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
     public static function getResourceClass(): string
     {
-        return CustomerResource::class;
+        return AnimalResource::class;
+    }
+
+    public static function getRoute(): Route
+    {
+        return Route::post('/api/v1/animals')
+            ->description('Create animal')
+            ->tags(self::getEmptyResource()->tags())
+            ->routeAuthorization(new RouteAuthorization('BearerAuth', ['animal'], ['animal:create']));
     }
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
-        // CustomerResource (typed via the template parameter), built from
-        // the validated body + identifier path param. No manual property copying.
-        $customer = $this->getResource($request);
+        $animal = AnimalResource::byRequest($request); // hydrated from validated body
+        $animal->animal_uuid = $this->repository->persist($animal);
 
-        // ... persist $customer via your repository here ...
-
-        return new ResourceCreatedResponse($customer);
+        return new ResourceCreatedResponse($animal);
     }
 }
 ```
 
-That's the full controller. `AbstractUpdateResourceController` has the same `getResource($request)` helper; `AbstractView/Delete/ListResourceController` don't need it since they don't hydrate from a body.
-
-### Example: Update
-
-`AbstractUpdateResourceController` gives you **both** helpers: `$this->getResource($request)` hydrates a typed resource from the validated body **and** the identifier in the path, and `$this->getResourceIdentifier($request)` returns the raw identifier on its own (useful if you need to look up the existing row first, merge, and persist).
+### View
 
 ```php
-namespace App\Http\Controller\Customer;
+namespace App\Http\Controller\Animal;
 
+use apivalk\apivalk\Documentation\Property\StringProperty;
+use apivalk\apivalk\Http\Controller\Resource\AbstractViewResourceController;
+use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
+use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
+use apivalk\apivalk\Http\Response\NotFoundApivalkResponse;
+use apivalk\apivalk\Http\Response\Resource\ResourceViewResponse;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Security\RouteAuthorization;
+use App\Domain\Animal\AnimalRepository;
+use App\Resource\AnimalResource;
+
+/**
+ * @extends AbstractViewResourceController<AnimalResource>
+ */
+final class ViewAnimalController extends AbstractViewResourceController
+{
+    /** @var AnimalRepository */
+    private $repository;
+
+    public function __construct(AnimalRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public static function getResourceClass(): string
+    {
+        return AnimalResource::class;
+    }
+
+    public static function getRoute(): Route
+    {
+        return Route::get('/api/v1/animals/{animal_uuid}')
+            ->pathProperty(new StringProperty('animal_uuid', 'Animal UUID'))
+            ->description('Get animal')
+            ->tags(self::getEmptyResource()->tags())
+            ->routeAuthorization(new RouteAuthorization('BearerAuth', ['animal'], ['animal:read']));
+    }
+
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        $uuid = $request->path()->get('animal_uuid')->getValue();
+        $row  = $this->repository->findByUuid($uuid);
+
+        if ($row === null) {
+            return new NotFoundApivalkResponse();
+        }
+
+        return new ResourceViewResponse(AnimalResource::byArray($row));
+    }
+}
+```
+
+### Update
+
+```php
+namespace App\Http\Controller\Animal;
+
+use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Controller\Resource\AbstractUpdateResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceUpdatedResponse;
-use App\Resource\CustomerResource;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Security\RouteAuthorization;
+use App\Domain\Animal\AnimalRepository;
+use App\Resource\AnimalResource;
 
 /**
- * @extends AbstractUpdateResourceController<CustomerResource>
+ * @extends AbstractUpdateResourceController<AnimalResource>
  */
-final class UpdateCustomerController extends AbstractUpdateResourceController
+final class UpdateAnimalController extends AbstractUpdateResourceController
 {
+    /** @var AnimalRepository */
+    private $repository;
+
+    public function __construct(AnimalRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
     public static function getResourceClass(): string
     {
-        return CustomerResource::class;
+        return AnimalResource::class;
+    }
+
+    public static function getRoute(): Route
+    {
+        return Route::patch('/api/v1/animals/{animal_uuid}')
+            ->pathProperty(new StringProperty('animal_uuid', 'Animal UUID'))
+            ->description('Update animal')
+            ->tags(self::getEmptyResource()->tags())
+            ->routeAuthorization(new RouteAuthorization('BearerAuth', ['animal'], ['animal:update']));
     }
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
-        // CustomerResource with path id + body fields already merged in.
-        $customer = $this->getResource($request);
+        $animal = AnimalResource::byRequest($request); // body fields only
+        $animal->animal_uuid = $request->path()->get('animal_uuid')->getValue();
 
-        // ... persist updates via your repository here ...
+        $this->repository->update($animal);
 
-        return new ResourceUpdatedResponse($customer);
+        return new ResourceUpdatedResponse($animal);
     }
 }
 ```
 
-### Example: View
-
-`AbstractView/Delete/UpdateResourceController` expose `$this->getResourceIdentifier($request)` — a typed convenience for pulling the identifier path parameter (defined by `$resource->getIdentifierProperty()`) out of the request. It throws `InvalidArgumentException` if the parameter is missing, so the validation middleware has already ensured it's present by the time you reach `__invoke()`.
+### Delete
 
 ```php
-namespace App\Http\Controller\Customer;
+namespace App\Http\Controller\Animal;
 
-use apivalk\apivalk\Http\Controller\Resource\AbstractViewResourceController;
+use apivalk\apivalk\Documentation\Property\StringProperty;
+use apivalk\apivalk\Http\Controller\Resource\AbstractDeleteResourceController;
 use apivalk\apivalk\Http\Request\ApivalkRequestInterface;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
-use apivalk\apivalk\Http\Response\Resource\ResourceViewResponse;
-use App\Resource\CustomerResource;
+use apivalk\apivalk\Http\Response\DeletedApivalkResponse;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Security\RouteAuthorization;
+use App\Domain\Animal\AnimalRepository;
+use App\Resource\AnimalResource;
 
 /**
- * @extends AbstractViewResourceController<CustomerResource>
+ * @extends AbstractDeleteResourceController<AnimalResource>
  */
-final class ViewCustomerController extends AbstractViewResourceController
+final class DeleteAnimalController extends AbstractDeleteResourceController
 {
+    /** @var AnimalRepository */
+    private $repository;
+
+    public function __construct(AnimalRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
     public static function getResourceClass(): string
     {
-        return CustomerResource::class;
+        return AnimalResource::class;
+    }
+
+    public static function getRoute(): Route
+    {
+        return Route::delete('/api/v1/animals/{animal_uuid}')
+            ->pathProperty(new StringProperty('animal_uuid', 'Animal UUID'))
+            ->description('Delete animal')
+            ->tags(self::getEmptyResource()->tags())
+            ->routeAuthorization(new RouteAuthorization('BearerAuth', ['animal'], ['animal:delete']));
     }
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
-        $customerUuid = $this->getResourceIdentifier($request);
+        $this->repository->delete(
+            $request->path()->get('animal_uuid')->getValue()
+        );
 
-        // ... fetch the row from your repository here ...
-        $customer = CustomerResource::byArray([
-            'uuid'       => $customerUuid,
-            'first_name' => 'John',
-            'last_name'  => 'Doe',
-            'status'     => 'active',
-        ]);
-
-        return new ResourceViewResponse($customer);
+        return new DeletedApivalkResponse();
     }
 }
 ```
 
-`AbstractDeleteResourceController` follows the same pattern — call `$this->getResourceIdentifier($request)`, delete the row, return a `ResourceDeletedResponse`.
-
-### Example: List
+### List
 
 ```php
 namespace App\Http\Controller\Animal;
@@ -147,6 +252,9 @@ use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 use apivalk\apivalk\Http\Response\Pagination\PagePaginationResponse;
 use apivalk\apivalk\Http\Response\Resource\ResourceListResponse;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
+use apivalk\apivalk\Router\Route\Route;
+use apivalk\apivalk\Security\RouteAuthorization;
+use App\Domain\Animal\AnimalRepository;
 use App\Resource\AnimalResource;
 
 /**
@@ -154,68 +262,113 @@ use App\Resource\AnimalResource;
  */
 final class ListAnimalController extends AbstractListResourceController
 {
+    /** @var AnimalRepository */
+    private $repository;
+
+    public function __construct(AnimalRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
     public static function getResourceClass(): string
     {
         return AnimalResource::class;
     }
 
-    public static function pagination(): ?Pagination
+    public static function getRoute(): Route
     {
-        return new Pagination(Pagination::TYPE_PAGE, 100);
+        $resource = self::getEmptyResource();
+
+        return Route::get('/api/v1/animals')
+            ->description('List animals')
+            ->tags($resource->tags())
+            ->filtering($resource->availableFilters())
+            ->sorting($resource->availableSortings())
+            ->pagination(Pagination::page()->setMaxLimit(50))
+            ->routeAuthorization(new RouteAuthorization('BearerAuth', ['animal'], ['animal:read']));
     }
 
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
         $paginator = $request->paginator();
+        $filters   = $request->filtering();
+        $sorting   = $request->sorting();
 
-        // $request->filtering()->status, $request->sorting() etc. are already typed
-        $animals = $this->repository->findAll(
-            $request->filtering(),
-            $request->sorting(),
-            $paginator->getLimit(),
-            ($paginator->getPage() - 1) * $paginator->getLimit()
-        );
+        $rows  = $this->repository->findPage($filters, $sorting, $paginator);
+        $total = $this->repository->countForFilters($filters);
+
+        $resources = [];
+        foreach ($rows as $row) {
+            $resources[] = AnimalResource::byArray($row);
+        }
+
+        $totalPages = (int)\ceil($total / $paginator->getLimit());
 
         return new ResourceListResponse(
-            $animals,
+            $resources,
             new PagePaginationResponse(
                 $paginator->getPage(),
                 $paginator->getLimit(),
-                /* hasMore */ true
+                $paginator->getPage() < $totalPages,
+                $totalPages
             )
         );
     }
 }
 ```
 
-The five things the base class handles for you:
+## Nested Resources
 
-1. `getRoute()` — built via `Route::resource($this->getEmptyResource(), static::getMode())`, wired with the resource's filters / sortings / pagination hook.
-2. `getRequestClass()` — returns `ResourceRequest::class` (a shared, empty request class).
-3. `getResponseClasses()` — the mode-specific response + standard error responses.
-4. `getMode()` — the constant for Create / View / Update / Delete / List.
-5. `getDescription()` — e.g. `"Create animal"`, `"List animals"`.
+Because `getRoute()` is fully explicit, nested URLs are straightforward — add more path segments and declare each path parameter:
 
-## What You Can Override
+```php
+/**
+ * GET /api/v1/users/{user_uuid}/authenticators/{authenticator_uuid}
+ *
+ * @extends AbstractViewResourceController<AuthenticatorResource>
+ */
+final class ViewUserAuthenticatorController extends AbstractViewResourceController
+{
+    public static function getResourceClass(): string
+    {
+        return AuthenticatorResource::class;
+    }
 
-- `pagination(): ?Pagination` — on `AbstractListResourceController`. Default `null` (no pagination).
-- `routeAuthorization(): ?RouteAuthorization` — declare required scopes/permissions.
-- `rateLimit(): ?RateLimitInterface` — per-endpoint rate limit.
-- `getDescription(): string` — override the auto-generated description if needed.
-- `configureRoute(Route $route): void` — for exotic tweaks. `AbstractListResourceController` uses this internally to wire filters/sortings/pagination; if you override it on `List`, call back into the parent or re-wire manually.
+    public static function getRoute(): Route
+    {
+        return Route::get('/api/v1/users/{user_uuid}/authenticators/{authenticator_uuid}')
+            ->pathProperty(new StringProperty('user_uuid', 'User UUID'))
+            ->pathProperty(new StringProperty('authenticator_uuid', 'Authenticator UUID'))
+            ->description('Get user authenticator')
+            ->tags(self::getEmptyResource()->tags())
+            ->routeAuthorization(new RouteAuthorization('BearerAuth', ['user'], ['user:read']));
+    }
 
-## The Shared `ResourceRequest`
+    public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
+    {
+        $userUuid          = $request->path()->get('user_uuid')->getValue();
+        $authenticatorUuid = $request->path()->get('authenticator_uuid')->getValue();
 
-All resource controllers return `ResourceRequest::class` from `getRequestClass()`. This is intentional: the runtime documentation (body fields for create/update, path id for view/update/delete, filters/sortings/pagination for list) is built from the **resource declaration**, not from per-mode request classes. You never need to author a resource request class yourself.
+        $row = $this->repository->findForUser($userUuid, $authenticatorUuid);
 
-The [docblock generator](/documentation/docblock-generator#resource-docblock-generation) can emit an optional per-resource `AnimalListRequest` subclass purely for IDE autocompletion — that file only carries `@method` annotations, no runtime behavior.
+        if ($row === null) {
+            return new NotFoundApivalkResponse();
+        }
 
-## Registering Controllers
+        return new ResourceViewResponse(AuthenticatorResource::byArray($row));
+    }
+}
+```
 
-Resource controllers are ordinary controllers — the `ClassLocator` finds them automatically during route cache building. No manual registration.
+The same pattern extends to any depth. Each `->pathProperty()` call documents the parameter in OpenAPI and registers it for validation.
+
+## What the Base Class Provides
+
+- `getRequestClass()` — returns `ResourceRequest::class` (a shared, empty request class; no per-endpoint request class needed).
+- `getResponseClasses()` — the mode-appropriate success response + `BadRequestApivalkResponse` + `ForbiddenApivalkResponse`.
+- `getEmptyResource()` — instantiates the resource class returned by `getResourceClass()`, useful inside `getRoute()`.
 
 ## Related
 
 - [Defining a Resource](/resources/resource)
 - [Resource Responses](/resources/responses)
-- [Route::resource()](/routing/route#resource-routes)

--- a/docs/resources/index.mdx
+++ b/docs/resources/index.mdx
@@ -9,13 +9,12 @@ description: "Resources are Apivalk's declarative model for CRUD endpoints. You 
 
 In Apivalk, a **resource** is a concrete subclass of `AbstractResource` that describes one domain entity:
 
-- its **identifier property** (e.g. `animal_uuid`);
-- its **data properties** (name, type, weight, ...);
-- which properties are **excluded from a given mode** (e.g. hide `password` from list responses);
+- its **properties** — including the identifier, declared as a regular property in `init()`;
+- which properties are **excluded from a given mode** (e.g. hide the identifier from create request bodies, hide `weight` from list responses);
 - the **filters** and **sortings** list endpoints expose;
 - the OpenAPI **tags** for grouping.
 
-One resource declaration powers five controllers — Create, View, Update, Delete, List — and the matching response envelopes. The framework derives URLs, request validation, response shapes, and OpenAPI documentation from that single source of truth.
+One resource declaration powers five controllers — Create, View, Update, Delete, List — and the matching response envelopes. The framework derives request validation, response shapes, and OpenAPI documentation from that single source of truth.
 
 ## Why Use Resources?
 
@@ -24,17 +23,16 @@ Without resources, building a full CRUD surface for one entity means authoring ~
 Benefits:
 
 - **Zero duplicate documentation**: identifier, properties, filters, and sortings are declared once.
-- **Consistent URLs and methods**: `Route::resource()` picks the correct URL template and HTTP verb per mode.
 - **Built-in validation**: `RequestValidationMiddleware` validates body, path, filters, and sort fields — all derived from the resource.
 - **Built-in OpenAPI**: request and response schemas are emitted for all five modes automatically.
 - **Shared response envelopes**: `ResourceCreated/View/Updated/Deleted/ListResponse` wrap the `data` key and pagination envelope for you.
+- **Nested URLs**: because each controller declares its own `getRoute()`, any URL structure is possible — including `/users/{user_uuid}/authenticators/{authenticator_uuid}`.
 
 ## Big Picture
 
 ```text
 AbstractResource (your declaration)
-   ├─ getIdentifierProperty()  ── path param on view/update/delete
-   ├─ init() + addProperty()   ── body fields on create/update, response fields on all modes
+   ├─ init() + addProperty()   ── identifier + body fields; response fields on all modes
    ├─ excludeFromMode($mode)   ── per-mode field visibility
    ├─ availableFilters()       ── list endpoint query params
    ├─ availableSortings()      ── order_by fields
@@ -44,7 +42,7 @@ AbstractResource (your declaration)
     │ paired with one of
     │
 Abstract{Create,View,Update,Delete,List}ResourceController
-   ├─ getRoute()         ── built by Route::resource($resource, $mode)
+   ├─ getRoute()         ── explicit: your URL, method, auth, filters, sortings, pagination
    ├─ getRequestClass()  ── always ResourceRequest
    ├─ getResponseClasses ── mode-specific Resource*Response
    └─ __invoke()         ── your business logic (only thing you implement)
@@ -57,7 +55,7 @@ Abstract{Create,View,Update,Delete,List}ResourceController
     How to subclass `AbstractResource`: identifier, properties, filters, sortings, per-mode exclusions.
   </Card>
   <Card title="Resource Controllers" href="/resources/controllers">
-    The five CRUD controller bases, how they wire up, and what you override.
+    The five CRUD controller bases, explicit `getRoute()`, and nested resource patterns.
   </Card>
   <Card title="Resource Responses" href="/resources/responses">
     The five pre-built response envelopes and how to attach pagination.

--- a/docs/resources/resource.mdx
+++ b/docs/resources/resource.mdx
@@ -8,23 +8,13 @@ description: "Every CRUD surface starts with a single class extending `AbstractR
 ```php
 namespace App\Resource;
 
-use apivalk\apivalk\Documentation\Property\AbstractProperty;
+use apivalk\apivalk\Documentation\OpenAPI\Object\TagObject;
 use apivalk\apivalk\Documentation\Property\FloatProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Resource\AbstractResource;
 
 class AnimalResource extends AbstractResource
 {
-    public function getIdentifierProperty(): AbstractProperty
-    {
-        return new StringProperty('animal_uuid', 'Unique identifier of the animal');
-    }
-
-    public function getBaseUrl(): string
-    {
-        return '/api/v1';
-    }
-
     public function getName(): string
     {
         return 'animal';
@@ -41,36 +31,25 @@ class AnimalResource extends AbstractResource
 
     protected function init(): void
     {
-        $this->addProperty(new StringProperty('name', 'Name of the animal'));
-        $this->addProperty(new StringProperty('type', 'Type of the animal'));
-        $this->addProperty(
-            (new FloatProperty('weight', 'Weight of the animal in kg'))->setIsRequired(false)
-        );
+        $this->addProperty(new StringProperty('animal_uuid', 'Unique identifier of the animal'));
+        $this->addProperty(new StringProperty('name', 'Animal name'));
+        $this->addProperty(new StringProperty('type', 'Animal type'));
+        $this->addProperty((new FloatProperty('weight', 'Weight in kg'))->setIsRequired(false));
     }
 }
 ```
 
-That's it — five CRUD endpoints' worth of documentation.
+The resource is a pure data shape — no URL knowledge, no routing. URLs live in controllers.
 
 ## Hook Reference
 
 ### `init(): void` (required)
 
-Declare data properties with `$this->addProperty(...)`. The constructor is `final` — all setup happens here.
-
-### `getIdentifierProperty(): AbstractProperty` (required)
-
-The property used for view / update / delete path parameters (`/animals/{animal_uuid}`) and the resource's identity in response bodies.
-
-Use UUID-typed identifiers (`StringProperty`) rather than integer IDs to comply with the framework's [REST naming standards](/open-api-best-practices/02-rest-design-and-naming#resource-identifiers-ids-vs-uuids).
-
-### `getBaseUrl(): string` (required)
-
-The URL prefix used by `Route::resource()` when building paths. Example: `/api/v1` produces `/api/v1/animals`, `/api/v1/animals/{animal_uuid}`.
+Declare all data properties with `$this->addProperty(...)`. This includes the resource identifier — it is a regular property like any other, declared first by convention. The constructor is `final` — all setup happens here.
 
 ### `getName(): string` (required)
 
-Singular resource name. Used in descriptions ("Create animal"), OpenAPI response names, generated request class names (e.g. `AnimalListRequest`), and plural URL derivation.
+Singular resource name. Used in descriptions ("Create animal") and OpenAPI response names.
 
 ### `getPluralName(): string` (optional)
 
@@ -85,17 +64,17 @@ public function getPluralName(): string
 
 ### `excludeFromMode(string $mode): array` (required)
 
-Return an array of property names to exclude from a given mode. Typical uses:
+Return property names to exclude from a given mode. Typical uses:
 
 - Hide `password` from **every** response.
 - Hide `weight` from **list** responses only.
-- Exclude `created_at` / `updated_at` from **create** bodies because the server sets them.
+- Exclude `animal_uuid` from **create** request bodies (the server generates the identifier; use `MODE_CREATE` to suppress it from the body documentation).
 
 Modes are constants on `AbstractResource`: `MODE_CREATE`, `MODE_VIEW`, `MODE_UPDATE`, `MODE_DELETE`, `MODE_LIST`.
 
 ### `availableFilters(): FilterInterface[]`
 
-Declare filters exposed on the list endpoint. Use the typed filter builders from `Router\Route\Filter\`:
+Declare filters exposed on the list endpoint:
 
 ```php
 public function availableFilters(): array
@@ -123,11 +102,11 @@ public function availableSortings(): array
 }
 ```
 
-Any sort field sent via `?order_by=...` that isn't in this list is rejected by the validation middleware with a 422.
+Any `?order_by=...` field not in this list is rejected by the validation middleware with a 422.
 
 ### `tags(): TagObject[]`
 
-OpenAPI tags for grouping operations. All five CRUD endpoints for one resource inherit these.
+OpenAPI tags for grouping operations.
 
 ```php
 public function tags(): array
@@ -141,11 +120,18 @@ public function tags(): array
 Controllers build resource instances from requests and arrays:
 
 ```php
-$resource = AnimalResource::byRequest($request);   // from path + body
+$resource = AnimalResource::byRequest($request);   // from request body only
 $resource = AnimalResource::byArray($row);         // from a database row
 ```
 
-And serialize them per mode:
+For view / update / delete, the identifier is a path parameter declared in `getRoute()`. Read it directly from the request and set it on the resource if needed:
+
+```php
+$resource = AnimalResource::byRequest($request);
+$resource->animal_uuid = $request->path()->get('animal_uuid')->getValue();
+```
+
+Serialize per mode:
 
 ```php
 $resource->toArray(AbstractResource::MODE_LIST);   // respects excludeFromMode()


### PR DESCRIPTION
…and docs

- Remove redundant `getMode` and `getDescription` methods from resource controllers.
- Simplify resource identifier handling by removing `getIdentifierProperty` references.
- Consolidate resource property management into `init()` for clearer data structure.
- Update documentation to reflect changes in resource serialization and controller responsibilities.

Issue: #127