### PR TITLE
feat: add `SimpleArrayProperty` for scalar array validation and docum…

### DIFF
--- a/Documentation/Property/SimpleArrayProperty.php
+++ b/Documentation/Property/SimpleArrayProperty.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Documentation\Property;
+
+/**
+ * Describes a one-dimensional array of scalar values (e.g. ["ids" => [23, 41, 22]]).
+ *
+ * Unlike {@see ArrayProperty}, which requires an object property to describe each
+ * item, a simple array only needs the scalar item type. The configured type defines
+ * what is written into the documentation as the array's item type.
+ */
+class SimpleArrayProperty extends AbstractProperty
+{
+    /** @var string */
+    public const TYPE_INT = 'int';
+    /** @var string */
+    public const TYPE_STRING = 'string';
+    /** @var string */
+    public const TYPE_NUMBER = 'number';
+    /** @var string */
+    public const TYPE_BOOL = 'bool';
+
+    /**
+     * @var array<string, string>
+     */
+    private const SWAGGER_TYPE_MAP = [
+        self::TYPE_INT => 'integer',
+        self::TYPE_STRING => 'string',
+        self::TYPE_NUMBER => 'number',
+        self::TYPE_BOOL => 'boolean',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const PHP_TYPE_MAP = [
+        self::TYPE_INT => 'int',
+        self::TYPE_STRING => 'string',
+        self::TYPE_NUMBER => 'float',
+        self::TYPE_BOOL => 'bool',
+    ];
+
+    /** @var string */
+    private $itemType;
+
+    public function __construct(
+        string $propertyName,
+        string $propertyDescription = '',
+        string $itemType = self::TYPE_STRING
+    ) {
+        parent::__construct($propertyName, $propertyDescription);
+
+        $this->setItemType($itemType);
+    }
+
+    public function setItemType(string $itemType): self
+    {
+        if (!isset(self::SWAGGER_TYPE_MAP[$itemType])) {
+            throw new \InvalidArgumentException(\sprintf('Invalid item type "%s"', $itemType));
+        }
+
+        $this->itemType = $itemType;
+
+        return $this;
+    }
+
+    public function getItemType(): string
+    {
+        return $this->itemType;
+    }
+
+    public function getType(): string
+    {
+        return 'array';
+    }
+
+    public function getPhpType(): string
+    {
+        return self::PHP_TYPE_MAP[$this->itemType] . '[]';
+    }
+
+    /** @return array<string, mixed> */
+    public function getDocumentationArray(): array
+    {
+        $array = [
+            'type' => $this->getType(),
+            'items' => [
+                'type' => self::SWAGGER_TYPE_MAP[$this->itemType],
+            ],
+        ];
+
+        if ($this->getPropertyDescription() !== '') {
+            $array['description'] = $this->getPropertyDescription();
+        }
+
+        if ($this->getExample() !== null) {
+            $array['example'] = $this->getExample();
+        }
+
+        return $array;
+    }
+}

--- a/Documentation/Property/Validator/SimpleArrayValidator.php
+++ b/Documentation/Property/Validator/SimpleArrayValidator.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Documentation\Property\Validator;
+
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
+use apivalk\apivalk\Http\Request\Parameter\Parameter;
+
+/**
+ * Validates a one-dimensional array of scalars.
+ *
+ * Unlike {@see ArrayValidator}, which only checks that the value is an array, this
+ * validator also asserts that every element matches the array's configured item type
+ * (int, string, number or bool).
+ *
+ * The raw (pre-cast) value is validated on purpose: type casting coerces elements to the
+ * item type (e.g. "abc" would become 0 for an int array), so validating the cast value
+ * would let invalid input slip through.
+ */
+class SimpleArrayValidator extends AbstractValidator
+{
+    public function validate(Parameter $parameter): ValidatorResult
+    {
+        $value = $parameter->getRawValue();
+
+        if (\is_string($value)) {
+            $value = json_decode($value, true);
+        }
+
+        if (!\is_array($value)) {
+            return new ValidatorResult(false, ValidatorResult::VALUE_IS_NOT_AN_ARRAY);
+        }
+
+        /** @var SimpleArrayProperty $property */
+        $property = $this->getProperty();
+        $itemType = $property->getItemType();
+
+        foreach ($value as $item) {
+            $itemResult = $this->validateItem($item, $itemType);
+            if (!$itemResult->isSuccess()) {
+                return $itemResult;
+            }
+        }
+
+        return new ValidatorResult(true);
+    }
+
+    /**
+     * @param mixed $item
+     */
+    private function validateItem($item, string $itemType): ValidatorResult
+    {
+        switch ($itemType) {
+            case SimpleArrayProperty::TYPE_INT:
+            case SimpleArrayProperty::TYPE_NUMBER:
+                if (!is_numeric($item)) {
+                    return new ValidatorResult(false, ValidatorResult::VALUE_IS_NOT_NUMERIC);
+                }
+
+                return new ValidatorResult(true);
+
+            case SimpleArrayProperty::TYPE_BOOL:
+                if (!\in_array($item, [0, 1, 'true', 'false', true, false], true)) {
+                    return new ValidatorResult(false, ValidatorResult::VALUE_IS_NOT_BOOLEAN);
+                }
+
+                return new ValidatorResult(true);
+
+            case SimpleArrayProperty::TYPE_STRING:
+            default:
+                if (!\is_string($item)) {
+                    return new ValidatorResult(false, ValidatorResult::VALUE_IS_NOT_A_STRING);
+                }
+
+                return new ValidatorResult(true);
+        }
+    }
+}

--- a/Documentation/Property/Validator/ValidatorFactory.php
+++ b/Documentation/Property/Validator/ValidatorFactory.php
@@ -15,6 +15,7 @@ use apivalk\apivalk\Documentation\Property\EnumProperty;
 use apivalk\apivalk\Documentation\Property\FloatProperty;
 use apivalk\apivalk\Documentation\Property\IntegerProperty;
 use apivalk\apivalk\Documentation\Property\AbstractObjectProperty;
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Request\Parameter\Parameter;
 
@@ -44,6 +45,10 @@ final class ValidatorFactory
 
         if ($property instanceof StringProperty) {
             return new StringValidator($property);
+        }
+
+        if ($property instanceof SimpleArrayProperty) {
+            return new SimpleArrayValidator($property);
         }
 
         if ($property instanceof ArrayProperty) {

--- a/Http/Request/Parameter/ParameterBagFactory.php
+++ b/Http/Request/Parameter/ParameterBagFactory.php
@@ -6,6 +6,7 @@ namespace apivalk\apivalk\Http\Request\Parameter;
 
 use apivalk\apivalk\Documentation\Property\AbstractProperty;
 use apivalk\apivalk\Documentation\Property\ArrayProperty;
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
 use apivalk\apivalk\Router\Route\Route;
 
 final class ParameterBagFactory
@@ -175,6 +176,39 @@ final class ParameterBagFactory
         if (($property instanceof ArrayProperty)
             && \is_string($value)) {
             $value = json_decode($value, true);
+        }
+
+        if ($property instanceof SimpleArrayProperty) {
+            if (\is_string($value)) {
+                $value = json_decode($value, true);
+            }
+
+            if (!\is_array($value)) {
+                return null;
+            }
+
+            $itemType = $property->getItemType();
+
+            return array_map(
+                static function ($item) use ($itemType) {
+                    if (!\is_scalar($item)) {
+                        return $item;
+                    }
+
+                    switch ($itemType) {
+                        case SimpleArrayProperty::TYPE_INT:
+                            return (int)$item;
+                        case SimpleArrayProperty::TYPE_NUMBER:
+                            return (float)$item;
+                        case SimpleArrayProperty::TYPE_BOOL:
+                            return (bool)$item;
+                        case SimpleArrayProperty::TYPE_STRING:
+                        default:
+                            return (string)$item;
+                    }
+                },
+                $value
+            );
         }
 
         switch ($property->getPhpType()) {

--- a/Tests/Integration/RealWorld/Contract/ContractResource.php
+++ b/Tests/Integration/RealWorld/Contract/ContractResource.php
@@ -8,6 +8,7 @@ use apivalk\apivalk\Documentation\Property\DateProperty;
 use apivalk\apivalk\Documentation\Property\EnumProperty;
 use apivalk\apivalk\Documentation\Property\FloatProperty;
 use apivalk\apivalk\Documentation\Property\IntegerProperty;
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\Route\Filter\DateFilter;
@@ -28,6 +29,8 @@ use apivalk\apivalk\Router\Route\Sort\Sort;
  * @property \DateTime $start_date Contract start date
  * @property \DateTime|null $end_date Contract end date
  * @property string|null $notes Notes
+ * @property string[]|null $tags Free-form contract tags
+ * @property int[]|null $attachment_ids IDs of documents attached to the contract
  * @property string $created_at Created at
  * @property string $updated_at Updated at
  */
@@ -53,6 +56,14 @@ class ContractResource extends AbstractResource
         $this->addProperty(new DateProperty('start_date', 'Contract start date'));
         $this->addProperty((new DateProperty('end_date', 'Contract end date'))->setIsRequired(false));
         $this->addProperty((new StringProperty('notes', 'Notes'))->setMaxLength(5000)->setIsRequired(false));
+        $this->addProperty(
+            (new SimpleArrayProperty('tags', 'Free-form contract tags', SimpleArrayProperty::TYPE_STRING))
+                ->setIsRequired(false)
+        );
+        $this->addProperty(
+            (new SimpleArrayProperty('attachment_ids', 'IDs of documents attached to the contract', SimpleArrayProperty::TYPE_INT))
+                ->setIsRequired(false)
+        );
         $this->addProperty(new StringProperty('created_at', 'Created at'));
         $this->addProperty(new StringProperty('updated_at', 'Updated at'));
     }

--- a/Tests/Integration/RealWorld/Contract/ViewContractController.php
+++ b/Tests/Integration/RealWorld/Contract/ViewContractController.php
@@ -50,6 +50,8 @@ class ViewContractController extends AbstractViewResourceController
         $resource->currency = 'EUR';
         $resource->status = 'active';
         $resource->start_date = '2024-01-01';
+        $resource->tags = ['vip', 'enterprise', 'renewal'];
+        $resource->attachment_ids = [101, 102, 103];
         $resource->created_at = '2024-01-01T00:00:00Z';
         $resource->updated_at = '2024-01-01T00:00:00Z';
 

--- a/Tests/Integration/RealWorld/Customer/CreateCustomerController.php
+++ b/Tests/Integration/RealWorld/Customer/CreateCustomerController.php
@@ -40,6 +40,8 @@ class CreateCustomerController extends AbstractApivalkController
             'email'       => $request->body()->has('email') ? $request->body()->get('email')->getValue() : null,
             'phone'       => $request->body()->has('phone') ? $request->body()->get('phone')->getValue() : null,
             'status'      => $request->body()->has('status') ? $request->body()->get('status')->getValue() : null,
+            'roles'          => ['admin', 'billing'],
+            'permission_ids' => [10, 20, 30],
             'created_at'  => '2024-01-01T00:00:00Z',
             'updated_at'  => '2024-01-01T00:00:00Z',
         ];

--- a/Tests/Integration/RealWorld/Customer/CustomerCreatedResponse.php
+++ b/Tests/Integration/RealWorld/Customer/CustomerCreatedResponse.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\RealWorld\Customer;
 
 use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 
 class CustomerCreatedResponse extends AbstractApivalkResponse
@@ -22,6 +23,12 @@ class CustomerCreatedResponse extends AbstractApivalkResponse
     {
         $doc = new ApivalkResponseDocumentation();
         $doc->setDescription('Create customer response');
+        $doc->addProperty(
+            new SimpleArrayProperty('roles', 'Role names assigned to the customer', SimpleArrayProperty::TYPE_STRING)
+        );
+        $doc->addProperty(
+            new SimpleArrayProperty('permission_ids', 'Granted permission IDs', SimpleArrayProperty::TYPE_INT)
+        );
         return $doc;
     }
 

--- a/Tests/Integration/RealWorld/Tests/ContractIntegrationTest.php
+++ b/Tests/Integration/RealWorld/Tests/ContractIntegrationTest.php
@@ -291,6 +291,44 @@ class ContractIntegrationTest extends TestCase
         $this->assertNotEmpty($data['errors']);
     }
 
+    public function testCreateContract_withSimpleArrayFields_returns201AndEchoesArrays(): void
+    {
+        // attachment_ids are sent as numeric strings (the usual wire format) to prove that
+        // the int item type is cast through to the value the controller reads back.
+        $body = array_merge(self::VALID_CONTRACT_BODY, [
+            'tags'           => ['vip', 'renewal'],
+            'attachment_ids' => ['11', '22', '33'],
+        ]);
+        $response = $this->makeRequest('POST', $this->listUrl(), [], $body, 'admin-token');
+        $this->assertSame(201, $response->getStatusCode());
+
+        $data = $response->toArray()['data'];
+        $this->assertSame(['vip', 'renewal'], $data['tags']);
+        $this->assertSame([11, 22, 33], $data['attachment_ids']);
+    }
+
+    public function testCreateContract_withoutSimpleArrayFields_returns201(): void
+    {
+        // tags / attachment_ids are optional simple arrays — omitting them is valid
+        $response = $this->makeRequest('POST', $this->listUrl(), [], self::VALID_CONTRACT_BODY, 'admin-token');
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    public function testCreateContract_tagsNotAnArray_returns422(): void
+    {
+        $body = array_merge(self::VALID_CONTRACT_BODY, ['tags' => 'not-an-array']);
+        $response = $this->makeRequest('POST', $this->listUrl(), [], $body, 'admin-token');
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testCreateContract_attachmentIdsWithNonNumericElement_returns422(): void
+    {
+        // attachment_ids is an int simple array; a non-numeric element fails element-level validation
+        $body = array_merge(self::VALID_CONTRACT_BODY, ['attachment_ids' => [11, 'not-a-number', 33]]);
+        $response = $this->makeRequest('POST', $this->listUrl(), [], $body, 'admin-token');
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
     // --- View ---
 
     public function testViewContract_withAdminToken_returns200(): void
@@ -349,6 +387,22 @@ class ContractIntegrationTest extends TestCase
         $data = $response->toArray();
         $this->assertArrayHasKey('data', $data);
         $this->assertArrayHasKey('contract_uuid', $data['data']);
+    }
+
+    public function testViewContract_responseContainsStringSimpleArray(): void
+    {
+        $response = $this->makeRequest('GET', $this->itemUrl(self::VALID_UUID), [], [], 'admin-token');
+        $this->assertSame(200, $response->getStatusCode());
+        $data = $response->toArray()['data'];
+        $this->assertSame(['vip', 'enterprise', 'renewal'], $data['tags']);
+    }
+
+    public function testViewContract_responseContainsIntSimpleArray(): void
+    {
+        $response = $this->makeRequest('GET', $this->itemUrl(self::VALID_UUID), [], [], 'admin-token');
+        $this->assertSame(200, $response->getStatusCode());
+        $data = $response->toArray()['data'];
+        $this->assertSame([101, 102, 103], $data['attachment_ids']);
     }
 
     // --- Update ---

--- a/Tests/Integration/RealWorld/Tests/CustomerIntegrationTest.php
+++ b/Tests/Integration/RealWorld/Tests/CustomerIntegrationTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Integration\RealWorld\Tests;
 
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
 use PHPUnit\Framework\TestCase;
 use Tests\Integration\RealWorld\Bootstrap\ApiFactory;
 use Tests\Integration\RealWorld\Bootstrap\InMemoryCache;
 use Tests\Integration\RealWorld\Bootstrap\RequestTrait;
+use Tests\Integration\RealWorld\Customer\CustomerCreatedResponse;
 
 class CustomerIntegrationTest extends TestCase
 {
@@ -15,18 +17,48 @@ class CustomerIntegrationTest extends TestCase
 
     private const VALID_CUSTOMER_BODY = [
         'first_name' => 'John',
-        'last_name'  => 'Doe',
-        'email'      => 'john@example.com',
-        'status'     => 'active',
+        'last_name' => 'Doe',
+        'email' => 'john@example.com',
+        'status' => 'active',
     ];
 
     // Fixture data returned by ListCustomersController (5 customers)
     private const FIXTURES = [
-        ['customer_id' => 1, 'first_name' => 'Alice', 'last_name' => 'Anderson', 'email' => 'alice@example.com', 'status' => 'active'],
-        ['customer_id' => 2, 'first_name' => 'Bob',   'last_name' => 'Brown',    'email' => 'bob@example.com',   'status' => 'inactive'],
-        ['customer_id' => 3, 'first_name' => 'Carol', 'last_name' => 'Clark',    'email' => 'carol@example.com', 'status' => 'active'],
-        ['customer_id' => 4, 'first_name' => 'Dave',  'last_name' => 'Davis',    'email' => 'dave@example.com',  'status' => 'pending'],
-        ['customer_id' => 5, 'first_name' => 'Eve',   'last_name' => 'Evans',    'email' => 'eve@example.com',   'status' => 'active'],
+        [
+            'customer_id' => 1,
+            'first_name' => 'Alice',
+            'last_name' => 'Anderson',
+            'email' => 'alice@example.com',
+            'status' => 'active'
+        ],
+        [
+            'customer_id' => 2,
+            'first_name' => 'Bob',
+            'last_name' => 'Brown',
+            'email' => 'bob@example.com',
+            'status' => 'inactive'
+        ],
+        [
+            'customer_id' => 3,
+            'first_name' => 'Carol',
+            'last_name' => 'Clark',
+            'email' => 'carol@example.com',
+            'status' => 'active'
+        ],
+        [
+            'customer_id' => 4,
+            'first_name' => 'Dave',
+            'last_name' => 'Davis',
+            'email' => 'dave@example.com',
+            'status' => 'pending'
+        ],
+        [
+            'customer_id' => 5,
+            'first_name' => 'Eve',
+            'last_name' => 'Evans',
+            'email' => 'eve@example.com',
+            'status' => 'active'
+        ],
     ];
 
     // --- List ---
@@ -94,13 +126,15 @@ class CustomerIntegrationTest extends TestCase
     public function testListCustomers_unknownFilterField_returns422(): void
     {
         // Unknown query params that don't match declared filter fields or query properties are silently ignored
-        $response = $this->makeRequest('GET', '/v1/api/customers', ['nonexistent_filter_field' => 'value'], [], 'admin-token');
+        $response =
+            $this->makeRequest('GET', '/v1/api/customers', ['nonexistent_filter_field' => 'value'], [], 'admin-token');
         $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testListCustomers_unknownSortField_returns422(): void
     {
-        $response = $this->makeRequest('GET', '/v1/api/customers', ['order_by' => 'nonexistent_field'], [], 'admin-token');
+        $response =
+            $this->makeRequest('GET', '/v1/api/customers', ['order_by' => 'nonexistent_field'], [], 'admin-token');
         $this->assertSame(422, $response->getStatusCode());
     }
 
@@ -118,7 +152,8 @@ class CustomerIntegrationTest extends TestCase
 
     public function testListCustomers_sortByMultipleFields_returns200(): void
     {
-        $response = $this->makeRequest('GET', '/v1/api/customers', ['order_by' => '+last_name,-created_at'], [], 'admin-token');
+        $response =
+            $this->makeRequest('GET', '/v1/api/customers', ['order_by' => '+last_name,-created_at'], [], 'admin-token');
         $this->assertSame(200, $response->getStatusCode());
     }
 
@@ -210,7 +245,8 @@ class CustomerIntegrationTest extends TestCase
 
     public function testListCustomers_filterByEmailNoMatch_returnsEmpty(): void
     {
-        $response = $this->makeRequest('GET', '/v1/api/customers', ['email' => 'nobody@example.com'], [], 'admin-token');
+        $response =
+            $this->makeRequest('GET', '/v1/api/customers', ['email' => 'nobody@example.com'], [], 'admin-token');
         $this->assertSame(200, $response->getStatusCode());
         $this->assertCount(0, $response->toArray()['data']);
     }
@@ -227,7 +263,8 @@ class CustomerIntegrationTest extends TestCase
 
     public function testListCustomers_bracketFilterByStatus_returns200WithMatchingData(): void
     {
-        $response = $this->makeRequest('GET', '/v1/api/customers', ['filter' => ['status' => 'active']], [], 'admin-token');
+        $response =
+            $this->makeRequest('GET', '/v1/api/customers', ['filter' => ['status' => 'active']], [], 'admin-token');
         $this->assertSame(200, $response->getStatusCode());
         $items = $response->toArray()['data'];
         $this->assertCount(3, $items);
@@ -238,7 +275,8 @@ class CustomerIntegrationTest extends TestCase
 
     public function testListCustomers_bracketFilterByFirstNameLike_returnsMatch(): void
     {
-        $response = $this->makeRequest('GET', '/v1/api/customers', ['filter' => ['first_name' => 'ali']], [], 'admin-token');
+        $response =
+            $this->makeRequest('GET', '/v1/api/customers', ['filter' => ['first_name' => 'ali']], [], 'admin-token');
         $this->assertSame(200, $response->getStatusCode());
         $items = $response->toArray()['data'];
         $this->assertCount(1, $items);
@@ -264,7 +302,13 @@ class CustomerIntegrationTest extends TestCase
 
     public function testListCustomers_bracketFilterNonScalarValueIsIgnored_returnsAllItems(): void
     {
-        $response = $this->makeRequest('GET', '/v1/api/customers', ['filter' => ['status' => ['active', 'pending']]], [], 'admin-token');
+        $response = $this->makeRequest(
+            'GET',
+            '/v1/api/customers',
+            ['filter' => ['status' => ['active', 'pending']]],
+            [],
+            'admin-token'
+        );
         $this->assertSame(200, $response->getStatusCode());
         $this->assertCount(5, $response->toArray()['data']);
     }
@@ -303,7 +347,13 @@ class CustomerIntegrationTest extends TestCase
     public function testListCustomers_filterAndSort_activeByLastNameAsc(): void
     {
         // Filter: active (Alice, Carol, Eve) → sort by last_name asc → Anderson, Clark, Evans
-        $response = $this->makeRequest('GET', '/v1/api/customers', ['status' => 'active', 'order_by' => '+last_name'], [], 'admin-token');
+        $response = $this->makeRequest(
+            'GET',
+            '/v1/api/customers',
+            ['status' => 'active', 'order_by' => '+last_name'],
+            [],
+            'admin-token'
+        );
         $items = $response->toArray()['data'];
         $this->assertCount(3, $items);
         $this->assertSame(['Anderson', 'Clark', 'Evans'], array_column($items, 'last_name'));
@@ -311,7 +361,13 @@ class CustomerIntegrationTest extends TestCase
 
     public function testListCustomers_filterAndSort_activeByLastNameDesc(): void
     {
-        $response = $this->makeRequest('GET', '/v1/api/customers', ['status' => 'active', 'order_by' => '-last_name'], [], 'admin-token');
+        $response = $this->makeRequest(
+            'GET',
+            '/v1/api/customers',
+            ['status' => 'active', 'order_by' => '-last_name'],
+            [],
+            'admin-token'
+        );
         $items = $response->toArray()['data'];
         $this->assertCount(3, $items);
         $this->assertSame(['Evans', 'Clark', 'Anderson'], array_column($items, 'last_name'));
@@ -440,6 +496,40 @@ class CustomerIntegrationTest extends TestCase
         $this->assertNotEmpty($data['errors']);
     }
 
+    public function testCreateCustomer_responseContainsStringSimpleArray(): void
+    {
+        $response = $this->makeRequest('POST', '/v1/api/customers', [], self::VALID_CUSTOMER_BODY, 'admin-token');
+        $this->assertSame(201, $response->getStatusCode());
+        $data = $response->toArray()['data'];
+        $this->assertSame(['admin', 'billing'], $data['roles']);
+    }
+
+    public function testCreateCustomer_responseContainsIntSimpleArray(): void
+    {
+        $response = $this->makeRequest('POST', '/v1/api/customers', [], self::VALID_CUSTOMER_BODY, 'admin-token');
+        $this->assertSame(201, $response->getStatusCode());
+        $data = $response->toArray()['data'];
+        $this->assertSame([10, 20, 30], $data['permission_ids']);
+    }
+
+    public function testCustomerCreatedResponse_documentsSimpleArrayProperties(): void
+    {
+        $properties = CustomerCreatedResponse::getDocumentation()->getProperties();
+
+        $byName = [];
+        foreach ($properties as $property) {
+            $byName[$property->getPropertyName()] = $property;
+        }
+
+        $this->assertArrayHasKey('roles', $byName);
+        $this->assertInstanceOf(SimpleArrayProperty::class, $byName['roles']);
+        $this->assertSame(['type' => 'string'], $byName['roles']->getDocumentationArray()['items']);
+
+        $this->assertArrayHasKey('permission_ids', $byName);
+        $this->assertInstanceOf(SimpleArrayProperty::class, $byName['permission_ids']);
+        $this->assertSame(['type' => 'integer'], $byName['permission_ids']->getDocumentationArray()['items']);
+    }
+
     // --- View ---
 
     public function testViewCustomer_withAdminToken_returns200(): void
@@ -508,7 +598,8 @@ class CustomerIntegrationTest extends TestCase
 
     public function testUpdateCustomer_withReadOnlyToken_returns403(): void
     {
-        $response = $this->makeRequest('PATCH', '/v1/api/customers/42', [], self::VALID_CUSTOMER_BODY, 'read-only-token');
+        $response =
+            $this->makeRequest('PATCH', '/v1/api/customers/42', [], self::VALID_CUSTOMER_BODY, 'read-only-token');
         $this->assertSame(403, $response->getStatusCode());
     }
 
@@ -555,7 +646,8 @@ class CustomerIntegrationTest extends TestCase
 
     public function testUpdateCustomer_unknownCustomerId_returns404(): void
     {
-        $response = $this->makeRequest('PATCH', '/v1/api/customers/99999', [], self::VALID_CUSTOMER_BODY, 'admin-token');
+        $response =
+            $this->makeRequest('PATCH', '/v1/api/customers/99999', [], self::VALID_CUSTOMER_BODY, 'admin-token');
         $this->assertSame(404, $response->getStatusCode());
     }
 

--- a/Tests/PhpUnit/Documentation/DocBlock/DocBlockGeneratorTest.php
+++ b/Tests/PhpUnit/Documentation/DocBlock/DocBlockGeneratorTest.php
@@ -196,6 +196,92 @@ PHP;
         $this->assertStringContainsString('@property float|null $weight', $updatedResource);
     }
 
+    public function testRunGeneratesSimpleArrayPropertyDocBlocks(): void
+    {
+        $resourceDir = $this->tempDir . '/Resource';
+        mkdir($resourceDir);
+
+        $resourceClassName = 'TestArrayResource_' . str_replace('.', '_', uniqid('', true));
+        $resourceFile = $resourceDir . '/' . $resourceClassName . '.php';
+        $resourceContent = <<<PHP
+<?php
+
+namespace TestNamespace\\Resource;
+
+use apivalk\\apivalk\\Documentation\\Property\\SimpleArrayProperty;
+use apivalk\\apivalk\\Documentation\\Property\\StringProperty;
+use apivalk\\apivalk\\Resource\\AbstractResource;
+
+class {$resourceClassName} extends AbstractResource
+{
+    public function getName(): string { return 'thing'; }
+    public function excludeFromMode(string \$mode): array { return []; }
+
+    protected function init(): void
+    {
+        \$this->addProperty(new StringProperty('thing_uuid', 'Identifier of the thing'));
+        \$this->addProperty(new SimpleArrayProperty('tags', 'Free-form tags', SimpleArrayProperty::TYPE_STRING));
+        \$this->addProperty(
+            (new SimpleArrayProperty('attachment_ids', 'Attached document IDs', SimpleArrayProperty::TYPE_INT))
+                ->setIsRequired(false)
+        );
+        \$this->addProperty(new SimpleArrayProperty('scores', 'Scores', SimpleArrayProperty::TYPE_NUMBER));
+        \$this->addProperty(new SimpleArrayProperty('flags', 'Flags', SimpleArrayProperty::TYPE_BOOL));
+    }
+}
+PHP;
+        file_put_contents($resourceFile, $resourceContent);
+        require_once $resourceFile;
+
+        $controllerClassName = 'TestArrayResourceController_' . str_replace('.', '_', uniqid('', true));
+        $controllerFile = $this->tempDir . '/' . $controllerClassName . '.php';
+        $controllerContent = <<<PHP
+<?php
+
+namespace TestNamespace;
+
+use apivalk\\apivalk\\Http\\Controller\\Resource\\AbstractListResourceController;
+use apivalk\\apivalk\\Http\\Request\\ApivalkRequestInterface;
+use apivalk\\apivalk\\Http\\Response\\AbstractApivalkResponse;
+use apivalk\\apivalk\\Http\\Response\\Resource\\ResourceListResponse;
+use apivalk\\apivalk\\Http\\Response\\Pagination\\PagePaginationResponse;
+use apivalk\\apivalk\\Router\\Route\\Route;
+use TestNamespace\\Resource\\{$resourceClassName};
+
+class {$controllerClassName} extends AbstractListResourceController
+{
+    protected static function buildRoute(): Route
+    {
+        return Route::get('/api/v1/things');
+    }
+
+    public static function getResourceClass(): string
+    {
+        return {$resourceClassName}::class;
+    }
+
+    public function __invoke(ApivalkRequestInterface \$request): AbstractApivalkResponse
+    {
+        return new ResourceListResponse([], new PagePaginationResponse(1, 25, false, 0));
+    }
+}
+PHP;
+        file_put_contents($controllerFile, $controllerContent);
+        require_once $controllerFile;
+
+        $generator = new DocBlockGenerator();
+
+        ob_start();
+        $generator->run($this->tempDir, 'TestNamespace');
+        ob_get_clean();
+
+        $updatedResource = file_get_contents($resourceFile);
+        $this->assertStringContainsString('@property string[] $tags Free-form tags', $updatedResource);
+        $this->assertStringContainsString('@property int[]|null $attachment_ids Attached document IDs', $updatedResource);
+        $this->assertStringContainsString('@property float[] $scores Scores', $updatedResource);
+        $this->assertStringContainsString('@property bool[] $flags Flags', $updatedResource);
+    }
+
     public function testRunOnlyProcessesEachResourceClassOnce(): void
     {
         $resourceDir = $this->tempDir . '/Resource';

--- a/Tests/PhpUnit/Documentation/DocBlock/DocBlockShapeTest.php
+++ b/Tests/PhpUnit/Documentation/DocBlock/DocBlockShapeTest.php
@@ -7,6 +7,7 @@ namespace apivalk\apivalk\Tests\PhpUnit\Documentation\DocBlock;
 use PHPUnit\Framework\TestCase;
 use apivalk\apivalk\Documentation\DocBlock\DocBlockShape;
 use apivalk\apivalk\Documentation\Property\DateProperty;
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Documentation\Property\IntegerProperty;
 
@@ -60,6 +61,25 @@ class DocBlockShapeTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $shape = new DocBlockShape('User', 'Body');
         $shape->toString('Invalid-Namespace');
+    }
+
+    public function testToStringWithSimpleArrayProperty(): void
+    {
+        $shape = new DocBlockShape('User', 'Body');
+
+        $required = new SimpleArrayProperty('tags', 'Tags', SimpleArrayProperty::TYPE_STRING);
+        $required->setIsRequired(true);
+
+        $optional = new SimpleArrayProperty('attachment_ids', 'IDs', SimpleArrayProperty::TYPE_INT);
+        $optional->setIsRequired(false);
+
+        $shape->addProperty($required);
+        $shape->addProperty($optional);
+
+        $result = $shape->toString('App\\Api\\Shape');
+
+        $this->assertStringContainsString('@property-read string[] $tags', $result);
+        $this->assertStringContainsString('@property-read int[]|null $attachment_ids', $result);
     }
 
     public function testToStringWithNamespacedPhpType(): void

--- a/Tests/PhpUnit/Documentation/OpenAPI/Object/SchemaObjectTest.php
+++ b/Tests/PhpUnit/Documentation/OpenAPI/Object/SchemaObjectTest.php
@@ -6,6 +6,7 @@ namespace apivalk\apivalk\Tests\PhpUnit\Documentation\OpenAPI\Object;
 
 use PHPUnit\Framework\TestCase;
 use apivalk\apivalk\Documentation\OpenAPI\Object\SchemaObject;
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Router\Route\Pagination\Pagination;
 
@@ -30,5 +31,27 @@ class SchemaObjectTest extends TestCase
         $this->assertTrue($schema->isRequired());
         $this->assertCount(1, $schema->getProperties());
         $this->assertNotNull($schema->getPagination());
+    }
+
+    public function testSchemaObjectRendersSimpleArrayPropertyItems(): void
+    {
+        $required = new SimpleArrayProperty('ids', 'Selected IDs', SimpleArrayProperty::TYPE_INT);
+        $optional = (new SimpleArrayProperty('tags', 'Labels', SimpleArrayProperty::TYPE_STRING))
+            ->setIsRequired(false);
+
+        $schema = new SchemaObject('object', true, [$required, $optional]);
+
+        $result = $schema->toArray();
+
+        $this->assertSame(
+            ['type' => 'array', 'items' => ['type' => 'integer'], 'description' => 'Selected IDs'],
+            $result['properties']['ids']
+        );
+        $this->assertSame(
+            ['type' => 'array', 'items' => ['type' => 'string'], 'description' => 'Labels'],
+            $result['properties']['tags']
+        );
+
+        $this->assertSame(['ids'], $result['required']);
     }
 }

--- a/Tests/PhpUnit/Documentation/Property/SimpleArrayPropertyTest.php
+++ b/Tests/PhpUnit/Documentation/Property/SimpleArrayPropertyTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Documentation\Property;
+
+use PHPUnit\Framework\TestCase;
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
+
+class SimpleArrayPropertyTest extends TestCase
+{
+    public function testIntArray()
+    {
+        $property = new SimpleArrayProperty('ids', 'A list of ids', SimpleArrayProperty::TYPE_INT);
+
+        $this->assertSame('array', $property->getType());
+        $this->assertSame('int[]', $property->getPhpType());
+        $this->assertSame(SimpleArrayProperty::TYPE_INT, $property->getItemType());
+
+        $doc = $property->getDocumentationArray();
+        $this->assertSame('array', $doc['type']);
+        $this->assertSame(['type' => 'integer'], $doc['items']);
+        $this->assertSame('A list of ids', $doc['description']);
+    }
+
+    public function testDefaultsToString()
+    {
+        $property = new SimpleArrayProperty('names');
+
+        $this->assertSame('string', $property->getItemType());
+        $this->assertSame('string[]', $property->getPhpType());
+        $this->assertSame(['type' => 'string'], $property->getDocumentationArray()['items']);
+    }
+
+    public function testNumberArray()
+    {
+        $property = new SimpleArrayProperty('prices', '', SimpleArrayProperty::TYPE_NUMBER);
+
+        $this->assertSame('float[]', $property->getPhpType());
+        $this->assertSame(['type' => 'number'], $property->getDocumentationArray()['items']);
+    }
+
+    public function testBoolArray()
+    {
+        $property = new SimpleArrayProperty('flags', '', SimpleArrayProperty::TYPE_BOOL);
+
+        $this->assertSame('bool[]', $property->getPhpType());
+        $this->assertSame(['type' => 'boolean'], $property->getDocumentationArray()['items']);
+    }
+
+    public function testDescriptionIsOmittedWhenEmpty()
+    {
+        $property = new SimpleArrayProperty('ids', '', SimpleArrayProperty::TYPE_INT);
+
+        $this->assertArrayNotHasKey('description', $property->getDocumentationArray());
+    }
+
+    public function testExampleIsIncludedWhenSet()
+    {
+        $property = new SimpleArrayProperty('ids', '', SimpleArrayProperty::TYPE_INT);
+        $property->setExample('[23, 41, 22]');
+
+        $this->assertSame('[23, 41, 22]', $property->getDocumentationArray()['example']);
+    }
+
+    public function testInvalidItemTypeThrows()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new SimpleArrayProperty('ids', '', 'object');
+    }
+}

--- a/Tests/PhpUnit/Documentation/Property/Validator/SimpleArrayValidatorTest.php
+++ b/Tests/PhpUnit/Documentation/Property/Validator/SimpleArrayValidatorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace apivalk\apivalk\Tests\PhpUnit\Documentation\Property\Validator;
+
+use PHPUnit\Framework\TestCase;
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
+use apivalk\apivalk\Documentation\Property\Validator\SimpleArrayValidator;
+use apivalk\apivalk\Documentation\Property\Validator\ValidatorResult;
+use apivalk\apivalk\Http\Request\Parameter\Parameter;
+
+class SimpleArrayValidatorTest extends TestCase
+{
+    private function validate(string $itemType, $value): ValidatorResult
+    {
+        $property = new SimpleArrayProperty('test', '', $itemType);
+        $validator = new SimpleArrayValidator($property);
+
+        return $validator->validate(new Parameter('test', $value, $value));
+    }
+
+    public function testNonArrayValueIsRejected(): void
+    {
+        $result = $this->validate(SimpleArrayProperty::TYPE_INT, 123);
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame(ValidatorResult::VALUE_IS_NOT_AN_ARRAY, $result->getErrorKey());
+    }
+
+    public function testJsonStringArrayIsBuiltAndValidated(): void
+    {
+        $this->assertTrue($this->validate(SimpleArrayProperty::TYPE_INT, '[1, 2, 3]')->isSuccess());
+        $this->assertTrue($this->validate(SimpleArrayProperty::TYPE_STRING, '["a", "b"]')->isSuccess());
+    }
+
+    public function testNonJsonStringIsRejected(): void
+    {
+        $result = $this->validate(SimpleArrayProperty::TYPE_STRING, 'not a json array');
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame(ValidatorResult::VALUE_IS_NOT_AN_ARRAY, $result->getErrorKey());
+    }
+
+    public function testEmptyArrayIsValid(): void
+    {
+        $this->assertTrue($this->validate(SimpleArrayProperty::TYPE_INT, [])->isSuccess());
+    }
+
+    public function testIntArrayWithValidValues(): void
+    {
+        $this->assertTrue($this->validate(SimpleArrayProperty::TYPE_INT, [1, 2, 3])->isSuccess());
+        // numeric strings pass validation; ParameterBagFactory casts them to int when the value is fetched
+        $this->assertTrue($this->validate(SimpleArrayProperty::TYPE_INT, ['1', '2'])->isSuccess());
+    }
+
+    public function testIntArrayWithInvalidElementIsRejected(): void
+    {
+        $result = $this->validate(SimpleArrayProperty::TYPE_INT, [1, 'not-a-number', 3]);
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame(ValidatorResult::VALUE_IS_NOT_NUMERIC, $result->getErrorKey());
+    }
+
+    public function testStringArrayWithInvalidElementIsRejected(): void
+    {
+        $result = $this->validate(SimpleArrayProperty::TYPE_STRING, ['a', 5]);
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame(ValidatorResult::VALUE_IS_NOT_A_STRING, $result->getErrorKey());
+    }
+
+    public function testNumberArrayWithValidValues(): void
+    {
+        $this->assertTrue($this->validate(SimpleArrayProperty::TYPE_NUMBER, [1.5, 2, '3.7'])->isSuccess());
+    }
+
+    public function testNumberArrayWithInvalidElementIsRejected(): void
+    {
+        $result = $this->validate(SimpleArrayProperty::TYPE_NUMBER, [1.5, 'abc']);
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame(ValidatorResult::VALUE_IS_NOT_NUMERIC, $result->getErrorKey());
+    }
+
+    public function testBoolArrayWithValidValues(): void
+    {
+        $this->assertTrue($this->validate(SimpleArrayProperty::TYPE_BOOL, [true, false, 0, 1])->isSuccess());
+    }
+
+    public function testBoolArrayWithInvalidElementIsRejected(): void
+    {
+        $result = $this->validate(SimpleArrayProperty::TYPE_BOOL, [true, 'maybe']);
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame(ValidatorResult::VALUE_IS_NOT_BOOLEAN, $result->getErrorKey());
+    }
+}

--- a/Tests/PhpUnit/Http/Request/Parameter/ParameterBagFactoryTest.php
+++ b/Tests/PhpUnit/Http/Request/Parameter/ParameterBagFactoryTest.php
@@ -8,6 +8,7 @@ use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Documentation\Property\DateProperty;
 use apivalk\apivalk\Documentation\Property\DateTimeProperty;
 use apivalk\apivalk\Documentation\Property\IntegerProperty;
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Request\Parameter\ParameterBagFactory;
 use apivalk\apivalk\Router\Route\Route;
@@ -115,6 +116,30 @@ class ParameterBagFactoryTest extends TestCase
         
         $prop = new StringProperty('test');
         $this->assertEquals('123', ParameterBagFactory::typeCastValueByProperty(123, $prop));
+    }
+
+    public function testTypeCastSimpleArrayCastsElementsToItemType(): void
+    {
+        $intProp = new SimpleArrayProperty('ids', '', SimpleArrayProperty::TYPE_INT);
+        $this->assertSame([1, 2, 3], ParameterBagFactory::typeCastValueByProperty(['1', '2', '3'], $intProp));
+
+        $numberProp = new SimpleArrayProperty('prices', '', SimpleArrayProperty::TYPE_NUMBER);
+        $this->assertSame([1.5, 2.0], ParameterBagFactory::typeCastValueByProperty(['1.5', 2], $numberProp));
+
+        $stringProp = new SimpleArrayProperty('codes', '', SimpleArrayProperty::TYPE_STRING);
+        $this->assertSame(['1', '2'], ParameterBagFactory::typeCastValueByProperty([1, 2], $stringProp));
+    }
+
+    public function testTypeCastSimpleArrayDecodesJsonString(): void
+    {
+        $intProp = new SimpleArrayProperty('ids', '', SimpleArrayProperty::TYPE_INT);
+        $this->assertSame([1, 2, 3], ParameterBagFactory::typeCastValueByProperty('[1, 2, 3]', $intProp));
+    }
+
+    public function testTypeCastSimpleArrayReturnsNullForNonArray(): void
+    {
+        $intProp = new SimpleArrayProperty('ids', '', SimpleArrayProperty::TYPE_INT);
+        $this->assertNull(ParameterBagFactory::typeCastValueByProperty('not-an-array', $intProp));
     }
 
     public function testTypeCastDateTimeValue(): void

--- a/docs/documentation/property.mdx
+++ b/docs/documentation/property.mdx
@@ -18,7 +18,8 @@ Apivalk provides several built-in property classes:
 | `ByteProperty`           | Base64-encoded data            | `string`    | `string`     |
 | `BinaryProperty`         | Raw binary data                | `string`    | `string`     |
 | `BooleanProperty`        | True/False values              | `bool`      | `boolean`    |
-| `ArrayProperty`          | List of items                  | `array`     | `array`      |
+| `SimpleArrayProperty`    | List of scalars (one-dimensional) | `int[]` / `string[]` / `float[]` / `bool[]` | `array` |
+| `ArrayProperty`          | List of objects                | `array`     | `array`      |
 | `AbstractObjectProperty` | Nested object structure         | `array`     | `object`     |
 
 ## Base Configuration
@@ -126,6 +127,31 @@ For raw binary data (e.g., file uploads). Automatically sets the OpenAPI format 
 $prop = new BinaryProperty('file', 'Uploaded file content');
 ```
 
+### `SimpleArrayProperty`
+
+For one-dimensional arrays of scalar values (e.g. `["ids" => [23, 41, 22]]`). Unlike `ArrayProperty`, it does **not** require an `AbstractObjectProperty` — you only declare the scalar item type, which is what gets written into the OpenAPI `items` schema.
+
+The item type is passed as the third constructor argument:
+
+* `SimpleArrayProperty::TYPE_INT` → OpenAPI `integer`, casts elements to `int`
+* `SimpleArrayProperty::TYPE_STRING` → OpenAPI `string`, casts elements to `string` (default)
+* `SimpleArrayProperty::TYPE_NUMBER` → OpenAPI `number`, casts elements to `float`
+* `SimpleArrayProperty::TYPE_BOOL` → OpenAPI `boolean`, casts elements to `bool`
+
+`setItemType(string)` can also change the type after construction.
+
+```php
+$prop = new SimpleArrayProperty('ids', 'Selected record IDs', SimpleArrayProperty::TYPE_INT);
+```
+
+In your response that backs:
+
+```php
+return ['ids' => [23, 41, 22]];
+```
+
+Each element is validated against the declared item type (a non-numeric element in an `int` array yields a `422`), and the value read back in the controller is cast to the item type — `["1", "2"]` on the wire becomes `[1, 2]`. Use `ArrayProperty` when the list holds objects rather than scalars.
+
 ### `ArrayProperty`
 
 * `setItemProperty(AbstractProperty)`: Defines the type of items within the array.
@@ -138,4 +164,4 @@ $prop = new BinaryProperty('file', 'Uploaded file content');
 
 When a property is instantiated, it automatically creates a corresponding validator via the `ValidatorFactory`. This validator is used by the `RequestValidationMiddleware` to ensure incoming data matches your definitions.
 
-Each property type has its own dedicated validator (e.g., `StringValidator`, `IntegerValidator`, `FloatValidator`, `EnumValidator`, `DateValidator`, `DateTimeValidator`, `ByteValidator`, `BinaryValidator`), ensuring type-specific validation rules are applied automatically.
+Each property type has its own dedicated validator (e.g., `StringValidator`, `IntegerValidator`, `FloatValidator`, `EnumValidator`, `DateValidator`, `DateTimeValidator`, `ByteValidator`, `BinaryValidator`, `SimpleArrayValidator`), ensuring type-specific validation rules are applied automatically. `SimpleArrayValidator` additionally checks that every element matches the array's declared item type.

--- a/docs/how-to/complex-objects.mdx
+++ b/docs/how-to/complex-objects.mdx
@@ -3,6 +3,10 @@ title: "Model complex objects with PropertyCollection"
 description: "When a request body or response carries nested objects or arrays of objects, compose them with AbstractPropertyCollection + AbstractObjectProperty + ArrayProperty. This keeps the OpenAPI schema and runtime validation in sync."
 ---
 
+<Note>
+For a one-dimensional list of **scalars** (e.g. `"ids": [23, 41, 22]`) you don't need any of this — reach for [`SimpleArrayProperty`](/documentation/property#simplearrayproperty) instead. The classes below are for lists of **objects**.
+</Note>
+
 Flat properties (`StringProperty`, `IntegerProperty`, `EnumProperty`, ...) cover most fields. When a payload carries structured data — a nested object or a list of objects — you compose it with three classes:
 
 - **`AbstractPropertyCollection`** — an iterable container of properties, mode-aware so you can vary fields between `CREATE`, `UPDATE`, `VIEW`, `LIST`, `DELETE`.

--- a/docs/how-to/manual-crud.mdx
+++ b/docs/how-to/manual-crud.mdx
@@ -56,6 +56,7 @@ namespace App\Http\Request\Pet;
 use apivalk\apivalk\Documentation\ApivalkRequestDocumentation;
 use apivalk\apivalk\Documentation\Property\EnumProperty;
 use apivalk\apivalk\Documentation\Property\FloatProperty;
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Request\AbstractApivalkRequest;
 
@@ -67,6 +68,11 @@ class CreatePetRequest extends AbstractApivalkRequest
         $doc->addBodyProperty(new StringProperty('name', 'Pet name'));
         $doc->addBodyProperty(new EnumProperty('species', 'Species', ['cat', 'dog', 'fish']));
         $doc->addBodyProperty((new FloatProperty('weight', 'Weight in kg'))->setIsRequired(false));
+        // One-dimensional scalar array — accepts ["Rex", "Buddy"], validates each element is a string
+        $doc->addBodyProperty(
+            (new SimpleArrayProperty('nicknames', 'Alternate names', SimpleArrayProperty::TYPE_STRING))
+                ->setIsRequired(false)
+        );
 
         return $doc;
     }
@@ -83,12 +89,13 @@ declare(strict_types=1);
 namespace App\Http\Response\Pet;
 
 use apivalk\apivalk\Documentation\ApivalkResponseDocumentation;
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Http\Response\AbstractApivalkResponse;
 
 class CreatePetResponse extends AbstractApivalkResponse
 {
-    /** @var array{pet_uuid: string, name: string, species: string} */
+    /** @var array{pet_uuid: string, name: string, species: string, nicknames: string[]} */
     private $pet;
 
     public function __construct(array $pet)
@@ -108,6 +115,7 @@ class CreatePetResponse extends AbstractApivalkResponse
         $doc->addProperty(new StringProperty('pet_uuid', 'Unique identifier'));
         $doc->addProperty(new StringProperty('name', 'Pet name'));
         $doc->addProperty(new StringProperty('species', 'Species'));
+        $doc->addProperty(new SimpleArrayProperty('nicknames', 'Alternate names', SimpleArrayProperty::TYPE_STRING));
 
         return $doc;
     }
@@ -173,9 +181,11 @@ final class CreatePetController extends AbstractApivalkController
     public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse
     {
         $pet = $this->repository->create([
-            'name'    => $request->body()->name,
-            'species' => $request->body()->species,
-            'weight'  => $request->body()->weight,
+            'name'      => $request->body()->name,
+            'species'   => $request->body()->species,
+            'weight'    => $request->body()->weight,
+            // already validated and cast to string[] by the time it reaches here
+            'nicknames' => $request->body()->nicknames ?? [],
         ]);
 
         return new CreatePetResponse($pet);

--- a/docs/how-to/resource-crud.mdx
+++ b/docs/how-to/resource-crud.mdx
@@ -33,6 +33,7 @@ namespace App\Resource;
 use apivalk\apivalk\Documentation\OpenAPI\Object\TagObject;
 use apivalk\apivalk\Documentation\Property\EnumProperty;
 use apivalk\apivalk\Documentation\Property\FloatProperty;
+use apivalk\apivalk\Documentation\Property\SimpleArrayProperty;
 use apivalk\apivalk\Documentation\Property\StringProperty;
 use apivalk\apivalk\Resource\AbstractResource;
 use apivalk\apivalk\Router\Route\Filter\EnumFilter;
@@ -83,11 +84,18 @@ class AnimalResource extends AbstractResource
         $this->addProperty(new StringProperty('name', 'Animal name'));
         $this->addProperty(new EnumProperty('status', 'Lifecycle status', ['active', 'archived']));
         $this->addProperty((new FloatProperty('weight', 'Weight in kg'))->setIsRequired(false));
+        // One-dimensional scalar array — no object wrapper needed
+        $this->addProperty(
+            (new SimpleArrayProperty('tags', 'Free-form labels', SimpleArrayProperty::TYPE_STRING))
+                ->setIsRequired(false)
+        );
     }
 }
 ```
 
 The identifier (`animal_uuid`) is a regular property declared first by convention. Excluding it from `MODE_CREATE` removes it from the create request body documentation — the server generates it.
+
+`tags` is a [`SimpleArrayProperty`](/documentation/property#simplearrayproperty): a plain list of scalars (`["friendly", "indoor"]`). Each element is validated against the declared item type and cast on the way in, so `$animal->tags` is always a `string[]`. Reach for the object-based [`ArrayProperty`](/how-to/complex-objects) only when the list holds objects.
 
 ## 2. Wire the five controllers
 


### PR DESCRIPTION
…entation

- Introduced `SimpleArrayProperty` to support one-dimensional scalar arrays.
- Extended validators, parameter casting, and request handling for `SimpleArrayProperty`.
- Updated contract and customer tests to cover `SimpleArrayProperty` use cases.
- Enhanced integration tests and API docs to reflect new property type capabilities.

Issue: #144