### PR TITLE
fix: improve cache handling for FilesystemCache and RouteCacheFactory

### DIFF
--- a/Cache/FilesystemCache.php
+++ b/Cache/FilesystemCache.php
@@ -55,25 +55,45 @@ class FilesystemCache implements CacheInterface
 
     public function set(CacheItem $cacheItem): bool
     {
-        return (bool)file_put_contents(
-            $this->getCacheFilePath($cacheItem->getKey()),
-            $cacheItem->toJson()
-        );
+        $path = $this->getCacheFilePath($cacheItem->getKey());
+        $tmpPath = \sprintf('%s.%d.tmp', $path, getmypid());
+
+        if (file_put_contents($tmpPath, $cacheItem->toJson()) === false) {
+            return false;
+        }
+
+        if (!rename($tmpPath, $path)) {
+            @unlink($tmpPath);
+            return false;
+        }
+
+        return true;
     }
 
     public function delete(string $key): bool
     {
-        if (!file_exists($this->getCacheFilePath($key))) {
-            return true;
+        $path = $this->getCacheFilePath($key);
+
+        try {
+            if (@unlink($path)) {
+                return true;
+            }
+        } catch (\Throwable $exception) {
+            // A strict error handler may promote unlink()'s warning to an exception when a
+            // concurrent process removed the file first; the desired state is still reached.
         }
 
-        return unlink($this->getCacheFilePath($key));
+        return !file_exists($path);
     }
 
     public function clear(): void
     {
         foreach (glob(\sprintf('%s/*.cache', $this->cacheDir)) as $file) {
-            unlink($file);
+            try {
+                @unlink($file);
+            } catch (\Throwable $exception) {
+                // Another process may have removed this file concurrently; nothing left to do.
+            }
         }
     }
 

--- a/Router/Route/RouteCacheFactory.php
+++ b/Router/Route/RouteCacheFactory.php
@@ -10,6 +10,13 @@ use apivalk\apivalk\Router\AbstractRouter;
 
 class RouteCacheFactory
 {
+    /**
+     * Route entries live longer than the index so that an expired index always triggers a
+     * rebuild while its route files are still present, avoiding a window where the index
+     * references already-expired route files.
+     */
+    private const ROUTE_CACHE_LIFETIME_BUFFER = 60;
+
     /** @var AbstractRouter */
     private $abstractRouter;
 
@@ -26,8 +33,6 @@ class RouteCacheFactory
         if ($cacheIndex instanceof CacheItem) {
             return;
         }
-
-        $cache->clear();
 
         $cacheIndex = [];
 
@@ -53,7 +58,7 @@ class RouteCacheFactory
                 new CacheItem(
                     $routeCacheKey,
                     json_encode(RouteJsonSerializer::serialize($route)),
-                    $cache->getDefaultCacheLifetime()
+                    $cache->getDefaultCacheLifetime() + self::ROUTE_CACHE_LIFETIME_BUFFER
                 )
             );
 

--- a/Tests/PhpUnit/Cache/FilesystemCacheTest.php
+++ b/Tests/PhpUnit/Cache/FilesystemCacheTest.php
@@ -92,6 +92,64 @@ class FilesystemCacheTest extends TestCase
         $this->assertFalse($cache->has('key2'));
     }
 
+    public function testDeleteReturnsTrueWhenFileAlreadyGone(): void
+    {
+        $cache = new FilesystemCache($this->cacheDir);
+
+        $this->assertTrue($cache->delete('never_existed'));
+    }
+
+    public function testDeleteSurvivesHandlerThatPromotesWarningToException(): void
+    {
+        $cache = new FilesystemCache($this->cacheDir);
+        $cache->set(new CacheItem('racy_key', 'value'));
+
+        $reflection = new \ReflectionMethod(FilesystemCache::class, 'getCacheFilePath');
+        $reflection->setAccessible(true);
+        $path = $reflection->invoke($cache, 'racy_key');
+
+        // Simulate a concurrent process winning the unlink race after our guard would have passed.
+        $this->assertFileExists($path);
+        unlink($path);
+
+        // Mirror CRMI's ErrorHandler: promote every PHP warning to an exception, ignoring @-suppression.
+        set_error_handler(static function (int $errno, string $message): bool {
+            throw new \ErrorException($message, 0, $errno);
+        });
+
+        try {
+            $result = $cache->delete('racy_key');
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertTrue($result, 'delete() must report success when the file is already gone');
+    }
+
+    public function testClearSurvivesHandlerThatPromotesWarningToException(): void
+    {
+        $cache = new FilesystemCache($this->cacheDir);
+        $cache->set(new CacheItem('key1', 'val1'));
+        $cache->set(new CacheItem('key2', 'val2'));
+
+        set_error_handler(static function (int $errno, string $message): bool {
+            throw new \ErrorException($message, 0, $errno);
+        });
+
+        try {
+            // Remove the files out from under clear() to mimic a concurrent deletion.
+            foreach (glob($this->cacheDir . '/*.cache') as $file) {
+                unlink($file);
+            }
+            $cache->clear();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertFalse($cache->has('key1'));
+        $this->assertFalse($cache->has('key2'));
+    }
+
     public function testTtlValidation(): void
     {
         $cache = new FilesystemCache($this->cacheDir);

--- a/Tests/PhpUnit/Router/RouteCacheFactoryTest.php
+++ b/Tests/PhpUnit/Router/RouteCacheFactoryTest.php
@@ -52,10 +52,60 @@ class RouteCacheFactoryTest extends TestCase
 
         // Expect cache sets
         $cache->expects($this->atLeastOnce())->method('set');
-        $cache->expects($this->once())->method('clear');
+        // clear() must never run: it is non-atomic and wipes route files a concurrent process relies on.
+        $cache->expects($this->never())->method('clear');
 
         $factory = new RouteCacheFactory($router);
         $factory->build();
+    }
+
+    public function testBuildCacheGivesRouteEntriesLongerLifetimeThanIndex(): void
+    {
+        $cache = $this->createMock(CacheInterface::class);
+        $classLocator = $this->createMock(ClassLocator::class);
+
+        $cache->method('get')->with(AbstractRouter::CACHE_INDEX_KEY)->willReturn(null);
+        $cache->method('getDefaultCacheLifetime')->willReturn(600);
+
+        $controllerClass = get_class(new class extends AbstractApivalkController {
+            public static function getRoute(): Route { return new Route('/test', new GetMethod()); }
+            public static function getRequestClass(): string { return ''; }
+            public static function getResponseClasses(): array { return []; }
+            public function __invoke(ApivalkRequestInterface $request): AbstractApivalkResponse {
+                return $this->createMock(AbstractApivalkResponse::class);
+            }
+        });
+
+        $classLocator->method('find')->willReturn([
+            ['className' => $controllerClass, 'path' => 'path/to/controller.php']
+        ]);
+
+        $router = $this->getMockBuilder(AbstractRouter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $router->method('getCache')->willReturn($cache);
+        $router->method('getClassLocator')->willReturn($classLocator);
+
+        $ttlByKey = [];
+        $cache->method('set')->willReturnCallback(function (CacheItem $item) use (&$ttlByKey) {
+            $ttlByKey[$item->getKey()] = $item->getTtl();
+            return true;
+        });
+
+        $factory = new RouteCacheFactory($router);
+        $factory->build();
+
+        $indexTtl = $ttlByKey[AbstractRouter::CACHE_INDEX_KEY];
+        unset($ttlByKey[AbstractRouter::CACHE_INDEX_KEY]);
+
+        $this->assertNotEmpty($ttlByKey, 'expected at least one route entry to be cached');
+        foreach ($ttlByKey as $key => $routeTtl) {
+            $this->assertGreaterThan(
+                $indexTtl,
+                $routeTtl,
+                \sprintf('route entry "%s" must outlive the index so an expired index rebuilds before routes vanish', $key)
+            );
+        }
     }
 
     public function testBuildCacheSkipsAbstractControllerSubclasses(): void
@@ -75,7 +125,7 @@ class RouteCacheFactoryTest extends TestCase
         $router->method('getCache')->willReturn($cache);
         $router->method('getClassLocator')->willReturn($classLocator);
 
-        $cache->expects($this->once())->method('clear');
+        $cache->expects($this->never())->method('clear');
         // Only the index entry is written; no per-route cache entry for the abstract class.
         $cache->expects($this->once())->method('set');
 


### PR DESCRIPTION
- Added error handling resilience to `FilesystemCache::delete` and `clear` for concurrent file operations.
- Improved atomicity with temporary file usage in `FilesystemCache::set`.
- Prevented non-atomic `clear` execution in `RouteCacheFactory`.
- Introduced a buffer to route cache lifetimes to ensure route files outlive index expiration.
- Added PHPUnit tests to validate new cache behaviors and error scenarios.

Issue: #147