### PR TITLE
fix: improve regex handling and enhance response documentation

### DIFF
--- a/Documentation/OpenAPI/Object/ResponseObject.php
+++ b/Documentation/OpenAPI/Object/ResponseObject.php
@@ -60,14 +60,15 @@ class ResponseObject implements ObjectInterface
             return $headerObject->toArray();
         }, $this->headers);
 
-        return [
-            $this->statusCode => array_filter(
-                [
-                    'description' => $this->description ?? '',
-                    'headers' => $headers,
-                    'content' => $this->content !== null ? array_filter($this->content->toArray()) : null,
-                ]
-            )
-        ];
+        $body = array_filter(
+            [
+                'headers' => $headers,
+                'content' => $this->content !== null ? array_filter($this->content->toArray()) : null,
+            ]
+        );
+
+        $body['description'] = $this->description ?? '';
+
+        return [$this->statusCode => $body];
     }
 }

--- a/Documentation/Property/StringProperty.php
+++ b/Documentation/Property/StringProperty.php
@@ -73,6 +73,29 @@ class StringProperty extends AbstractProperty
         return $this->pattern;
     }
 
+    private function stripPhpRegexDelimiters(string $pattern): string
+    {
+        if (\strlen($pattern) < 2) {
+            return $pattern;
+        }
+
+        $delimiter = $pattern[0];
+
+        if (ctype_alnum($delimiter) || $delimiter === '\\') {
+            return $pattern;
+        }
+
+        $closingMap = ['{' => '}', '[' => ']', '(' => ')', '<' => '>'];
+        $closing = $closingMap[$delimiter] ?? $delimiter;
+
+        $closingPos = strrpos($pattern, $closing, 1);
+        if ($closingPos === false || $closingPos === 0) {
+            return $pattern;
+        }
+
+        return substr($pattern, 1, $closingPos - 1);
+    }
+
     public function getDocumentationArray(): array
     {
         $array = [
@@ -92,7 +115,7 @@ class StringProperty extends AbstractProperty
         }
 
         if ($this->getPattern() !== null) {
-            $array['pattern'] = $this->getPattern();
+            $array['pattern'] = $this->stripPhpRegexDelimiters($this->getPattern());
         }
 
         if ($this->getPropertyDescription() !== '') {

--- a/Tests/Integration/RealWorld/Customer/Address/AddressCreatedResponse.php
+++ b/Tests/Integration/RealWorld/Customer/Address/AddressCreatedResponse.php
@@ -20,7 +20,9 @@ class AddressCreatedResponse extends AbstractApivalkResponse
 
     public static function getDocumentation(): ApivalkResponseDocumentation
     {
-        return new ApivalkResponseDocumentation();
+        $doc = new ApivalkResponseDocumentation();
+        $doc->setDescription('Create address response');
+        return $doc;
     }
 
     public static function getStatusCode(): int

--- a/Tests/Integration/RealWorld/Customer/Address/AddressListResponse.php
+++ b/Tests/Integration/RealWorld/Customer/Address/AddressListResponse.php
@@ -20,7 +20,9 @@ class AddressListResponse extends AbstractApivalkResponse
 
     public static function getDocumentation(): ApivalkResponseDocumentation
     {
-        return new ApivalkResponseDocumentation();
+        $doc = new ApivalkResponseDocumentation();
+        $doc->setDescription('List addresses response');
+        return $doc;
     }
 
     public static function getStatusCode(): int

--- a/Tests/Integration/RealWorld/Customer/Address/AddressUpdatedResponse.php
+++ b/Tests/Integration/RealWorld/Customer/Address/AddressUpdatedResponse.php
@@ -20,7 +20,9 @@ class AddressUpdatedResponse extends AbstractApivalkResponse
 
     public static function getDocumentation(): ApivalkResponseDocumentation
     {
-        return new ApivalkResponseDocumentation();
+        $doc = new ApivalkResponseDocumentation();
+        $doc->setDescription('Update address response');
+        return $doc;
     }
 
     public static function getStatusCode(): int

--- a/Tests/Integration/RealWorld/Customer/Address/AddressViewResponse.php
+++ b/Tests/Integration/RealWorld/Customer/Address/AddressViewResponse.php
@@ -20,7 +20,9 @@ class AddressViewResponse extends AbstractApivalkResponse
 
     public static function getDocumentation(): ApivalkResponseDocumentation
     {
-        return new ApivalkResponseDocumentation();
+        $doc = new ApivalkResponseDocumentation();
+        $doc->setDescription('View address response');
+        return $doc;
     }
 
     public static function getStatusCode(): int

--- a/Tests/Integration/RealWorld/Customer/CustomerCreatedResponse.php
+++ b/Tests/Integration/RealWorld/Customer/CustomerCreatedResponse.php
@@ -20,7 +20,9 @@ class CustomerCreatedResponse extends AbstractApivalkResponse
 
     public static function getDocumentation(): ApivalkResponseDocumentation
     {
-        return new ApivalkResponseDocumentation();
+        $doc = new ApivalkResponseDocumentation();
+        $doc->setDescription('Create customer response');
+        return $doc;
     }
 
     public static function getStatusCode(): int

--- a/Tests/Integration/RealWorld/Customer/CustomerListResponse.php
+++ b/Tests/Integration/RealWorld/Customer/CustomerListResponse.php
@@ -20,7 +20,9 @@ class CustomerListResponse extends AbstractApivalkResponse
 
     public static function getDocumentation(): ApivalkResponseDocumentation
     {
-        return new ApivalkResponseDocumentation();
+        $doc = new ApivalkResponseDocumentation();
+        $doc->setDescription('List customers response');
+        return $doc;
     }
 
     public static function getStatusCode(): int

--- a/Tests/Integration/RealWorld/Customer/CustomerUpdatedResponse.php
+++ b/Tests/Integration/RealWorld/Customer/CustomerUpdatedResponse.php
@@ -20,7 +20,9 @@ class CustomerUpdatedResponse extends AbstractApivalkResponse
 
     public static function getDocumentation(): ApivalkResponseDocumentation
     {
-        return new ApivalkResponseDocumentation();
+        $doc = new ApivalkResponseDocumentation();
+        $doc->setDescription('Update customer response');
+        return $doc;
     }
 
     public static function getStatusCode(): int

--- a/Tests/Integration/RealWorld/Customer/CustomerViewResponse.php
+++ b/Tests/Integration/RealWorld/Customer/CustomerViewResponse.php
@@ -20,7 +20,9 @@ class CustomerViewResponse extends AbstractApivalkResponse
 
     public static function getDocumentation(): ApivalkResponseDocumentation
     {
-        return new ApivalkResponseDocumentation();
+        $doc = new ApivalkResponseDocumentation();
+        $doc->setDescription('View customer response');
+        return $doc;
     }
 
     public static function getStatusCode(): int

--- a/Tests/PhpUnit/Documentation/OpenAPI/Generator/OperationGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Generator/OperationGeneratorTest.php
@@ -110,7 +110,7 @@ class OperationGeneratorTest extends TestCase
         );
         $this->assertFalse($orderByParameter->isRequired());
         $this->assertEquals(
-            '/^([+-](id|price))(,([+-](id|price)))*$/',
+            '^([+-](id|price))(,([+-](id|price)))*$',
             $orderByParameter->toArray()['schema']['pattern']
         );
 

--- a/Tests/PhpUnit/Documentation/OpenAPI/Object/ResponseObjectTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Object/ResponseObjectTest.php
@@ -53,6 +53,7 @@ class ResponseObjectTest extends TestCase
         $result = $response->toArray();
 
         $this->assertArrayHasKey(204, $result);
-        $this->assertArrayNotHasKey('description', $result[204]);
+        $this->assertArrayHasKey('description', $result[204]);
+        $this->assertSame('', $result[204]['description']);
     }
 }

--- a/Tests/PhpUnit/Documentation/Property/StringPropertyTest.php
+++ b/Tests/PhpUnit/Documentation/Property/StringPropertyTest.php
@@ -25,7 +25,7 @@ class StringPropertyTest extends TestCase
         $this->assertEquals('default-val', $doc['default']);
         $this->assertEquals(2, $doc['minLength']);
         $this->assertEquals(10, $doc['maxLength']);
-        $this->assertEquals('/^[a-z]+$/', $doc['pattern']);
+        $this->assertEquals('^[a-z]+$', $doc['pattern']);
         $this->assertEquals('User Name', $doc['description']);
         $this->assertArrayNotHasKey('format', $doc);
         $this->assertArrayNotHasKey('enum', $doc);


### PR DESCRIPTION
- Added `stripPhpRegexDelimiters` utility to handle regex patterns in `StringProperty`.
- Updated `getDocumentation` methods across response classes to include descriptions.
- Adjusted OpenAPI response schema to consistently include `description`.
- Updated tests to validate new regex handling and documentation adjustments.

Issue: -